### PR TITLE
feat: copy Supabase link state into new worktrees

### DIFF
--- a/packages/git-core/src/task.ts
+++ b/packages/git-core/src/task.ts
@@ -1,5 +1,5 @@
-import { mkdir } from "node:fs/promises";
-import { dirname } from "node:path";
+import { cp, mkdir, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { gitFor, refExists } from "./git-client";
 import { GitCoreError } from "./errors";
 import { detectDefaultBranch, ensureWorktreesIgnored } from "./project";
@@ -37,6 +37,33 @@ async function resolveStartPoint(
 		return baseBranch;
 	}
 	return "HEAD";
+}
+
+/**
+ * Supabase's project link lives in `supabase/.temp/` (gitignored — it holds the
+ * `project-ref` and cached versions written by `supabase link`). The tracked
+ * `supabase/` config rides along on the branch, but `.temp` does not, so a fresh
+ * worktree's CLI would be unlinked. Copy that untracked link state across so the
+ * CLI in the new worktree is already linked. Best-effort: a missing source dir,
+ * a non-Supabase repo, or a copy error must never fail task creation.
+ */
+async function copySupabaseLink(
+	repoPath: string,
+	worktreePath: string,
+): Promise<void> {
+	const src = join(repoPath, "supabase", ".temp");
+	try {
+		if (!(await stat(src)).isDirectory()) return;
+	} catch {
+		return; // no Supabase link in the source repo — nothing to copy
+	}
+	try {
+		await cp(src, join(worktreePath, "supabase", ".temp"), {
+			recursive: true,
+		});
+	} catch {
+		/* best-effort — leave the worktree unlinked rather than fail the task */
+	}
 }
 
 /**
@@ -83,6 +110,9 @@ export async function createTask(input: CreateTaskInput): Promise<TaskInfo> {
 
 	// Record the base branch so update/merge know what to diff/merge against.
 	await gitFor(worktreePath).raw(["config", `branch.${branch}.base`, baseBranch]);
+
+	// Carry the Supabase link over so the worktree's CLI is already linked.
+	await copySupabaseLink(input.repoPath, worktreePath);
 
 	return { slug, branch, baseBranch, worktreePath };
 }

--- a/packages/git-core/test/git-core.test.ts
+++ b/packages/git-core/test/git-core.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import simpleGit from "simple-git";
 import {
@@ -106,6 +106,28 @@ describe("createTask isolation", () => {
 		// B's working tree and branch are untouched by work in A.
 		expect(await porcelainStatus(b.worktreePath)).toBe("");
 		expect(existsSync(join(b.worktreePath, "a.txt"))).toBe(false);
+	});
+
+	it("copies the Supabase link state into the new worktree", async () => {
+		// Simulate `supabase link`: the gitignored link cache in the main repo.
+		await mkdir(join(repo.work, "supabase", ".temp"), { recursive: true });
+		await writeFile(
+			join(repo.work, "supabase", ".temp", "project-ref"),
+			"abcdefghijklmnopqrst",
+		);
+
+		const task = await createTask({ repoPath: repo.work, name: "linked" });
+
+		const copied = join(task.worktreePath, "supabase", ".temp", "project-ref");
+		expect(existsSync(copied)).toBe(true);
+		expect(await Bun.file(copied).text()).toBe("abcdefghijklmnopqrst");
+	});
+
+	it("creates the worktree fine when there is no Supabase link", async () => {
+		// No supabase/.temp in the repo — task creation must still succeed.
+		const task = await createTask({ repoPath: repo.work, name: "unlinked" });
+		expect(existsSync(task.worktreePath)).toBe(true);
+		expect(existsSync(join(task.worktreePath, "supabase"))).toBe(false);
 	});
 });
 


### PR DESCRIPTION
A fresh worktree's Supabase CLI was unlinked: the link cache lives in the
gitignored supabase/.temp/ (holding project-ref), so it never rode along
on the branch even though the tracked supabase/ config did. createTask now
copies that untracked link state from the source repo into each new
worktree, best-effort — a non-Supabase repo or copy error never fails task
creation.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
