### PR TITLE
feat: attach files when creating a task

### DIFF
--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -460,6 +460,7 @@ export function registerIpc(ctx: IpcContext): void {
 				yolo?: boolean;
 				resume?: boolean;
 				prompt?: string;
+				files?: string[];
 			},
 		) => {
 			const task = requireTask(services, input.taskId);
@@ -489,10 +490,18 @@ export function registerIpc(ctx: IpcContext): void {
 			// Run the agent in a login shell, then drop to an interactive shell so
 			// the pane stays usable after the agent exits. YOLO appends the bypass
 			// flag; resume relaunches the agent's most recent conversation here.
+			// Attached files ride along in the prompt as absolute paths under a
+			// header — the agent reads them with its own Read tool (nothing is
+			// copied into the worktree). Skip on resume, which ignores the prompt.
+			let prompt = input.prompt;
+			if (input.files?.length) {
+				const list = input.files.map((f) => `- ${f}`).join("\n");
+				prompt = prompt ? `${prompt}\n\nAttached files:\n${list}` : `Attached files:\n${list}`;
+			}
 			let agentCmd = agentCommand(agent, {
 				yolo: input.yolo,
 				resume: input.resume,
-				prompt: input.prompt,
+				prompt,
 			});
 			if (agent.id === "codex") {
 				// Codex has no hooks, but `notify` invokes a program with a JSON

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -306,7 +306,13 @@ export function App() {
 	// Create the task, open it in the current panel mode (side when on the
 	// board, full when already full-width), and launch the chosen agent with
 	// the prompt as its first instruction.
-	const composeTask = (input: { name: string; prompt: string; agentId: string; yolo: boolean }) =>
+	const composeTask = (input: {
+		name: string;
+		prompt: string;
+		agentId: string;
+		yolo: boolean;
+		files: string[];
+	}) =>
 		run(async () => {
 			if (!activeProjectId) return;
 			setComposerOpen(false);
@@ -325,6 +331,7 @@ export function App() {
 				agentId: input.agentId,
 				yolo: input.yolo,
 				prompt: input.prompt || undefined,
+				files: input.files.length ? input.files : undefined,
 			});
 			setTermByTask((m) => ({ ...m, [task.id]: terminalId }));
 		});
@@ -601,10 +608,8 @@ export function App() {
 									confirm={confirm}
 									reload={() => activeProjectId && loadTasks(activeProjectId)}
 									onClose={(taskId) =>
-							setSelectedTaskId((cur) =>
-								taskId == null || cur === taskId ? null : cur,
-							)
-						}
+										setSelectedTaskId((cur) => (taskId == null || cur === taskId ? null : cur))
+									}
 								/>
 							)}
 						</>

--- a/apps/desktop/src/renderer/src/components/NewTaskComposer.tsx
+++ b/apps/desktop/src/renderer/src/components/NewTaskComposer.tsx
@@ -1,6 +1,11 @@
-import { ArrowUp, Zap } from "lucide-react";
+import { ArrowUp, Paperclip, X, Zap } from "lucide-react";
 import { useState } from "react";
 import type { AgentDTO } from "../../../shared/types";
+
+/** Last path segment, for a compact chip label. */
+function baseName(p: string): string {
+	return p.split(/[/\\]/).pop() || p;
+}
 
 /** Mirror of git-core's slugify, for the live branch-name preview. */
 function slugify(s: string): string {
@@ -33,25 +38,39 @@ export function NewTaskComposer({
 		prompt: string;
 		agentId: string;
 		yolo: boolean;
+		files: string[];
 	}) => void;
 }) {
 	const [name, setName] = useState("");
 	const [prompt, setPrompt] = useState("");
-	const [agentId, setAgentId] = useState(
-		agents.find((a) => a.available)?.id ?? "claude",
-	);
+	const [agentId, setAgentId] = useState(agents.find((a) => a.available)?.id ?? "claude");
 	const [yolo, setYolo] = useState(false);
+	const [files, setFiles] = useState<string[]>([]);
+	const [dragging, setDragging] = useState(false);
 
 	const branch = slugify(name.trim() || titleFromPrompt(prompt));
-	const canSubmit = Boolean(name.trim() || prompt.trim());
+	const canSubmit = Boolean(name.trim() || prompt.trim() || files.length);
+
+	// De-duped append, preserving order — the picker and drops both feed here.
+	const addFiles = (paths: string[]) =>
+		setFiles((cur) => [...cur, ...paths.filter((p) => p && !cur.includes(p))]);
+	const removeFile = (path: string) => setFiles((cur) => cur.filter((p) => p !== path));
+
+	const pickFiles = async () => {
+		addFiles(await window.ateam.utils.pickFiles());
+	};
+
+	const onDrop = (e: React.DragEvent) => {
+		e.preventDefault();
+		setDragging(false);
+		addFiles(Array.from(e.dataTransfer.files).map((f) => window.ateam.utils.pathForFile(f)));
+	};
 
 	const submit = () => {
 		if (!canSubmit) return;
 		const finalName =
-			name.trim() ||
-			titleFromPrompt(prompt) ||
-			`task ${new Date().toISOString().slice(0, 10)}`;
-		onCreate({ name: finalName, prompt: prompt.trim(), agentId, yolo });
+			name.trim() || titleFromPrompt(prompt) || `task ${new Date().toISOString().slice(0, 10)}`;
+		onCreate({ name: finalName, prompt: prompt.trim(), agentId, yolo, files });
 	};
 
 	const onKeys = (e: React.KeyboardEvent) => {
@@ -65,9 +84,15 @@ export function NewTaskComposer({
 	return (
 		<div className="overlay" onMouseDown={onClose}>
 			<div
-				className="dialog composer"
+				className={`dialog composer ${dragging ? "dropping" : ""}`}
 				onMouseDown={(e) => e.stopPropagation()}
 				onKeyDown={onKeys}
+				onDragOver={(e) => {
+					e.preventDefault();
+					setDragging(true);
+				}}
+				onDragLeave={() => setDragging(false)}
+				onDrop={onDrop}
 			>
 				<div className="comp-head">
 					<input
@@ -88,7 +113,33 @@ export function NewTaskComposer({
 					value={prompt}
 					onChange={(e) => setPrompt(e.target.value)}
 				/>
+				{files.length > 0 && (
+					<div className="comp-files">
+						{files.map((f) => (
+							<span key={f} className="file-chip" title={f}>
+								<span className="fc-name">{baseName(f)}</span>
+								<button
+									type="button"
+									className="fc-x"
+									aria-label={`Remove ${baseName(f)}`}
+									onClick={() => removeFile(f)}
+								>
+									<X size={12} strokeWidth={2.25} />
+								</button>
+							</span>
+						))}
+					</div>
+				)}
 				<div className="comp-foot">
+					<button
+						type="button"
+						className="iconbtn comp-attach"
+						title="Attach files — their paths are handed to the agent"
+						aria-label="Attach files"
+						onClick={pickFiles}
+					>
+						<Paperclip size={16} strokeWidth={1.75} />
+					</button>
 					<select
 						className="agent-select"
 						value={agentId}

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -843,6 +843,47 @@ input {
 	font-size: 13px;
 	outline: none;
 }
+.dialog.composer.dropping {
+	outline: 2px dashed var(--accent, #6ea8fe);
+	outline-offset: -4px;
+}
+.comp-files {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+.file-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	max-width: 220px;
+	padding: 2px 4px 2px 8px;
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	background: var(--bg);
+	font-size: 11.5px;
+	color: var(--text-dim);
+}
+.file-chip .fc-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.file-chip .fc-x {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border: none;
+	background: transparent;
+	color: var(--text-dim);
+	cursor: pointer;
+	padding: 2px;
+	border-radius: 4px;
+}
+.file-chip .fc-x:hover {
+	color: var(--text);
+	background: var(--border);
+}
 .comp-foot {
 	display: flex;
 	align-items: center;

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -292,6 +292,8 @@ export interface AteamApi {
 			resume?: boolean;
 			/** Initial instruction handed to the agent at launch. */
 			prompt?: string;
+			/** Absolute paths to attach — appended to the prompt for the agent to read. */
+			files?: string[];
 		}): Promise<{ terminalId: string }>;
 		spawnShell(input: { taskId: string }): Promise<{ terminalId: string }>;
 		write(terminalId: string, data: string): void;


### PR DESCRIPTION
The New Task composer now takes file attachments via a paperclip picker
(reusing utils.pickFiles) and drag-and-drop, shown as removable chips.
Attached files' absolute paths are appended to the agent's initial
prompt under an "Attached files:" header so the agent reads them with
its own Read tool — nothing is copied into the worktree, and it's
skipped on resume.
