### PR TITLE
chore: release 0.1.15

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {


### PR DESCRIPTION
Cuts the 0.1.15 release — everything merged after v0.1.14 (#8, #9, #11–#16).

**Features**
- Merge queue + Loops subsystem with agent routing — "two agents" (#8)
- Per-terminal toolbar with a + menu to attach files (#9)
- Open a new task in the current panel mode instead of forcing full-width (#15)
- Copy Supabase link state into new worktrees (#16)

**Fixes**
- Apply terminal snapshot before live data on reattach (#11)
- Scroll Mission Control when the terminals grid overflows the viewport (#12)
- Stop dropped images opening in a new window (#13)
- Don't switch to Board when deleting a task you've navigated away from (#14)

**Release tooling**
- Bump desktop app to 0.1.15