### PR TITLE
fix: don't switch to Board when deleting a task you've navigated away from

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -641,7 +641,11 @@ export function App() {
 									ask={ask}
 									confirm={confirm}
 									reload={() => activeProjectId && loadTasks(activeProjectId)}
-									onClose={() => setSelectedTaskId(null)}
+									onClose={(taskId) =>
+							setSelectedTaskId((cur) =>
+								taskId == null || cur === taskId ? null : cur,
+							)
+						}
 								/>
 							)}
 						</>
@@ -791,7 +795,7 @@ function TaskPanel({
 	ask: (title: string, initial?: string) => Promise<string | null>;
 	confirm: (title: string, body?: string) => Promise<boolean>;
 	reload: () => void;
-	onClose: () => void;
+	onClose: (taskId?: string) => void;
 }) {
 	const [agentId, setAgentId] = useState(
 		agents.find((a) => a.available)?.id ?? "claude",
@@ -1002,7 +1006,7 @@ function TaskPanel({
 										return;
 									}
 								}
-								onClose();
+								onClose(task.id);
 								reload();
 							},
 						},


### PR DESCRIPTION
Task deletion is async (git worktree teardown). Previously it
unconditionally cleared the selected task when done, dropping you on the
Board even if you'd since opened a different task. Now onClose takes an
optional taskId and only deselects when that task is still selected,
using a functional update to read the current selection.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
