### PR TITLE
fix: preserve terminal modes across reattach so paste works

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,6 +29,8 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-serialize": "^0.13.0",
+    "@xterm/headless": "^5.5.0",
     "@xterm/xterm": "^5.5.0",
     "drizzle-orm": "^0.38.4",
     "electron": "^34.0.0",

--- a/apps/desktop/src/daemon/index.ts
+++ b/apps/desktop/src/daemon/index.ts
@@ -4,24 +4,38 @@
 //
 // Protocol: newline-delimited JSON over a unix socket. Terminal bytes are
 // base64-encoded in the `data` field. Clients connect, (re)attach by listing
-// sessions + fetching each session's ring-buffer snapshot. Disconnecting a
-// client never kills sessions — that's the whole point.
+// sessions + fetching each session's snapshot. Disconnecting a client never
+// kills sessions — that's the whole point.
+//
+// The snapshot is NOT a raw byte buffer. Each session drives a headless xterm
+// emulator that holds the full terminal STATE — screen contents plus every
+// active mode (bracketed paste ?2004, focus reporting ?1004, alt screen ?1049,
+// cursor keys, mouse tracking, …). On reattach we hand the renderer a
+// serialized snapshot of that state, so a freshly-mounted xterm inherits the
+// modes the agent set long ago. A raw ring buffer can't do this: an app enables
+// bracketed paste once at startup, and once that `\x1b[?2004h` scrolls past the
+// retained window every new view attaches with paste broken (newlines arrive as
+// Enters instead of one bracketed block).
 import { existsSync, mkdirSync, unlinkSync } from "node:fs";
 import net from "node:net";
 import { connect as netConnect } from "node:net";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { SerializeAddon } from "@xterm/addon-serialize";
+import { Terminal } from "@xterm/headless";
 import * as pty from "node-pty";
 
 const SOCK =
 	process.env.ATEAM_PTY_SOCK || join(homedir(), ".ateam", "pty-daemon.sock");
-const RING = 256 * 1024; // chars of scrollback retained per session
+const SCROLLBACK = 5000; // lines of scrollback the emulator (and snapshot) keeps
 const IDLE_EXIT_MS = 10 * 60 * 1000; // exit if no sessions for 10 min
 
 interface Session {
 	id: string;
 	proc: pty.IPty;
-	buffer: string;
+	// Headless emulator mirroring the PTY: source of truth for snapshot state.
+	term: Terminal;
+	serialize: SerializeAddon;
 	exited: boolean;
 	cwd: string;
 	agentId: string;
@@ -58,17 +72,28 @@ function spawnSession(m: {
 	agentId?: string;
 }): void {
 	if (sessions.has(m.terminalId)) return;
+	const cols = m.cols ?? 80;
+	const rows = m.rows ?? 24;
 	const proc = pty.spawn(m.shell, m.args, {
 		name: "xterm-256color",
 		cwd: m.cwd,
 		env: m.env as { [key: string]: string },
-		cols: m.cols ?? 80,
-		rows: m.rows ?? 24,
+		cols,
+		rows,
 	});
+	const term = new Terminal({
+		cols,
+		rows,
+		scrollback: SCROLLBACK,
+		allowProposedApi: true,
+	});
+	const serialize = new SerializeAddon();
+	term.loadAddon(serialize);
 	const s: Session = {
 		id: m.terminalId,
 		proc,
-		buffer: "",
+		term,
+		serialize,
 		exited: false,
 		cwd: m.cwd,
 		agentId: m.agentId ?? "shell",
@@ -77,14 +102,16 @@ function spawnSession(m: {
 	if (idleTimer) clearTimeout(idleTimer);
 
 	proc.onData((data) => {
-		s.buffer += data;
-		if (s.buffer.length > RING) s.buffer = s.buffer.slice(-RING);
+		// Feed the emulator so it tracks screen + mode state for snapshots, and
+		// stream the raw bytes live to attached clients.
+		s.term.write(data);
 		broadcast({ t: "data", terminalId: m.terminalId, data: b64(data) });
 	});
 	proc.onExit(({ exitCode }) => {
 		s.exited = true;
 		broadcast({ t: "exit", terminalId: m.terminalId, exitCode });
 		sessions.delete(m.terminalId);
+		s.term.dispose();
 		if (sessions.size === 0) scheduleIdleExit();
 	});
 }
@@ -102,11 +129,11 @@ function handleMessage(sock: net.Socket, m: Record<string, unknown>): void {
 		case "resize": {
 			const s = sessions.get(m.terminalId as string);
 			if (s && !s.exited) {
+				const cols = Math.max(1, m.cols as number);
+				const rows = Math.max(1, m.rows as number);
 				try {
-					s.proc.resize(
-						Math.max(1, m.cols as number),
-						Math.max(1, m.rows as number),
-					);
+					s.proc.resize(cols, rows);
+					s.term.resize(cols, rows);
 				} catch {
 					/* ignore */
 				}
@@ -122,19 +149,27 @@ function handleMessage(sock: net.Socket, m: Record<string, unknown>): void {
 					/* gone */
 				}
 			}
+			s?.term.dispose();
 			sessions.delete(m.terminalId as string);
 			if (sessions.size === 0) scheduleIdleExit();
 			break;
 		}
-		case "snapshot":
-			sock.write(
-				`${JSON.stringify({
-					t: "snapshot",
-					id: m.id,
-					data: b64(sessions.get(m.terminalId as string)?.buffer ?? ""),
-				})}\n`,
-			);
+		case "snapshot": {
+			const s = sessions.get(m.terminalId as string);
+			const reply = (data: string) =>
+				sock.write(
+					`${JSON.stringify({ t: "snapshot", id: m.id, data: b64(data) })}\n`,
+				);
+			if (!s) {
+				reply("");
+				break;
+			}
+			// xterm parses writes asynchronously; drain the queue with an empty
+			// write so the serialized snapshot reflects the very latest bytes
+			// (modes included) rather than a state a few frames stale.
+			s.term.write("", () => reply(s.serialize.serialize()));
 			break;
+		}
 		case "list":
 			sock.write(
 				`${JSON.stringify({

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/desktop": {
       "name": "@ateam/desktop",
-      "version": "0.1.5",
+      "version": "0.1.13",
       "dependencies": {
         "better-sqlite3": "^11.8.1",
         "electron-updater": "^6.8.3",
@@ -30,6 +30,8 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-serialize": "^0.13.0",
+        "@xterm/headless": "^5.5.0",
         "@xterm/xterm": "^5.5.0",
         "drizzle-orm": "^0.38.4",
         "electron": "^34.0.0",
@@ -356,6 +358,10 @@
     "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.10.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ=="],
+
+    "@xterm/addon-serialize": ["@xterm/addon-serialize@0.13.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-kGs8o6LWAmN1l2NpMp01/YkpxbmO4UrfWybeGu79Khw5K9+Krp7XhXbBTOTc3GJRRhd6EmILjpR8k5+odY39YQ=="],
+
+    "@xterm/headless": ["@xterm/headless@5.5.0", "", {}, "sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g=="],
 
     "@xterm/xterm": ["@xterm/xterm@5.5.0", "", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
 


### PR DESCRIPTION
The PTY daemon kept a raw 256KB content ring buffer and replayed those
bytes into each freshly-mounted xterm. An agent enables bracketed paste
(\x1b[?2004h) once at startup; once that byte scrolls out of the window
every new terminal view attaches with bracketed-paste off, so xterm
sends pastes raw — newlines become Enters and a multi-line paste arrives
line-by-line instead of one collapsed block.

Drive a headless xterm emulator per session and snapshot its full
serialized state (screen + every active DEC mode: bracketed paste, focus
reporting, alt screen, cursor keys, mouse, …) instead of raw bytes. A
reattached view now inherits whatever modes the agent set, regardless of
session age.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
