### PR TITLE
fix: dropped files type their path again so Claude Code attaches them

### DIFF
--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -58,10 +58,13 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 		};
 		el.addEventListener("paste", onPaste, true);
 
-		// Dropping files pastes their paths, like iTerm: backslash-escaped and
-		// delivered via term.paste() so apps with bracketed paste on (Claude
-		// Code) see a *paste* of a file path — that's what makes them attach a
-		// dropped image as [Image #N] instead of leaving a literal path.
+		// Dropping files types their backslash-escaped paths straight to the PTY,
+		// exactly like a real terminal (iTerm/Terminal.app) does on a file drop.
+		// This is deliberately NOT term.paste(): a paste arrives wrapped in
+		// bracketed-paste markers, which Claude Code treats as a literal text
+		// block and does NOT scan for a droppable file path — so the image never
+		// attaches and you're left with a literal path. Typed keystrokes are what
+		// trigger its "dropped path → [Image #N]" detection.
 		const onDragOver = (e: DragEvent) => e.preventDefault();
 		const onDrop = (e: DragEvent) => {
 			e.preventDefault();
@@ -72,7 +75,7 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 				.filter(Boolean)
 				.map(escapePath);
 			if (paths.length) {
-				term.paste(`${paths.join(" ")} `);
+				window.ateam.pty.write(terminalId, `${paths.join(" ")} `);
 				term.focus();
 			}
 		};


### PR DESCRIPTION
Switching the file-drop handler to term.paste() (commit bcbb418) wrapped the
dropped path in bracketed-paste markers. Claude Code treats a bracketed paste
as a literal text block and skips its "dropped path -> [Image #N]" detection,
so dragging a file (e.g. a fresh screenshot thumbnail, delivered as a temp
file) just left the literal path in the prompt.

Type the escaped path straight to the PTY via pty.write instead, exactly like
a real terminal does on a file drop, which is what triggers the attach.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
