### PR TITLE
fix: tasks:remove tolerates a worktree deleted from disk

### DIFF
--- a/packages/git-core/src/task.ts
+++ b/packages/git-core/src/task.ts
@@ -110,7 +110,27 @@ export async function removeTask(
 
 	const args = ["worktree", "remove", input.worktreePath];
 	if (input.force) args.push("--force");
-	await git.raw(args);
+	try {
+		await git.raw(args);
+	} catch (err) {
+		// If the worktree directory was deleted out from under us (e.g. removed
+		// manually in Finder/the shell), `git worktree remove` fails with
+		// "is not a working tree". That's not a real failure for our purposes —
+		// the tree is already gone. Prune the stale admin entry below and carry
+		// on to branch deletion instead of surfacing the error to the user.
+		const message = err instanceof Error ? err.message : String(err);
+		if (!/is not a working tree|No such file or directory/i.test(message)) {
+			throw err;
+		}
+		warnings.push(
+			`Worktree "${input.worktreePath}" was already gone; pruned its stale entry.`,
+		);
+	}
+
+	// Prune before deleting the branch: if the worktree dir vanished, git still
+	// believes the branch is checked out there and `branch -d` would refuse with
+	// "Cannot delete branch ... checked out at ...". Pruning clears that link.
+	await git.raw(["worktree", "prune"]).catch(() => {});
 
 	let branchDeleted = false;
 	if (input.deleteBranch) {
@@ -126,8 +146,6 @@ export async function removeTask(
 			);
 		}
 	}
-
-	await git.raw(["worktree", "prune"]).catch(() => {});
 
 	return { removed: true, branchDeleted, warnings };
 }

--- a/packages/git-core/test/git-core.test.ts
+++ b/packages/git-core/test/git-core.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import simpleGit from "simple-git";
 import {
@@ -285,6 +285,31 @@ describe("removeTask", () => {
 		);
 		expect(list.some((w) => w.branch === a.branch)).toBe(false);
 		expect(list.some((w) => w.branch === b.branch)).toBe(true);
+	});
+
+	it("succeeds when the worktree dir was already deleted from disk", async () => {
+		const a = await createTask({ repoPath: repo.work, name: "task gone" });
+
+		// Simulate the user deleting the worktree folder out from under us.
+		await rm(a.worktreePath, { recursive: true, force: true });
+
+		const res = await removeTask({
+			repoPath: repo.work,
+			worktreePath: a.worktreePath,
+			branch: a.branch,
+			deleteBranch: true,
+		});
+
+		expect(res.removed).toBe(true);
+		expect(res.branchDeleted).toBe(true);
+
+		// The stale worktree admin entry and the branch are both gone.
+		const list = parseWorktreeList(
+			await simpleGit(repo.work).raw(["worktree", "list", "--porcelain"]),
+		);
+		expect(list.some((w) => w.branch === a.branch)).toBe(false);
+		const branches = await simpleGit(repo.work).raw(["branch", "--list"]);
+		expect(branches.includes(a.branch)).toBe(false);
 	});
 });
 


### PR DESCRIPTION
When a task's worktree directory was removed manually, `git worktree
remove` failed with "is not a working tree" and the error surfaced
through IPC, leaving the task unremovable. Catch that case, prune the
stale admin entry before deleting the branch, and carry on.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
