### PR TITLE
fix: paste image data natively via Ctrl+V instead of a temp file

### DIFF
--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { readFileSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { agentCommand, getAgent, listAgents } from "@ateam/agents";
@@ -435,20 +434,17 @@ export function registerIpc(ctx: IpcContext): void {
 		e.returnValue = clipboardImageKind() !== null;
 	});
 
-	// Resolve the clipboard image to a real file path the agent can read.
-	// Pasting a path (bracketed) beats sending Ctrl+V: the agent loads the
-	// file's actual bytes instead of letting its own clipboard read grab a
-	// file's generic Finder icon (the "blank PNG" bug).
+	// Classify the clipboard image for the renderer's paste handler.
+	// - "bitmap" (raw image data: a screenshot, copy-from-browser): the renderer
+	//   forwards a bare Ctrl+V so the agent reads the bytes off the clipboard
+	//   itself, exactly like a raw terminal — no temp file.
+	// - "file" (an image file copied in Finder): the agent's own clipboard read
+	//   would grab the file's generic Finder icon, so we hand back its real path
+	//   for the renderer to paste instead.
 	ipcMain.handle(CH.utilClipboardImagePath, async () => {
 		const kind = clipboardImageKind();
-		if (kind?.kind === "file") return kind.path;
-		if (kind?.kind === "bitmap") {
-			const img = clipboard.readImage();
-			if (img.isEmpty()) return null;
-			const file = join(tmpdir(), `ateam-paste-${Date.now()}.png`);
-			writeFileSync(file, img.toPNG());
-			return file;
-		}
+		if (kind?.kind === "file") return { kind: "file" as const, path: kind.path };
+		if (kind?.kind === "bitmap") return { kind: "bitmap" as const };
 		return null;
 	});
 

--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -10,8 +10,7 @@ import { Menu } from "./Menu";
  * "typed path → [Image #N]" detection fires — that wants shell-style escaping,
  * not quoting.
  */
-const escapePath = (p: string) =>
-	p.replace(/([ '"\\!$&*()[\]{};<>?#~`|])/g, "\\$1");
+const escapePath = (p: string) => p.replace(/([ '"\\!$&*()[\]{};<>?#~`|])/g, "\\$1");
 
 /**
  * One xterm.js view bound to a main-process PTY by terminalId. Replays the
@@ -50,22 +49,27 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 		const focusTerm = () => term.focus();
 		el.addEventListener("mousedown", focusTerm);
 
-		// Pasting an image: resolve it to a real file path and paste THAT
-		// (bracketed), so the agent loads the file's bytes. Sending Ctrl+V
-		// instead makes the agent do its own clipboard read, which grabs a
-		// copied file's generic Finder icon rather than its contents. The menu's
-		// Paste role fires a DOM `paste` event (the renderer never sees ⌘V's
-		// keydown — the menu owns that accelerator), intercepted here in capture
-		// phase before xterm's own textarea paste handler.
+		// Pasting an image. The menu's Paste role fires a DOM `paste` event (the
+		// renderer never sees ⌘V's keydown — the menu owns that accelerator),
+		// intercepted here in capture phase before xterm's own textarea handler.
+		//   - Raw image data (a screenshot, copy-from-browser): forward a bare
+		//     Ctrl+V so the agent reads the bitmap off the clipboard itself,
+		//     exactly like a raw terminal — no temp file.
+		//   - A copied image *file* (Finder): the agent's own clipboard read would
+		//     grab the file's generic Finder icon, so paste its real path instead
+		//     and let the agent load its bytes.
 		const onPaste = (e: Event) => {
 			if (!window.ateam.utils.clipboardHasImage()) return; // text → xterm
 			e.preventDefault();
 			e.stopPropagation();
-			void window.ateam.utils.clipboardImagePath().then((p) => {
-				if (p) {
-					term.paste(`${escapePath(p)} `);
-					term.focus();
+			void window.ateam.utils.clipboardImagePath().then((img) => {
+				if (!img) return;
+				if (img.kind === "file") {
+					term.paste(`${escapePath(img.path)} `);
+				} else {
+					window.ateam.pty.write(terminalId, "\x16");
 				}
+				term.focus();
 			});
 		};
 		el.addEventListener("paste", onPaste, true);
@@ -145,9 +149,7 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 			term.write("", () => term.scrollToBottom());
 		});
 
-		const disposeInput = term.onData((d) =>
-			window.ateam.pty.write(terminalId, d),
-		);
+		const disposeInput = term.onData((d) => window.ateam.pty.write(terminalId, d));
 
 		// Resize handling. Layout toggles fire several ResizeObserver callbacks
 		// in quick succession (sometimes while the element is mid-layout at zero

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -313,11 +313,13 @@ export interface AteamApi {
 		/** True when the clipboard holds an image and no text (sync). */
 		clipboardHasImage(): boolean;
 		/**
-		 * Resolve a clipboard image to a file path the agent can read: a copied
-		 * image file's own path, or a temp PNG written from a clipboard bitmap.
+		 * Classify the clipboard image so the renderer can paste it the right way:
+		 * "file" carries a copied image file's real path (paste it so the agent
+		 * reads its bytes, not its Finder icon); "bitmap" means raw image data the
+		 * agent should read off the clipboard itself via Ctrl+V (no temp file).
 		 * Null when the clipboard holds no image.
 		 */
-		clipboardImagePath(): Promise<string | null>;
+		clipboardImagePath(): Promise<{ kind: "file"; path: string } | { kind: "bitmap" } | null>;
 		/** Native open dialog; resolves to the chosen paths ([] on cancel). */
 		pickFiles(): Promise<string[]>;
 	};


### PR DESCRIPTION
Pasting a screenshot/clipboard bitmap regressed in 0.1.14: the renderer
resolved the clipboard to a temp PNG and pasted its path, which broke
Claude Code's own image detection. Restore the original behavior of
forwarding a bare Ctrl+V so the agent reads the bitmap off the clipboard
itself, exactly like a raw terminal — no temp file. Copied image *files*
(Finder) still paste their real path, since a native read there would
only grab the generic Finder icon.
