### PR TITLE
refactor: classify clipboard image paste in the renderer, no IPC

### DIFF
--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { basename, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { agentCommand, getAgent, listAgents } from "@ateam/agents";
 import { repo } from "@ateam/db";
 import {
@@ -19,7 +18,7 @@ import {
 	trackingStatus,
 	updateFromBase,
 } from "@ateam/git-core";
-import { BrowserWindow, clipboard, dialog, ipcMain } from "electron";
+import { dialog, ipcMain } from "electron";
 import {
 	CH,
 	type CreateLoopInput,
@@ -40,37 +39,6 @@ export interface IpcContext {
 	loopRunner: LoopRunner;
 	/** Push the current loop list to the renderer. */
 	sendLoopsUpdated: () => void;
-}
-
-const IMAGE_EXT = /\.(png|jpe?g|gif|webp|bmp|tiff?|heic|svg)$/i;
-
-/**
- * Classify the clipboard for image paste. A copied *file* (Finder) is preferred
- * — paste its real path so the agent reads its contents, not its Finder icon.
- * A raw bitmap (e.g. a ⌘⌃⇧4 screenshot) falls back to "bitmap". Text present →
- * not an image (let it paste normally). Returns null when there's nothing to do.
- */
-function clipboardImageKind(): { kind: "file"; path: string } | { kind: "bitmap" } | null {
-	if (clipboard.readText().length > 0) return null;
-	const formats = clipboard.availableFormats();
-	// A file reference (image file copied in Finder): use its path directly.
-	const fileUrlFmt = formats.find((f) => /file-?url|filenames/i.test(f));
-	if (fileUrlFmt) {
-		const raw = clipboard.read(fileUrlFmt).trim().split(/\r?\n/)[0];
-		if (raw) {
-			try {
-				const path = raw.startsWith("file:") ? fileURLToPath(raw) : raw;
-				if (IMAGE_EXT.test(path)) return { kind: "file", path };
-			} catch {
-				/* not a usable file url */
-			}
-		}
-	}
-	// A real bitmap on the clipboard.
-	if (formats.some((f) => /image|png|tiff|jpeg/i.test(f))) {
-		return { kind: "bitmap" };
-	}
-	return null;
 }
 
 /** Project display name from the repo's README H1 (md or HTML), if present. */
@@ -425,27 +393,6 @@ export function registerIpc(ctx: IpcContext): void {
 		repo.updateTask(db, task.id, { gitStatus: snapshot });
 		if (task.column !== "merged") void detectExternalMerge(task.id);
 		return snapshot;
-	});
-
-	// Sync (rare, keypress-driven): does the clipboard hold an image-only
-	// payload (a bitmap or a copied image file, no text)? Drives the renderer's
-	// decision to intercept a paste as an image rather than text.
-	ipcMain.on(CH.utilClipboardHasImage, (e) => {
-		e.returnValue = clipboardImageKind() !== null;
-	});
-
-	// Classify the clipboard image for the renderer's paste handler.
-	// - "bitmap" (raw image data: a screenshot, copy-from-browser): the renderer
-	//   forwards a bare Ctrl+V so the agent reads the bytes off the clipboard
-	//   itself, exactly like a raw terminal — no temp file.
-	// - "file" (an image file copied in Finder): the agent's own clipboard read
-	//   would grab the file's generic Finder icon, so we hand back its real path
-	//   for the renderer to paste instead.
-	ipcMain.handle(CH.utilClipboardImagePath, async () => {
-		const kind = clipboardImageKind();
-		if (kind?.kind === "file") return { kind: "file" as const, path: kind.path };
-		if (kind?.kind === "bitmap") return { kind: "bitmap" as const };
-		return null;
 	});
 
 	// Native file picker for the terminal toolbar's "+ → Files…" action; the

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -72,8 +72,6 @@ const api: AteamApi = {
 	},
 	utils: {
 		pathForFile: (file) => webUtils.getPathForFile(file),
-		clipboardHasImage: () => ipcRenderer.sendSync(CH.utilClipboardHasImage) === true,
-		clipboardImagePath: () => ipcRenderer.invoke(CH.utilClipboardImagePath),
 		pickFiles: () => ipcRenderer.invoke(CH.utilPickFiles),
 	},
 	events: {

--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -49,43 +49,15 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 		const focusTerm = () => term.focus();
 		el.addEventListener("mousedown", focusTerm);
 
-		// Pasting an image. The menu's Paste role fires a DOM `paste` event (the
-		// renderer never sees ⌘V's keydown — the menu owns that accelerator),
-		// intercepted here in capture phase before xterm's own textarea handler.
-		//   - Raw image data (a screenshot, copy-from-browser): forward a bare
-		//     Ctrl+V so the agent reads the bitmap off the clipboard itself,
-		//     exactly like a raw terminal — no temp file.
-		//   - A copied image *file* (Finder): the agent's own clipboard read would
-		//     grab the file's generic Finder icon, so paste its real path instead
-		//     and let the agent load its bytes.
-		const onPaste = (e: Event) => {
-			if (!window.ateam.utils.clipboardHasImage()) return; // text → xterm
-			e.preventDefault();
-			e.stopPropagation();
-			void window.ateam.utils.clipboardImagePath().then((img) => {
-				if (!img) return;
-				if (img.kind === "file") {
-					term.paste(`${escapePath(img.path)} `);
-				} else {
-					window.ateam.pty.write(terminalId, "\x16");
-				}
-				term.focus();
-			});
-		};
-		el.addEventListener("paste", onPaste, true);
-
-		// Dropping files types their backslash-escaped paths straight to the PTY,
-		// exactly like a real terminal (iTerm/Terminal.app) does on a file drop.
+		// Type dropped files' backslash-escaped paths straight to the PTY, exactly
+		// like a real terminal (iTerm/Terminal.app) does on a file drop.
+		//
 		// This is deliberately NOT term.paste(): a paste arrives wrapped in
-		// bracketed-paste markers, which Claude Code treats as a literal text
-		// block and does NOT scan for a droppable file path — so the image never
-		// attaches and you're left with a literal path. Typed keystrokes are what
-		// trigger its "dropped path → [Image #N]" detection.
-		const onDragOver = (e: DragEvent) => e.preventDefault();
-		const onDrop = (e: DragEvent) => {
-			e.preventDefault();
-			const files = Array.from(e.dataTransfer?.files ?? []);
-			if (files.length === 0) return;
+		// bracketed-paste markers, which Claude Code treats as a literal text block
+		// and does NOT scan for a droppable file path — so the image never attaches
+		// and you're left with a literal path. Typed keystrokes are what trigger its
+		// "path → [Image #N]" detection.
+		const typeFilePaths = (files: File[]) => {
 			const paths = files
 				.map((f) => window.ateam.utils.pathForFile(f))
 				.filter(Boolean)
@@ -94,6 +66,34 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 				window.ateam.pty.write(terminalId, `${paths.join(" ")} `);
 				term.focus();
 			}
+		};
+
+		// Pasting an image. The menu's Paste role fires a DOM `paste` event with a
+		// populated clipboardData (the renderer never sees ⌘V's keydown — the menu
+		// owns that accelerator), intercepted here in capture phase before xterm's
+		// own textarea handler. We classify straight off the event — no IPC.
+		//
+		// Plain text pastes normally. For any non-text clipboard payload (a raw
+		// bitmap like a screenshot, OR a copied file) we forward a bare Ctrl+V and
+		// let the agent read it off the clipboard itself, exactly like a raw
+		// terminal — no temp file, no typed path. The agent renders its own
+		// attachment (Claude Code shows "[Image #N]"); we never synthesize that.
+		const onPaste = (e: ClipboardEvent) => {
+			const dt = e.clipboardData;
+			if (!dt || dt.getData("text/plain")) return; // text → xterm
+			if (dt.files.length === 0) return; // nothing image/file-like
+			e.preventDefault();
+			e.stopPropagation();
+			window.ateam.pty.write(terminalId, "\x16");
+			term.focus();
+		};
+		el.addEventListener("paste", onPaste, true);
+
+		// Dropping files types their paths, same as above.
+		const onDragOver = (e: DragEvent) => e.preventDefault();
+		const onDrop = (e: DragEvent) => {
+			e.preventDefault();
+			typeFilePaths(Array.from(e.dataTransfer?.files ?? []));
 		};
 		el.addEventListener("dragover", onDragOver);
 		el.addEventListener("drop", onDrop);

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -201,8 +201,6 @@ export const CH = {
 	loopsCreate: "loops:create",
 	loopsDelete: "loops:delete",
 	agentsList: "agents:list",
-	utilClipboardHasImage: "util:clipboardHasImage",
-	utilClipboardImagePath: "util:clipboardImagePath",
 	utilPickFiles: "util:pickFiles",
 	ptySpawnAgent: "pty:spawnAgent",
 	ptySpawnShell: "pty:spawnShell",
@@ -308,18 +306,12 @@ export interface AteamApi {
 		onTaskUpdated(cb: (task: TaskDTO) => void): () => void;
 	};
 	utils: {
-		/** Absolute filesystem path for a dragged-in File (Electron webUtils). */
-		pathForFile(file: File): string;
-		/** True when the clipboard holds an image and no text (sync). */
-		clipboardHasImage(): boolean;
 		/**
-		 * Classify the clipboard image so the renderer can paste it the right way:
-		 * "file" carries a copied image file's real path (paste it so the agent
-		 * reads its bytes, not its Finder icon); "bitmap" means raw image data the
-		 * agent should read off the clipboard itself via Ctrl+V (no temp file).
-		 * Null when the clipboard holds no image.
+		 * Absolute filesystem path for a File from a drop or paste (Electron
+		 * webUtils). Returns "" for a File with no backing path — e.g. a raw
+		 * clipboard bitmap (screenshot) Chromium synthesizes into a File.
 		 */
-		clipboardImagePath(): Promise<{ kind: "file"; path: string } | { kind: "bitmap" } | null>;
+		pathForFile(file: File): string;
 		/** Native open dialog; resolves to the chosen paths ([] on cancel). */
 		pickFiles(): Promise<string[]>;
 	};


### PR DESCRIPTION
Paste handling read the clipboard via a blocking sendSync plus an async
IPC round-trip, with the main process re-deriving file-vs-bitmap from the
native clipboard. Match superset instead: classify straight off the DOM
paste event with no IPC.

  - plain text present -> let xterm paste it
  - any non-text payload (a screenshot bitmap OR a copied file) -> forward
    a bare Ctrl+V and let the agent read the clipboard itself; it renders
    its own attachment (Claude Code shows [Image #N]) — we never type a
    path or synthesize that text

Drop still types dropped files' escaped paths (the only way to attach a
dropped file), sharing the same escaping. Removes the synchronous IPC and
the main-process clipboard logic (clipboardImageKind, two IPC channels,
two API methods).
