### PR TITLE
chore: release 0.1.16

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {


### PR DESCRIPTION
Cuts the 0.1.16 release — everything merged after v0.1.15 (#18, #19, #22).

**Features**
- Full-height split tiles and a 2x2 grid in Mission Control (#18)
- Copy gitignored env files (.env*, .dev.vars*, including nested) into new worktrees (#22)

**Fixes**
- Paste image data natively via Ctrl+V instead of a temp file, restoring Claude Code's clipboard-image detection that regressed in 0.1.14 (#19)

**Release tooling**
- Bump desktop app to 0.1.16