### PR TITLE
chore: release 0.1.22

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -105,6 +105,11 @@ input {
 	border-right: 1px solid var(--border);
 	display: flex;
 	flex-direction: column;
+	/* Bounded by the .app grid row above; scroll the project/task lists rather
+	   than overflow off-screen (the collapsed .sidebar.rail already does this). */
+	min-height: 0;
+	overflow-y: auto;
+	overflow-x: hidden;
 }
 /* Slim header row sharing the traffic-light strip: the collapse toggle lives
    here (like Arc/Linear), and the accordions start right below — no dead gap. */

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -89,6 +89,11 @@ input {
 .app {
 	display: grid;
 	grid-template-columns: 240px 1fr;
+	/* A definite single row (not the implicit `auto`, which grows to its tallest
+	   child) so a long board column or a tall Mission Control grid stays bounded
+	   to the viewport — letting .content/.board/.mc scroll instead of overflowing
+	   #root's `overflow: hidden` and being clipped off-screen with no scrollbar. */
+	grid-template-rows: minmax(0, 1fr);
 	height: 100%;
 }
 .app.rail {


### PR DESCRIPTION
Cuts the 0.1.22 release.

**Fixes**
- Scroll long lists instead of clipping them off-screen. The `.app` grid had no `grid-template-rows`, so its implicit `auto` row grew to its tallest child and overflowed `#root`'s `overflow: hidden` with no scrollbar. Pin a definite `minmax(0, 1fr)` row so everything stays bounded to the viewport, and give the expanded sidebar its own `overflow-y: auto` (only the collapsed rail had it). Fixes the sidebar task/project lists, the board columns, and Mission Control not scrolling when they get long.

**Release tooling**
- Bump desktop app to 0.1.22