### PR TITLE
chore: release 0.1.14

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {

--- a/apps/desktop/scripts/notarize.cjs
+++ b/apps/desktop/scripts/notarize.cjs
@@ -26,7 +26,9 @@ exports.default = async function notarizeHook(context) {
 
 	const appPath = `${context.appOutDir}/${context.packager.appInfo.productFilename}.app`;
 	console.log(`[notarize] submitting ${appPath} (this can take a few minutes)…`);
-	const { notarize } = require("@electron/notarize");
+	// @electron/notarize is ESM-only (>=3.1); load it via dynamic import so this
+	// CommonJS hook works under Node without ERR_REQUIRE_ESM.
+	const { notarize } = await import("@electron/notarize");
 	await notarize({ appPath, keychainProfile: profile });
 	execSync(`xcrun stapler staple "${appPath}"`, { stdio: "inherit" });
 	console.log("[notarize] notarized + stapled");


### PR DESCRIPTION
Cuts the 0.1.14 release — everything merged after v0.1.13 (#1–#7) — plus the build fix needed to package it.

**Features**
- "Check for Updates…" in the macOS app menu (#1)
- Mission Control layout options — grid / split / stack (#6)

**Fixes**
- Repaint terminal on hidden→visible transition (#2)
- Cleanup preview shows a task's latest session (#3)
- Dropped files type their path again so Claude Code attaches them (#4)
- tasks:remove tolerates a worktree deleted from disk (#5)
- Preserve terminal modes across reattach so paste works (#7)

**Release tooling**
- Bump desktop app to 0.1.14
- Load ESM-only `@electron/notarize` (3.1+) via dynamic import so the notarize hook no longer crashes with ERR_REQUIRE_ESM during packaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)