### PR TITLE
fix finder image paste

### DIFF
--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { basename, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { agentCommand, getAgent, listAgents } from "@ateam/agents";
 import { repo } from "@ateam/db";
 import {
@@ -18,7 +19,7 @@ import {
 	trackingStatus,
 	updateFromBase,
 } from "@ateam/git-core";
-import { dialog, ipcMain } from "electron";
+import { clipboard, dialog, ipcMain, nativeImage } from "electron";
 import {
 	CH,
 	type CreateLoopInput,
@@ -403,6 +404,47 @@ export function registerIpc(ctx: IpcContext): void {
 			title: "Add files to terminal",
 		});
 		return res.canceled ? [] : res.filePaths;
+	});
+
+	// "+ → Attach image": stage a real bitmap on the clipboard so the renderer's
+	// following Ctrl+V hands the agent pixels, not a path or a file-icon. We must
+	// read an image *file* off disk by its path — clipboard.readImage() on a
+	// Finder file copy returns the file's generic type icon, which is the blank-
+	// placeholder bug. So: prefer a clipboard file URL (read its bytes), then a
+	// genuine clipboard bitmap (a screenshot), then a file the user picks.
+	ipcMain.handle(CH.utilStageImage, async () => {
+		const IMAGE_RE = /\.(png|jpe?g|gif|webp|bmp|tiff?|heic|heif|avif|ico)$/i;
+		const clipFile = clipboard.read("public.file-url").trim();
+		let path: string | null = null;
+		if (clipFile) {
+			try {
+				const p = fileURLToPath(clipFile);
+				if (IMAGE_RE.test(p)) path = p;
+			} catch {
+				/* not a usable file URL */
+			}
+		}
+		// A real bitmap already on the clipboard (e.g. a screenshot) — only trust
+		// it when there's no file URL, since for a file copy this is just the icon.
+		let img = path ? nativeImage.createFromPath(path) : clipboard.readImage();
+		if (img.isEmpty()) {
+			const res = await dialog.showOpenDialog({
+				properties: ["openFile"],
+				title: "Attach image",
+				filters: [
+					{
+						name: "Images",
+						extensions: ["png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "heic", "avif"],
+					},
+				],
+			});
+			const picked = res.canceled ? null : (res.filePaths[0] ?? null);
+			if (!picked) return false;
+			img = nativeImage.createFromPath(picked);
+		}
+		if (img.isEmpty()) return false;
+		clipboard.writeImage(img);
+		return true;
 	});
 
 	// ---- agents ----

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -73,6 +73,7 @@ const api: AteamApi = {
 	utils: {
 		pathForFile: (file) => webUtils.getPathForFile(file),
 		pickFiles: () => ipcRenderer.invoke(CH.utilPickFiles),
+		stageClipboardImage: () => ipcRenderer.invoke(CH.utilStageImage),
 	},
 	events: {
 		onTaskUpdated: (cb: (task: TaskDTO) => void) => {

--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -1,6 +1,6 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
-import { FileUp, Plus } from "lucide-react";
+import { FileUp, ImageUp, Plus } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { Menu } from "./Menu";
 
@@ -239,6 +239,17 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 		termRef.current?.focus();
 	};
 
+	// "+ → Attach image": main stages a real bitmap on the clipboard (from a
+	// copied image, a Finder-copied file's bytes, or one the user picks), then we
+	// forward a bare Ctrl+V so the agent reads the pixels off the clipboard — the
+	// one path that attaches reliably, regardless of typed-path detection.
+	const attachImage = async () => {
+		if (await window.ateam.utils.stageClipboardImage()) {
+			window.ateam.pty.write(terminalId, "\x16");
+		}
+		termRef.current?.focus();
+	};
+
 	return (
 		<div className="term-shell">
 			{/* .term-area is the flex-sized box; .term is absolutely positioned to
@@ -251,7 +262,10 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 				<Menu
 					icon={Plus}
 					label="Add to terminal"
-					items={[{ label: "Files…", icon: FileUp, onClick: addFiles }]}
+					items={[
+						{ label: "Attach image", icon: ImageUp, onClick: attachImage },
+						{ label: "Files…", icon: FileUp, onClick: addFiles },
+					]}
 				/>
 			</div>
 		</div>

--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -73,19 +73,28 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 		// owns that accelerator), intercepted here in capture phase before xterm's
 		// own textarea handler. We classify straight off the event — no IPC.
 		//
-		// Plain text pastes normally. For any non-text clipboard payload (a raw
-		// bitmap like a screenshot, OR a copied file) we forward a bare Ctrl+V and
-		// let the agent read it off the clipboard itself, exactly like a raw
-		// terminal — no temp file, no typed path. The agent renders its own
-		// attachment (Claude Code shows "[Image #N]"); we never synthesize that.
+		// Plain text pastes normally. A non-text payload splits two ways, and the
+		// split matters: a native ⌃V read of a Finder-copied file yields only its
+		// generic file-type icon, not the bytes, so the two cannot be collapsed.
+		//   - a copied file (Finder) has a real path → type it, exactly like a
+		//     drop, so Claude Code's "path → [Image #N]" detection attaches the
+		//     actual file.
+		//   - a raw bitmap (screenshot) has no path → forward a bare Ctrl+V and let
+		//     the agent read the bitmap off the clipboard itself, like a raw
+		//     terminal — no temp file. The agent renders its own "[Image #N]".
 		const onPaste = (e: ClipboardEvent) => {
 			const dt = e.clipboardData;
 			if (!dt || dt.getData("text/plain")) return; // text → xterm
 			if (dt.files.length === 0) return; // nothing image/file-like
 			e.preventDefault();
 			e.stopPropagation();
-			window.ateam.pty.write(terminalId, "\x16");
-			term.focus();
+			const files = Array.from(dt.files);
+			if (files.every((f) => window.ateam.utils.pathForFile(f))) {
+				typeFilePaths(files); // copied file(s) → real path
+			} else {
+				window.ateam.pty.write(terminalId, "\x16"); // bitmap → bare ⌃V
+				term.focus();
+			}
 		};
 		el.addEventListener("paste", onPaste, true);
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -202,6 +202,7 @@ export const CH = {
 	loopsDelete: "loops:delete",
 	agentsList: "agents:list",
 	utilPickFiles: "util:pickFiles",
+	utilStageImage: "util:stageImage",
 	ptySpawnAgent: "pty:spawnAgent",
 	ptySpawnShell: "pty:spawnShell",
 	ptyWrite: "pty:write",
@@ -316,5 +317,13 @@ export interface AteamApi {
 		pathForFile(file: File): string;
 		/** Native open dialog; resolves to the chosen paths ([] on cancel). */
 		pickFiles(): Promise<string[]>;
+		/**
+		 * Put a real image bitmap on the clipboard so a following Ctrl+V hands the
+		 * agent pixels, not a Finder file-icon. Sources, in order: an image already
+		 * on the clipboard, an image *file* copied in Finder (read off disk), or a
+		 * file the user picks. Resolves true when a bitmap was staged, false if the
+		 * user cancelled or the source wasn't an image.
+		 */
+		stageClipboardImage(): Promise<boolean>;
 	};
 }


### PR DESCRIPTION
- **fix: paste a Finder-copied image file by path, not bare Ctrl+V**
- **feat: "Attach image" in the terminal + menu**
