### PR TITLE
chore: release 0.1.20

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -89,6 +89,20 @@ async function computeGitStatus(
 	};
 }
 
+/**
+ * Load an image file and put it on the clipboard as a real bitmap, so a
+ * following Ctrl+V hands the agent pixels — not a path, and not the generic
+ * file-type icon a raw clipboard read of a Finder file copy returns. Returns
+ * false when the path is missing or isn't a decodable image.
+ */
+function stageImageOnClipboard(path: string | null): boolean {
+	if (!path) return false;
+	const img = nativeImage.createFromPath(path);
+	if (img.isEmpty()) return false;
+	clipboard.writeImage(img);
+	return true;
+}
+
 export function registerIpc(ctx: IpcContext): void {
 	const { services, sendTaskUpdated, mergeQueue, loopRunner, sendLoopsUpdated } = ctx;
 	const { db } = services;
@@ -425,13 +439,16 @@ export function registerIpc(ctx: IpcContext): void {
 				},
 			],
 		});
-		const picked = res.canceled ? null : (res.filePaths[0] ?? null);
-		if (!picked) return false;
-		const img = nativeImage.createFromPath(picked);
-		if (img.isEmpty()) return false;
-		clipboard.writeImage(img);
-		return true;
+		return stageImageOnClipboard(res.canceled ? null : (res.filePaths[0] ?? null));
 	});
+
+	// Paste/drop of a copied image *file*: stage its bytes as a real bitmap so the
+	// renderer's following Ctrl+V attaches the pixels. Typing the path only
+	// attaches when the agent runs typed-path detection, and a bare Ctrl+V on a
+	// file copy grabs the file's generic icon — staging the bytes is the reliable
+	// path. Returns false (renderer then falls back to typing the path) if the
+	// file isn't a decodable image.
+	ipcMain.handle(CH.utilStageImagePath, async (_e, path: string) => stageImageOnClipboard(path));
 
 	// ---- agents ----
 	ipcMain.handle(CH.agentsList, async () => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -74,6 +74,7 @@ const api: AteamApi = {
 		pathForFile: (file) => webUtils.getPathForFile(file),
 		pickFiles: () => ipcRenderer.invoke(CH.utilPickFiles),
 		stageClipboardImage: () => ipcRenderer.invoke(CH.utilStageImage),
+		stageImagePath: (path) => ipcRenderer.invoke(CH.utilStageImagePath, path),
 	},
 	events: {
 		onTaskUpdated: (cb: (task: TaskDTO) => void) => {

--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -12,6 +12,9 @@ import { Menu } from "./Menu";
  */
 const escapePath = (p: string) => p.replace(/([ '"\\!$&*()[\]{};<>?#~`|])/g, "\\$1");
 
+/** Paths we attach as a staged bitmap rather than a typed path. */
+const IMAGE_RE = /\.(png|jpe?g|gif|webp|bmp|tiff?|heic|heif|avif|ico)$/i;
+
 /**
  * One xterm.js view bound to a main-process PTY by terminalId. Replays the
  * ring-buffer snapshot on mount (so re-attaching shows recent scrollback),
@@ -68,20 +71,40 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 			}
 		};
 
+		// Bring copied/dropped file(s) into the terminal. A single image file is
+		// attached by staging its real bitmap on the clipboard + Ctrl+V — the only
+		// reliable path: a bare Ctrl+V grabs a Finder file's generic icon, and a
+		// typed path only attaches when the agent runs typed-path detection (else it
+		// just leaves a literal path). Anything else (non-image, or multiple files)
+		// types the escaped path(s); so does an image we couldn't decode.
+		const attachFiles = (files: File[]) => {
+			const paths = files.map((f) => window.ateam.utils.pathForFile(f)).filter(Boolean);
+			const [only] = paths;
+			if (paths.length === 1 && only && IMAGE_RE.test(only)) {
+				void window.ateam.utils.stageImagePath(only).then((staged) => {
+					if (staged) {
+						window.ateam.pty.write(terminalId, "\x16");
+						term.focus();
+					} else {
+						typeFilePaths(files);
+					}
+				});
+				return;
+			}
+			typeFilePaths(files);
+		};
+
 		// Pasting an image. The menu's Paste role fires a DOM `paste` event with a
 		// populated clipboardData (the renderer never sees ⌘V's keydown — the menu
 		// owns that accelerator), intercepted here in capture phase before xterm's
 		// own textarea handler. We classify straight off the event — no IPC.
 		//
-		// Plain text pastes normally. A non-text payload splits two ways, and the
-		// split matters: a native ⌃V read of a Finder-copied file yields only its
-		// generic file-type icon, not the bytes, so the two cannot be collapsed.
-		//   - a copied file (Finder) has a real path → type it, exactly like a
-		//     drop, so Claude Code's "path → [Image #N]" detection attaches the
-		//     actual file.
+		// Plain text pastes normally. A non-text payload splits two ways:
+		//   - a copied file (Finder) has a real path → attachFiles (a single image
+		//     is staged as a bitmap + Ctrl+V; other files type their path).
 		//   - a raw bitmap (screenshot) has no path → forward a bare Ctrl+V and let
 		//     the agent read the bitmap off the clipboard itself, like a raw
-		//     terminal — no temp file. The agent renders its own "[Image #N]".
+		//     terminal. The agent renders its own "[Image #N]".
 		const onPaste = (e: ClipboardEvent) => {
 			const dt = e.clipboardData;
 			if (!dt || dt.getData("text/plain")) return; // text → xterm
@@ -90,7 +113,7 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 			e.stopPropagation();
 			const files = Array.from(dt.files);
 			if (files.every((f) => window.ateam.utils.pathForFile(f))) {
-				typeFilePaths(files); // copied file(s) → real path
+				attachFiles(files); // copied file(s) on disk
 			} else {
 				window.ateam.pty.write(terminalId, "\x16"); // bitmap → bare ⌃V
 				term.focus();
@@ -98,11 +121,11 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 		};
 		el.addEventListener("paste", onPaste, true);
 
-		// Dropping files types their paths, same as above.
+		// Dropping files behaves like pasting copied files.
 		const onDragOver = (e: DragEvent) => e.preventDefault();
 		const onDrop = (e: DragEvent) => {
 			e.preventDefault();
-			typeFilePaths(Array.from(e.dataTransfer?.files ?? []));
+			attachFiles(Array.from(e.dataTransfer?.files ?? []));
 		};
 		el.addEventListener("dragover", onDragOver);
 		el.addEventListener("drop", onDrop);

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -203,6 +203,7 @@ export const CH = {
 	agentsList: "agents:list",
 	utilPickFiles: "util:pickFiles",
 	utilStageImage: "util:stageImage",
+	utilStageImagePath: "util:stageImagePath",
 	ptySpawnAgent: "pty:spawnAgent",
 	ptySpawnShell: "pty:spawnShell",
 	ptyWrite: "pty:write",
@@ -325,5 +326,12 @@ export interface AteamApi {
 		 * file wasn't a decodable image.
 		 */
 		stageClipboardImage(): Promise<boolean>;
+		/**
+		 * Put the image at `path` on the clipboard as a real bitmap (for a following
+		 * Ctrl+V), used when a copied/dropped image *file* is brought into a terminal.
+		 * Resolves false if the file isn't a decodable image, so the caller can fall
+		 * back to typing the path.
+		 */
+		stageImagePath(path: string): Promise<boolean>;
 	};
 }


### PR DESCRIPTION
Cuts the 0.1.20 release.

**Fixes**
- Pasting or dropping an image file copied from Finder now **attaches the image** instead of leaving its literal path in the prompt. A single copied/dropped image file is staged as a real bitmap on the clipboard and attached via Ctrl+V (the same reliable mechanism as `+ → Attach image`); non-image files, multiple files, or an undecodable image still type their path. Screenshots still paste via bare Ctrl+V.

**Release tooling**
- Bump desktop app to 0.1.20