### PR TITLE
chore: release 0.1.19

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { basename, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { agentCommand, getAgent, listAgents } from "@ateam/agents";
 import { repo } from "@ateam/db";
 import {
@@ -406,42 +405,29 @@ export function registerIpc(ctx: IpcContext): void {
 		return res.canceled ? [] : res.filePaths;
 	});
 
-	// "+ → Attach image": stage a real bitmap on the clipboard so the renderer's
-	// following Ctrl+V hands the agent pixels, not a path or a file-icon. We must
-	// read an image *file* off disk by its path — clipboard.readImage() on a
-	// Finder file copy returns the file's generic type icon, which is the blank-
-	// placeholder bug. So: prefer a clipboard file URL (read its bytes), then a
-	// genuine clipboard bitmap (a screenshot), then a file the user picks.
+	// "+ → Attach image": open a picker, then stage the chosen image as a real
+	// bitmap on the clipboard so the renderer's following Ctrl+V hands the agent
+	// pixels, not a path or a file-icon.
+	//
+	// Always a picker — deliberately never sourced from the clipboard. Staging
+	// writes the image *to* the clipboard, so reading it back here would skip the
+	// picker on the next attach and re-stage the same image (you could never add a
+	// second, different one). Copied screenshots/images are attached via ⌘V paste,
+	// handled separately in the renderer's paste handler.
 	ipcMain.handle(CH.utilStageImage, async () => {
-		const IMAGE_RE = /\.(png|jpe?g|gif|webp|bmp|tiff?|heic|heif|avif|ico)$/i;
-		const clipFile = clipboard.read("public.file-url").trim();
-		let path: string | null = null;
-		if (clipFile) {
-			try {
-				const p = fileURLToPath(clipFile);
-				if (IMAGE_RE.test(p)) path = p;
-			} catch {
-				/* not a usable file URL */
-			}
-		}
-		// A real bitmap already on the clipboard (e.g. a screenshot) — only trust
-		// it when there's no file URL, since for a file copy this is just the icon.
-		let img = path ? nativeImage.createFromPath(path) : clipboard.readImage();
-		if (img.isEmpty()) {
-			const res = await dialog.showOpenDialog({
-				properties: ["openFile"],
-				title: "Attach image",
-				filters: [
-					{
-						name: "Images",
-						extensions: ["png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "heic", "avif"],
-					},
-				],
-			});
-			const picked = res.canceled ? null : (res.filePaths[0] ?? null);
-			if (!picked) return false;
-			img = nativeImage.createFromPath(picked);
-		}
+		const res = await dialog.showOpenDialog({
+			properties: ["openFile"],
+			title: "Attach image",
+			filters: [
+				{
+					name: "Images",
+					extensions: ["png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "heic", "avif"],
+				},
+			],
+		});
+		const picked = res.canceled ? null : (res.filePaths[0] ?? null);
+		if (!picked) return false;
+		const img = nativeImage.createFromPath(picked);
 		if (img.isEmpty()) return false;
 		clipboard.writeImage(img);
 		return true;

--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -239,10 +239,11 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 		termRef.current?.focus();
 	};
 
-	// "+ → Attach image": main stages a real bitmap on the clipboard (from a
-	// copied image, a Finder-copied file's bytes, or one the user picks), then we
-	// forward a bare Ctrl+V so the agent reads the pixels off the clipboard — the
-	// one path that attaches reliably, regardless of typed-path detection.
+	// "+ → Attach image": main opens a picker and stages the chosen image as a
+	// bitmap on the clipboard, then we forward a bare Ctrl+V so the agent reads the
+	// pixels off the clipboard — the one path that attaches reliably, regardless of
+	// typed-path detection. Each click re-opens the picker, so you can add several
+	// different images one after another.
 	const attachImage = async () => {
 		if (await window.ateam.utils.stageClipboardImage()) {
 			window.ateam.pty.write(terminalId, "\x16");

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -318,11 +318,11 @@ export interface AteamApi {
 		/** Native open dialog; resolves to the chosen paths ([] on cancel). */
 		pickFiles(): Promise<string[]>;
 		/**
-		 * Put a real image bitmap on the clipboard so a following Ctrl+V hands the
-		 * agent pixels, not a Finder file-icon. Sources, in order: an image already
-		 * on the clipboard, an image *file* copied in Finder (read off disk), or a
-		 * file the user picks. Resolves true when a bitmap was staged, false if the
-		 * user cancelled or the source wasn't an image.
+		 * Open an image picker, then put the chosen image on the clipboard as a real
+		 * bitmap so a following Ctrl+V hands the agent pixels, not a Finder file-icon.
+		 * Always a picker (never read from the clipboard, which we just wrote to).
+		 * Resolves true when a bitmap was staged, false if the user cancelled or the
+		 * file wasn't a decodable image.
 		 */
 		stageClipboardImage(): Promise<boolean>;
 	};


### PR DESCRIPTION
Cuts the 0.1.19 release.

**Fixes**
- "+ → Attach image" now always opens the picker. Previously, staging the chosen image onto the clipboard meant the *next* Attach image read that staged image back, skipped the picker, and re-attached the same one — you could never add a second, different image. The action is now picker-only; copied screenshots/images remain attachable via ⌘V paste.

**Release tooling**
- Bump desktop app to 0.1.19