### PR TITLE
chore: release 0.1.18

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {


### PR DESCRIPTION
Cuts the 0.1.18 release — everything merged after v0.1.17 (#25, #26).

**Features**
- Attach files when creating a task — pick or drag files, shown as removable chips (#25)
- "Attach image" in the terminal + menu — stages a real bitmap on the clipboard (from a clipboard image, a Finder-copied file read off disk, or a picked file) and forwards Ctrl+V so the agent attaches the actual pixels (#26)

**Fixes**
- Paste a Finder-copied image file by path instead of a bare Ctrl+V, so it attaches the real file rather than a generic file-icon placeholder (#26)

**Release tooling**
- Bump desktop app to 0.1.18