### PR TITLE
chore: release 0.1.17

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {


### PR DESCRIPTION
Cuts the 0.1.17 release — everything merged after v0.1.16 (#23).

**Changes**
- Classify clipboard image paste in the renderer with no IPC — paste handling now decides text-vs-bitmap/file straight off the DOM paste event, dropping the blocking sendSync + async IPC round-trip (#23)

**Release tooling**
- Bump desktop app to 0.1.17