### PR TITLE
fix: scroll Mission Control when the terminals grid overflows the viewport

### DIFF
--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -310,6 +310,12 @@ input {
 	display: flex;
 	flex-direction: column;
 	min-width: 0;
+	/* Grid items default to min-height: auto, which would let this column grow to
+	   fit a tall child (e.g. a Mission Control grid with many terminals) and spill
+	   past the viewport — where #root's overflow: hidden clips it with no scroll.
+	   Pinning min-height: 0 keeps .main at the grid track height so .content/.mc
+	   stay bounded and their own overflow-y: auto scrolls instead. */
+	min-height: 0;
 }
 .topbar {
 	height: 44px;


### PR DESCRIPTION
.main is a grid item of .app, so it defaulted to min-height: auto and grew
to fit a tall Mission Control grid — spilling past the viewport where #root's
overflow: hidden clipped it with no scroll. Pin min-height: 0 so .main holds
the grid track height and .mc's own overflow-y: auto scrolls instead.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
