### PR TITLE
fix: apply terminal snapshot before live data on reattach

### DIFF
--- a/apps/desktop/src/daemon/index.ts
+++ b/apps/desktop/src/daemon/index.ts
@@ -39,6 +39,9 @@ interface Session {
 	exited: boolean;
 	cwd: string;
 	agentId: string;
+	// Monotonic chunk counter. Stamped on every broadcast `data` and reported
+	// with each snapshot so reattaching clients can dedupe (see PtyDataEvent).
+	seq: number;
 }
 
 const sessions = new Map<string, Session>();
@@ -97,6 +100,7 @@ function spawnSession(m: {
 		exited: false,
 		cwd: m.cwd,
 		agentId: m.agentId ?? "shell",
+		seq: 0,
 	};
 	sessions.set(m.terminalId, s);
 	if (idleTimer) clearTimeout(idleTimer);
@@ -105,7 +109,13 @@ function spawnSession(m: {
 		// Feed the emulator so it tracks screen + mode state for snapshots, and
 		// stream the raw bytes live to attached clients.
 		s.term.write(data);
-		broadcast({ t: "data", terminalId: m.terminalId, data: b64(data) });
+		s.seq += 1;
+		broadcast({
+			t: "data",
+			terminalId: m.terminalId,
+			data: b64(data),
+			seq: s.seq,
+		});
 	});
 	proc.onExit(({ exitCode }) => {
 		s.exited = true;
@@ -156,18 +166,23 @@ function handleMessage(sock: net.Socket, m: Record<string, unknown>): void {
 		}
 		case "snapshot": {
 			const s = sessions.get(m.terminalId as string);
-			const reply = (data: string) =>
+			const reply = (data: string, seq: number) =>
 				sock.write(
-					`${JSON.stringify({ t: "snapshot", id: m.id, data: b64(data) })}\n`,
+					`${JSON.stringify({ t: "snapshot", id: m.id, data: b64(data), seq })}\n`,
 				);
 			if (!s) {
-				reply("");
+				reply("", 0);
 				break;
 			}
+			// Capture the cut point synchronously: every chunk up to s.seq is
+			// already written into s.term, so the serialized state below reflects
+			// exactly bytes <= cutSeq. Chunks broadcast after this (seq > cutSeq)
+			// are what the client replays on top, with no overlap.
+			const cutSeq = s.seq;
 			// xterm parses writes asynchronously; drain the queue with an empty
 			// write so the serialized snapshot reflects the very latest bytes
 			// (modes included) rather than a state a few frames stale.
-			s.term.write("", () => reply(s.serialize.serialize()));
+			s.term.write("", () => reply(s.serialize.serialize(), cutSeq));
 			break;
 		}
 		case "list":

--- a/apps/desktop/src/main/pty/pty-client.ts
+++ b/apps/desktop/src/main/pty/pty-client.ts
@@ -98,6 +98,7 @@ export class PtyClient extends EventEmitter {
 				this.emit("data", {
 					terminalId: m.terminalId,
 					data: unb64(m.data as string),
+					seq: (m.seq as number) ?? 0,
 				});
 				break;
 			case "exit":
@@ -213,9 +214,12 @@ export class PtyClient extends EventEmitter {
 		return this.live.has(terminalId);
 	}
 
-	async snapshot(terminalId: string): Promise<string> {
+	async snapshot(terminalId: string): Promise<{ data: string; seq: number }> {
 		const r = await this.request({ t: "snapshot", terminalId });
-		return r.data ? unb64(r.data as string) : "";
+		return {
+			data: r.data ? unb64(r.data as string) : "",
+			seq: (r.seq as number) ?? 0,
+		};
 	}
 
 	async list(): Promise<{ terminalId: string; agentId: string; cwd: string }[]> {

--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -105,13 +105,32 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 		const onFocusRequest = () => term.focus();
 		window.addEventListener("ateam:focus-terminal", onFocusRequest);
 
+		// Reattach ordering matters: the snapshot is a point-in-time serialize of
+		// the whole screen + modes, while live chunks keep streaming. If we wrote
+		// live bytes straight away and the snapshot afterward, the two interleave —
+		// recent bytes get applied twice and out of order, and a snapshot write can
+		// land in the middle of a half-parsed live escape sequence (that's how a
+		// CSI like `\x1b[21;57H` loses its prefix and leaks as literal `21;57H`).
+		//
+		// So we buffer live chunks until the snapshot is applied, then replay only
+		// the ones the snapshot doesn't already include (seq > the snapshot's cut),
+		// and finally switch to writing live directly. JS is single-threaded, so no
+		// chunk can slip in between the flush and flipping `ready`.
+		let ready = false;
+		let pending: { data: string; seq: number }[] = [];
 		const offData = window.ateam.pty.onData((e) => {
-			if (e.terminalId === terminalId) term.write(e.data);
+			if (e.terminalId !== terminalId) return;
+			if (ready) term.write(e.data);
+			else pending.push({ data: e.data, seq: e.seq });
 		});
 
-		// Replay recent output after attaching the live listener.
-		void window.ateam.pty.snapshot(terminalId).then((buf) => {
-			if (buf) term.write(buf, () => term.scrollToBottom());
+		void window.ateam.pty.snapshot(terminalId).then(({ data, seq }) => {
+			if (data) term.write(data);
+			for (const c of pending) if (c.seq > seq) term.write(c.data);
+			pending = [];
+			ready = true;
+			// Scroll only once everything queued above has actually rendered.
+			term.write("", () => term.scrollToBottom());
 		});
 
 		const disposeInput = term.onData((d) =>

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -156,6 +156,18 @@ export const CH = {
 export interface PtyDataEvent {
 	terminalId: string;
 	data: string;
+	/**
+	 * Monotonic per-session sequence number for this chunk. The snapshot reply
+	 * carries the seq of the last chunk it already includes, so a freshly-mounted
+	 * view can replay the snapshot first and then apply only the live chunks that
+	 * came *after* it — never double-applying bytes the snapshot already has.
+	 */
+	seq: number;
+}
+/** A serialized terminal state plus the seq of the last chunk it reflects. */
+export interface PtySnapshot {
+	data: string;
+	seq: number;
 }
 export interface PtyExitEvent {
 	terminalId: string;
@@ -216,7 +228,7 @@ export interface AteamApi {
 		write(terminalId: string, data: string): void;
 		resize(terminalId: string, cols: number, rows: number): void;
 		kill(terminalId: string): void;
-		snapshot(terminalId: string): Promise<string>;
+		snapshot(terminalId: string): Promise<PtySnapshot>;
 		listForTask(taskId: string): Promise<SessionDTO[]>;
 		onData(cb: (e: PtyDataEvent) => void): () => void;
 		onExit(cb: (e: PtyExitEvent) => void): () => void;


### PR DESCRIPTION
On mount the renderer wrote live PTY chunks immediately and the
serialized snapshot afterward, so the two interleaved: recent bytes
were applied twice and out of order, and a snapshot write could splice
into a half-parsed live escape sequence — dropping its CSI prefix so
sequences like ESC[21;57H leaked on screen as literal "21;57H" and
scrolling output collapsed into scattered cells.

Stamp each broadcast chunk with a monotonic per-session seq and report
the seq the snapshot already reflects. The renderer now buffers live
chunks until the snapshot is applied, then replays only the chunks newer
than the snapshot's cut point before switching to direct writes — no
reordering, no double-application, no escapes spliced mid-parse.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
