### PR TITLE
chore: release 0.1.23

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -527,7 +527,7 @@ export function App() {
 				<div className="topbar">
 					<div className="tabs">
 						<div
-							className={`tab ${view === "board" ? "active" : ""}`}
+							className={`tab ${view === "board" && !(selectedTask && panelMode === "full") ? "active" : ""}`}
 							onClick={() => {
 								// A full-width task hides the board — clicking "Board" while
 								// one is open means "show me the board", so deselect it.

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -374,11 +374,17 @@ input {
 	flex: 0 0 100%;
 	min-width: 760px;
 	display: grid;
-	grid-template-columns: repeat(5, 1fr);
+	/* minmax(0, 1fr), not 1fr (= minmax(auto, 1fr)): a card with a long name or
+	   branch would otherwise widen its column past its share, so columns ended up
+	   unequal. The 0 min keeps all five exactly equal; card text truncates. */
+	grid-template-columns: repeat(5, minmax(0, 1fr));
 	gap: 10px;
 	padding: 14px;
 	overflow-y: auto;
 	align-content: start;
+}
+.col {
+	min-width: 0;
 }
 .col h3 {
 	font-size: 11px;
@@ -415,11 +421,17 @@ input {
 	font-size: 13px;
 	font-weight: 500;
 	margin-bottom: 4px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 .card .branch {
 	font-size: 11px;
 	color: var(--text-dim);
 	font-family: ui-monospace, Menlo, monospace;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 .card .meta {
 	display: flex;


### PR DESCRIPTION
Cuts the 0.1.23 release.

**Fixes**
- Board columns are now equal width. They used `repeat(5, 1fr)` (= `minmax(auto, 1fr)`), so a card with a long name or branch widened its column past its share. Switched to `minmax(0, 1fr)` and truncate the card name/branch so all five columns match.
- The **Board** tab no longer stays highlighted when you're in a full-width task/terminal (which hides the board). It's only marked active when the board is actually showing.

**Release tooling**
- Bump desktop app to 0.1.23