### PR TITLE
feat: per-terminal toolbar with + menu to attach files

### DIFF
--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -435,6 +435,16 @@ export function registerIpc(ctx: IpcContext): void {
 		e.returnValue = hasImage && clipboard.readText().length === 0;
 	});
 
+	// Native file picker for the terminal toolbar's "+ → Files…" action; the
+	// renderer types the chosen paths into the PTY like a drag-and-drop would.
+	ipcMain.handle(CH.utilPickFiles, async () => {
+		const res = await dialog.showOpenDialog({
+			properties: ["openFile", "multiSelections"],
+			title: "Add files to terminal",
+		});
+		return res.canceled ? [] : res.filePaths;
+	});
+
 	// ---- agents ----
 	ipcMain.handle(CH.agentsList, async () => {
 		const agents = await listAgents();

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -69,6 +69,7 @@ const api: AteamApi = {
 		pathForFile: (file) => webUtils.getPathForFile(file),
 		clipboardHasImage: () =>
 			ipcRenderer.sendSync(CH.utilClipboardHasImage) === true,
+		pickFiles: () => ipcRenderer.invoke(CH.utilPickFiles),
 	},
 	events: {
 		onTaskUpdated: (cb: (task: TaskDTO) => void) => {

--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -1,14 +1,22 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
+import { FileUp, Plus } from "lucide-react";
 import { useEffect, useRef } from "react";
+import { Menu } from "./Menu";
+
+/** Shell-quote a path so spaces and quotes survive being typed into a PTY. */
+const quotePath = (p: string) =>
+	/[\s'"\\]/.test(p) ? `"${p.replace(/"/g, '\\"')}"` : p;
 
 /**
  * One xterm.js view bound to a main-process PTY by terminalId. Replays the
  * ring-buffer snapshot on mount (so re-attaching shows recent scrollback),
  * streams live output, and forwards keystrokes + resize back to the PTY.
+ * A slim toolbar underneath offers a `+` menu (e.g. attach files by path).
  */
 export function TerminalView({ terminalId }: { terminalId: string }) {
 	const ref = useRef<HTMLDivElement>(null);
+	const termRef = useRef<Terminal | null>(null);
 
 	useEffect(() => {
 		const el = ref.current;
@@ -24,6 +32,7 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 		const fit = new FitAddon();
 		term.loadAddon(fit);
 		term.open(el);
+		termRef.current = term;
 		try {
 			fit.fit();
 		} catch {
@@ -62,7 +71,7 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 			const paths = files
 				.map((f) => window.ateam.utils.pathForFile(f))
 				.filter(Boolean)
-				.map((p) => (/[\s'"\\]/.test(p) ? `"${p.replace(/"/g, '\\"')}"` : p));
+				.map(quotePath);
 			if (paths.length) {
 				window.ateam.pty.write(terminalId, `${paths.join(" ")} `);
 				term.focus();
@@ -127,9 +136,36 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 			offData();
 			disposeInput.dispose();
 			ro.disconnect();
+			termRef.current = null;
 			term.dispose();
 		};
 	}, [terminalId]);
 
-	return <div className="term" ref={ref} />;
+	// "+ → Files…": native picker, then type the quoted paths into the PTY —
+	// same effect as dragging the files onto the terminal.
+	const addFiles = async () => {
+		const paths = (await window.ateam.utils.pickFiles()).map(quotePath);
+		if (paths.length) {
+			window.ateam.pty.write(terminalId, `${paths.join(" ")} `);
+		}
+		termRef.current?.focus();
+	};
+
+	return (
+		<div className="term-shell">
+			{/* .term-area is the flex-sized box; .term is absolutely positioned to
+			    fill it, so the xterm canvas can never prop the layout open — the
+			    available space drives the terminal size, not the other way round. */}
+			<div className="term-area">
+				<div className="term" ref={ref} />
+			</div>
+			<div className="term-toolbar">
+				<Menu
+					icon={Plus}
+					label="Add to terminal"
+					items={[{ label: "Files…", icon: FileUp, onClick: addFiles }]}
+				/>
+			</div>
+		</div>
+	);
 }

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -453,8 +453,11 @@ input {
 	flex: 0 0 480px; /* fixed width; board scrolls beside it, not squeezed */
 	/* Flex min-width:auto would let the terminal's canvas (sized while the
 	   panel was full-width) clamp the panel and stop it collapsing back to
-	   480px — the basis must always win over content min-width. */
+	   480px — the basis must always win over content min-width. Same on the
+	   vertical axis: without min-height:0 the (tall) canvas pins the panel
+	   open, so shrinking the window can't shrink the terminal. */
 	min-width: 0;
+	min-height: 0;
 	/* Pin the panel in view while the board scrolls horizontally behind it. */
 	position: sticky;
 	right: 0;
@@ -497,6 +500,34 @@ input {
 	background: #000;
 	padding: 6px;
 }
+/* Self-contained terminal: a single flex:1 box (drop-in for the old lone .term)
+   that splits into the xterm area + the bottom toolbar. Parents (.term-wrap,
+   .tile) keep treating the terminal as one fill child. */
+.term-shell {
+	flex: 1;
+	min-width: 0;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+/* The flex-sized terminal region. position:relative makes it the containing
+   block for the absolutely-positioned xterm host below. */
+.term-area {
+	flex: 1;
+	min-width: 0;
+	min-height: 0;
+	position: relative;
+}
+/* Decouple the xterm host from its canvas: pin it to fill .term-area. Its size
+   is then driven purely by flex (available space), so shrinking the window
+   shrinks the host → ResizeObserver fires → fit() drops rows. Without this the
+   canvas's intrinsic height props the layout open and it only ever grows. */
+.term-area .term {
+	position: absolute;
+	inset: 0;
+	min-height: 0;
+}
 /* panel body: terminal, or the changes view (files left · diff right) */
 .panel-body {
 	flex: 1;
@@ -509,6 +540,15 @@ input {
 	min-height: 0;
 	display: flex;
 	flex-direction: column;
+}
+/* slim bar under each terminal: `+` menu (attach files, …) */
+.term-toolbar {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	padding: 2px 6px;
+	border-top: 1px solid var(--border);
+	flex: none;
 }
 
 /* +N -N stat on the right of the actions bar; opens the changes view */

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -138,6 +138,7 @@ export const CH = {
 	gitStatus: "git:status",
 	agentsList: "agents:list",
 	utilClipboardHasImage: "util:clipboardHasImage",
+	utilPickFiles: "util:pickFiles",
 	ptySpawnAgent: "pty:spawnAgent",
 	ptySpawnShell: "pty:spawnShell",
 	ptyWrite: "pty:write",
@@ -228,5 +229,7 @@ export interface AteamApi {
 		pathForFile(file: File): string;
 		/** True when the clipboard holds an image and no text (sync). */
 		clipboardHasImage(): boolean;
+		/** Native open dialog; resolves to the chosen paths ([] on cancel). */
+		pickFiles(): Promise<string[]>;
 	};
 }


### PR DESCRIPTION
Add a slim toolbar under each terminal with a + menu whose "Files…"
action opens a native picker and types the chosen (shell-quoted) paths
into the PTY — same effect as dragging files onto the terminal.

Restructure the terminal into .term-shell / .term-area / .term-toolbar
and absolutely-position the xterm host (inset:0) inside the flex-sized
.term-area. This decouples the canvas's intrinsic size from the layout
so flex drives the terminal size: the toolbar no longer overflows the
panel and the terminal reflows correctly when the window shrinks.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
