### PR TITLE
fix: stop dropped images opening in a new window

### DIFF
--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -2,6 +2,17 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./index.css";
 
+// Global drop guard. The terminal handles drops on its own element (typing the
+// dropped file's path to the PTY), but a file dropped ANYWHERE else in the
+// window — sidebar, header, gaps between Mission Control tiles — would hit
+// Chromium's default and navigate the window to file://…/image.png, i.e. it
+// "opens the image in a new window". Preventing the default at the window level
+// makes a stray drop a no-op. The terminal's own listeners sit closer to the
+// drop target, so they still run first and do their job; this only catches the
+// misses.
+window.addEventListener("dragover", (e) => e.preventDefault());
+window.addEventListener("drop", (e) => e.preventDefault());
+
 // Note: intentionally NOT wrapped in <StrictMode>. Its dev-only double
 // mount/unmount disposes and recreates each xterm, which leaves terminal focus
 // and PTY input in a bad state (Enter/keys not reaching the pty), especially


### PR DESCRIPTION
Drag-drop was only prevented on the terminal element. A file dropped
anywhere else in the window (sidebar, header, Mission Control gaps) hit
Chromium's default and navigated to file://…/image.png — i.e. opened the
image in a new window. Add a window-level dragover/drop guard so a stray
drop is a no-op; the terminal's own listeners still run first and type
the path to the PTY.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
