### PR TITLE
fix: cleanup preview shows a task's latest session

### DIFF
--- a/packages/db/src/repo.ts
+++ b/packages/db/src/repo.ts
@@ -95,11 +95,14 @@ export const repo = {
 			.get();
 	},
 
+	// Latest-first: callers that want the most recent chat session (e.g. the
+	// cleanup preview) can take the first live one without re-sorting.
 	listSessionsByTask(db: AteamDb, taskId: string) {
 		return db
 			.select()
 			.from(agentSessions)
 			.where(eq(agentSessions.taskId, taskId))
+			.orderBy(desc(agentSessions.startedAt))
 			.all();
 	},
 

--- a/packages/db/test/repo.test.ts
+++ b/packages/db/test/repo.test.ts
@@ -90,6 +90,37 @@ describe("agent sessions & events", () => {
 		});
 		expect(e.eventType).toBe("Stop");
 	});
+
+	it("lists a task's sessions latest-first", () => {
+		const p = repo.upsertProject(db, { repoPath: "/r/a", name: "A" });
+		const t = repo.createTask(db, {
+			projectId: p!.id,
+			name: "t",
+			slug: "t",
+			branch: "t",
+			baseBranch: "main",
+			worktreePath: "/wt/t",
+		});
+		const older = repo.createSession(db, {
+			taskId: t.id,
+			agentId: "claude",
+			terminalId: "term-old",
+			cwd: "/wt/t",
+		});
+		const newer = repo.createSession(db, {
+			taskId: t.id,
+			agentId: "claude",
+			terminalId: "term-new",
+			cwd: "/wt/t",
+		});
+		repo.updateSession(db, older.id, { startedAt: 1000 });
+		repo.updateSession(db, newer.id, { startedAt: 2000 });
+
+		expect(repo.listSessionsByTask(db, t.id).map((s) => s.id)).toEqual([
+			newer.id,
+			older.id,
+		]);
+	});
 });
 
 describe("settings", () => {


### PR DESCRIPTION
Order listSessionsByTask by startedAt descending so the cleanup
candidate preview (and task re-attach) resumes the most recent live
session instead of the oldest.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
