### PR TITLE
feat: use auto permission mode for Claude bolt/YOLO launch

### DIFF
--- a/packages/agents/src/registry.ts
+++ b/packages/agents/src/registry.ts
@@ -41,7 +41,7 @@ export const AGENTS = [
 			"Anthropic's coding agent for reading code, editing files, and running terminal workflows.",
 		bin: "claude",
 		command: "claude",
-		yoloFlag: "--dangerously-skip-permissions",
+		yoloFlag: "--permission-mode auto",
 		resumeCommand: "claude --continue",
 	},
 	{


### PR DESCRIPTION
Swap Claude's YOLO flag from --dangerously-skip-permissions to
--permission-mode auto so the bolt icon launches Claude in its native
auto mode instead of full permission bypass.
