### PR TITLE
feat(loops): agent-driven board loops — MCP board tools, triage done-detection, Done button

### DIFF
--- a/apps/desktop/src/main/agent-setup/index.ts
+++ b/apps/desktop/src/main/agent-setup/index.ts
@@ -210,6 +210,38 @@ export async function ensureCodexHooks(
 	await writeFile(file, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
 }
 
+/**
+ * Write a per-session MCP config pointing Claude at Ateam's board tools (served
+ * on the hook server's `/mcp` endpoint). The session's terminal id rides along
+ * as a header so `set_status` can tell a self-move (a session moving its OWN
+ * card) from an organizer move. Pass an empty `terminalId` for the board-level
+ * organizer, which is bound to no single task. Returns the file path to hand to
+ * `claude --mcp-config`.
+ */
+export async function ensureBoardMcpConfig(opts: {
+	hooksDir: string;
+	hookPort: number;
+	terminalId: string;
+}): Promise<string> {
+	const dir = join(opts.hooksDir, "mcp");
+	await mkdir(dir, { recursive: true });
+	const file = join(dir, `board-${opts.terminalId || "organizer"}.json`);
+	const config = {
+		mcpServers: {
+			ateam_board: {
+				type: "http",
+				url: `http://127.0.0.1:${opts.hookPort}/mcp`,
+				headers: { "x-ateam-terminal-id": opts.terminalId },
+			},
+		},
+	};
+	await writeFile(file, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+	return file;
+}
+
+/** The board tools, named for `claude --allowedTools`. */
+export const BOARD_MCP_TOOLS = ["mcp__ateam_board__get_board", "mcp__ateam_board__set_status"];
+
 /** Build the PTY environment for an agent session, injecting hook correlation. */
 export function buildAgentEnv(opts: {
 	terminalId: string;

--- a/apps/desktop/src/main/hooks/board-mcp.ts
+++ b/apps/desktop/src/main/hooks/board-mcp.ts
@@ -1,0 +1,155 @@
+/**
+ * Minimal MCP server for the Board Organizer's tools, spoken over the existing
+ * hook HTTP server (Streamable HTTP transport). We reuse the running localhost
+ * server rather than spawning a stdio subprocess or pulling in the MCP SDK: the
+ * spec lets a server answer a JSON-RPC *request* with a plain `application/json`
+ * body (no SSE) and answer GET with 405, which is exactly the request/response
+ * shape these two tools need.
+ *
+ * This module is the pure protocol dispatcher — hook-server.ts owns the HTTP
+ * plumbing (Origin check, body read, status codes) and hands each parsed
+ * message here. Testable with a fake `BoardHandlers`; no HTTP, no I/O.
+ */
+
+/**
+ * Request/response handlers for the board tools, injected by the main process
+ * (which owns the db). Defined here (not in hook-server) so both the plain
+ * `/board/*` debug endpoints and this MCP endpoint share one type without a
+ * circular import.
+ */
+export interface BoardHandlers {
+	get(): Promise<unknown>;
+	setStatus(req: {
+		taskId: string;
+		to: string;
+		reason?: string;
+		/** The calling session's terminal id (a self-move), when known. */
+		callerTerminalId?: string;
+	}): Promise<{ ok: boolean; reason: string }>;
+}
+
+/** Per-request context the HTTP layer derives (e.g. the caller's terminal id). */
+export interface McpContext {
+	callerTerminalId?: string;
+}
+
+const DEFAULT_PROTOCOL_VERSION = "2025-06-18";
+const SERVER_INFO = { name: "ateam_board", version: "0.1.0" };
+
+/** The two tools. `to` is constrained to the assignable columns to steer the
+ *  model; the guardrail (validateSetStatus) still enforces it server-side. */
+const TOOLS = [
+	{
+		name: "get_board",
+		description:
+			"List every in-play task (excludes merged) with its board column and a triage verdict — whether it looks done or still ongoing, and why. Read this before moving anything.",
+		inputSchema: { type: "object", properties: {}, additionalProperties: false },
+	},
+	{
+		name: "set_status",
+		description:
+			"Move one task to a new board column. Only 'todo' and 'review' are settable — 'running', 'needs_attention', and 'merged' are set by real events/hooks and will be refused. The organizer cannot move a card with a live agent; a task's own session can move its own card. Always give a short reason (audited).",
+		inputSchema: {
+			type: "object",
+			properties: {
+				taskId: { type: "string", description: "The task's id (from get_board)." },
+				to: {
+					type: "string",
+					enum: ["todo", "review"],
+					description: "Target column.",
+				},
+				reason: { type: "string", description: "Why this move — recorded in the audit trail." },
+			},
+			required: ["taskId", "to"],
+			additionalProperties: false,
+		},
+	},
+];
+
+/** What the HTTP layer should send back. `accepted` → 202 no body (notifications). */
+export type McpReply = { kind: "accepted" } | { kind: "json"; body: unknown };
+
+interface JsonRpcMessage {
+	jsonrpc?: string;
+	id?: string | number | null;
+	method?: string;
+	params?: Record<string, unknown>;
+}
+
+const ok = (id: JsonRpcMessage["id"], result: unknown): McpReply => ({
+	kind: "json",
+	body: { jsonrpc: "2.0", id, result },
+});
+const err = (id: JsonRpcMessage["id"], code: number, message: string): McpReply => ({
+	kind: "json",
+	body: { jsonrpc: "2.0", id, error: { code, message } },
+});
+const textContent = (text: string, isError = false) => ({
+	content: [{ type: "text", text }],
+	isError,
+});
+
+/** Dispatch one parsed JSON-RPC message against the board handlers. */
+export async function dispatchMcp(
+	msg: JsonRpcMessage,
+	board: BoardHandlers,
+	ctx: McpContext = {},
+): Promise<McpReply> {
+	const { method, id } = msg;
+
+	// Notifications (no id) — acknowledge with 202, never a JSON-RPC reply.
+	if (id == null && method?.startsWith("notifications/")) return { kind: "accepted" };
+
+	switch (method) {
+		case "initialize": {
+			const clientVersion = (msg.params?.protocolVersion as string) ?? DEFAULT_PROTOCOL_VERSION;
+			return ok(id, {
+				protocolVersion: clientVersion,
+				capabilities: { tools: { listChanged: false } },
+				serverInfo: SERVER_INFO,
+			});
+		}
+		case "ping":
+			return ok(id, {});
+		case "tools/list":
+			return ok(id, { tools: TOOLS });
+		case "tools/call":
+			return callTool(msg, board, ctx);
+		default:
+			return err(id, -32601, `method not found: ${method}`);
+	}
+}
+
+async function callTool(
+	msg: JsonRpcMessage,
+	board: BoardHandlers,
+	ctx: McpContext,
+): Promise<McpReply> {
+	const { id } = msg;
+	const name = msg.params?.name as string | undefined;
+	const args = (msg.params?.arguments as Record<string, unknown>) ?? {};
+	try {
+		if (name === "get_board") {
+			const view = await board.get();
+			return ok(id, textContent(JSON.stringify(view, null, 2)));
+		}
+		if (name === "set_status") {
+			const taskId = String(args.taskId ?? "");
+			const to = String(args.to ?? "");
+			const reason = args.reason != null ? String(args.reason) : undefined;
+			if (!taskId || !to) {
+				return ok(id, textContent("taskId and to are required", true));
+			}
+			const res = await board.setStatus({
+				taskId,
+				to,
+				reason,
+				callerTerminalId: ctx.callerTerminalId,
+			});
+			return ok(id, textContent(res.reason, !res.ok));
+		}
+		return err(id, -32602, `unknown tool: ${name}`);
+	} catch (e) {
+		return ok(id, textContent(`tool failed: ${e instanceof Error ? e.message : String(e)}`, true));
+	}
+}

--- a/apps/desktop/src/main/hooks/hook-server.ts
+++ b/apps/desktop/src/main/hooks/hook-server.ts
@@ -1,5 +1,8 @@
 import { EventEmitter } from "node:events";
 import http from "node:http";
+import { type BoardHandlers, dispatchMcp } from "./board-mcp";
+
+export type { BoardHandlers };
 
 export interface HookEvent {
 	terminalId: string;
@@ -13,6 +16,9 @@ export interface MergeRequestEvent {
 	strategy?: string;
 }
 
+/** Only localhost origins may reach the MCP endpoint (DNS-rebinding guard). */
+const LOCAL_ORIGIN = /^https?:\/\/(127\.0\.0\.1|localhost)(:\d+)?$/;
+
 /**
  * Tiny localhost HTTP server that agent hooks ping to report lifecycle events.
  * GET /hook/complete?terminalId=&eventType=&sessionId= → emits "hook".
@@ -21,12 +27,101 @@ export interface MergeRequestEvent {
  */
 export class HookServer extends EventEmitter {
 	private server?: http.Server;
+	private board?: BoardHandlers;
 	port = 0;
+
+	/** Wire the Board Organizer's request/response tool handlers. */
+	setBoardHandlers(handlers: BoardHandlers): void {
+		this.board = handlers;
+	}
 
 	async start(preferred?: number): Promise<number> {
 		this.server = http.createServer((req, res) => {
+			const json = (status: number, body: unknown) => {
+				res.writeHead(status, { "content-type": "application/json" });
+				res.end(JSON.stringify(body));
+			};
 			try {
 				const url = new URL(req.url ?? "/", "http://127.0.0.1");
+
+				// MCP endpoint (Streamable HTTP). Both the organizer loop and a
+				// task's own session reach the board tools here; the caller's
+				// terminal id (header) is what distinguishes a self-move.
+				if (url.pathname === "/mcp") {
+					if (req.method !== "POST") {
+						res.writeHead(405);
+						res.end();
+						return;
+					}
+					const origin = req.headers.origin;
+					if (origin && !LOCAL_ORIGIN.test(origin)) {
+						res.writeHead(403);
+						res.end();
+						return;
+					}
+					if (!this.board) return json(503, { error: "board handlers not ready" });
+					const board = this.board;
+					const callerTerminalId =
+						(req.headers["x-ateam-terminal-id"] as string | undefined) || undefined;
+					let body = "";
+					req.on("data", (c) => {
+						body += c;
+						if (body.length > 1_000_000) req.destroy();
+					});
+					req.on("end", () => {
+						let msg: unknown;
+						try {
+							msg = JSON.parse(body);
+						} catch {
+							return json(400, {
+								jsonrpc: "2.0",
+								id: null,
+								error: { code: -32700, message: "parse error" },
+							});
+						}
+						dispatchMcp(msg as Parameters<typeof dispatchMcp>[0], board, { callerTerminalId })
+							.then((reply) => {
+								if (reply.kind === "accepted") {
+									res.writeHead(202);
+									res.end();
+								} else {
+									json(200, reply.body);
+								}
+							})
+							.catch((e) =>
+								json(500, {
+									jsonrpc: "2.0",
+									id: null,
+									error: { code: -32603, message: String(e) },
+								}),
+							);
+					});
+					return;
+				}
+
+				// Board tools as plain GET (debug / non-MCP clients). The MCP
+				// endpoint above is the path agents actually use.
+				if (req.method === "GET" && url.pathname === "/board/get") {
+					if (!this.board) return json(503, { error: "board handlers not ready" });
+					this.board
+						.get()
+						.then((view) => json(200, view))
+						.catch((e) => json(500, { error: String(e) }));
+					return;
+				}
+				if (req.method === "GET" && url.pathname === "/board/set-status") {
+					const taskId = url.searchParams.get("taskId") ?? "";
+					const to = url.searchParams.get("to") ?? "";
+					const reason = url.searchParams.get("reason") ?? undefined;
+					const callerTerminalId = url.searchParams.get("terminalId") ?? undefined;
+					if (!this.board) return json(503, { error: "board handlers not ready" });
+					if (!taskId || !to) return json(400, { ok: false, reason: "taskId and to required" });
+					this.board
+						.setStatus({ taskId, to, reason, callerTerminalId })
+						.then((r) => json(200, r))
+						.catch((e) => json(500, { ok: false, reason: String(e) }));
+					return;
+				}
 				if (req.method === "GET" && url.pathname === "/hook/complete") {
 					const terminalId = url.searchParams.get("terminalId") ?? "";
 					const eventType = url.searchParams.get("eventType") ?? "";

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -11,6 +11,7 @@ import { APP_NAME } from "./app-name";
 import { type HookEvent, HookServer, type MergeRequestEvent } from "./hooks/hook-server";
 import { registerIpc } from "./ipc";
 import { createBoardReconciler } from "./loops/board-reconciler";
+import { applySetStatus, buildBoardView } from "./loops/board-signals";
 import { LoopRunner } from "./loops/runner";
 import { MergeQueue } from "./merge-queue";
 import { PtyClient } from "./pty/pty-client";
@@ -318,6 +319,13 @@ async function initServices(): Promise<Services> {
 		mergeQueue,
 	});
 	loopRunner.register(createBoardReconciler());
+
+	// Board Organizer tools: the organizer loop's headless `claude -p` turn reads
+	// the board and proposes moves through these, guarded by validateSetStatus.
+	hooks.setBoardHandlers({
+		get: () => buildBoardView(db),
+		setStatus: async (req) => applySetStatus(db, req, sendTaskUpdated),
+	});
 
 	const svc: Services = {
 		db,

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -190,6 +190,9 @@ export function registerIpc(ctx: IpcContext): void {
 
 	ipcMain.handle(CH.tasksSetColumn, async (_e, id: string, column: KanbanColumn) => {
 		const row = repo.updateTask(db, id, { column });
+		// Broadcast so every view (board, sidebar) reflects the move — e.g. the
+		// "Done" button under the terminal that sends a review task to merged.
+		sendTaskUpdated(id);
 		return toTaskDTO(row!);
 	});
 

--- a/apps/desktop/src/main/loops/agent-loop.ts
+++ b/apps/desktop/src/main/loops/agent-loop.ts
@@ -1,0 +1,151 @@
+/**
+ * Agent-driven prompt loops — the "keep the agent going until done" primitive,
+ * distinct from the reconciler loops in this directory (board-reconciler etc.).
+ *
+ * A reconciler loop is an app-side timer that does deterministic bookkeeping and
+ * NEVER touches the agent. An agent loop is the opposite: it re-drives the agent
+ * itself on its own rhythm — the `/loop` analogue — so a task keeps iterating
+ * (test-fix, TODO burndown, "keep going until X") without a human retyping
+ * "continue".
+ *
+ * We deliberately do NOT re-invent a scheduler for this: every agent already
+ * exposes a native seam for it, and the binding differs per agent (see
+ * agent-loops.design.md). What they SHARE is the decision this module owns:
+ * given a loop's config and how many turns it has taken, should the agent take
+ * another turn, and with what prompt? Keeping that one decision pure and
+ * agent-agnostic is what lets the Codex `Stop`-hook, the OpenCode `session.idle`
+ * plugin, and the Claude native `/loop` all be thin bindings over the same brain.
+ *
+ * Pure module: no db, no electron, no I/O. Unit-tested in
+ * apps/desktop/test/agent-loop.test.ts.
+ */
+
+/**
+ * A hard cap on turns is MANDATORY, not optional. None of the three agents
+ * guarantees loop termination for us — Codex's own docs note "infinite loops
+ * would have to be prevented by your own logic", Claude's `/loop` expires only
+ * after 7 days, and OpenCode has no native stop at all. The cap is the backstop
+ * that makes an agent loop safe to hand to any of them.
+ */
+export const DEFAULT_MAX_ITERATIONS = 25;
+
+/** An absolute ceiling a user-supplied cap is clamped to — defense in depth. */
+export const HARD_MAX_ITERATIONS = 1000;
+
+/**
+ * What a user configures when they attach a loop to a task. Persisted (as the
+ * `config` JSON on the loop row) and reused by every binding: the two
+ * hook-driven bindings feed it to `decideContinuation` each turn; the Claude
+ * binding uses it to compose the native `/loop` command it launches.
+ */
+export interface AgentLoopConfig {
+	/** The instruction re-sent to the agent at the start of each new turn. */
+	prompt: string;
+	/**
+	 * Safety backstop: stop after this many turns no matter what. Clamped to
+	 * `[1, HARD_MAX_ITERATIONS]`; omitted → DEFAULT_MAX_ITERATIONS.
+	 */
+	maxIterations?: number;
+	/**
+	 * Optional goal sentinel. If set, the loop ends the moment the agent's last
+	 * turn output contains this exact string — the agent declares itself done by
+	 * printing it (e.g. instruct it to emit `LOOP_DONE` when the task is
+	 * complete). Without it, the loop runs until the iteration cap.
+	 */
+	stopSignal?: string;
+}
+
+/** Mutable per-loop runtime, tracked alongside the config. */
+export interface AgentLoopState {
+	/** Turns the agent has already taken for this loop (0 on first decision). */
+	iterations: number;
+}
+
+/** The verdict for one turn boundary. */
+export type LoopDecision =
+	| { continue: true; prompt: string; reason: string }
+	| { continue: false; reason: string };
+
+/** Why a loop stopped — useful for the Loops panel summary and telemetry. */
+export type StopReason = "goal_reached" | "max_iterations" | "empty_prompt";
+
+/** Clamp a configured cap into the safe range. */
+export function resolveMaxIterations(config: AgentLoopConfig): number {
+	const raw = config.maxIterations ?? DEFAULT_MAX_ITERATIONS;
+	if (!Number.isFinite(raw)) return DEFAULT_MAX_ITERATIONS;
+	return Math.max(1, Math.min(HARD_MAX_ITERATIONS, Math.floor(raw)));
+}
+
+/**
+ * The shared brain. Called at a turn boundary (the agent just finished a turn):
+ * decide whether it should take another, and if so with what prompt.
+ *
+ * Order matters — safety and completion are checked BEFORE continuation:
+ *   1. A blank prompt can never drive a useful turn → stop.
+ *   2. Iteration cap reached → stop (the backstop; see DEFAULT_MAX_ITERATIONS).
+ *   3. Goal sentinel present in the last output → stop (agent declared done).
+ *   4. Otherwise → continue with the configured prompt.
+ *
+ * `lastOutput` is the text the agent produced on the turn that just ended, used
+ * only for the goal check. Bindings that can't cheaply capture it (or loops with
+ * no `stopSignal`) pass undefined; the cap still bounds the loop.
+ */
+export function decideContinuation(
+	config: AgentLoopConfig,
+	state: AgentLoopState,
+	lastOutput?: string,
+): LoopDecision {
+	const prompt = config.prompt?.trim() ?? "";
+	if (!prompt) {
+		return { continue: false, reason: stopReasonMessage("empty_prompt") };
+	}
+
+	const max = resolveMaxIterations(config);
+	if (state.iterations >= max) {
+		return { continue: false, reason: stopReasonMessage("max_iterations", max) };
+	}
+
+	if (config.stopSignal && lastOutput?.includes(config.stopSignal)) {
+		return {
+			continue: false,
+			reason: stopReasonMessage("goal_reached", undefined, config.stopSignal),
+		};
+	}
+
+	return {
+		continue: true,
+		prompt,
+		reason: `turn ${state.iterations + 1}/${max}`,
+	};
+}
+
+/**
+ * Compose the natural-language loop instruction from a config — the body a
+ * self-pacing binding hands to the agent (Claude's `/loop` prepends its own
+ * `/loop ` verb; a plain-prompt fallback uses this as-is). Bakes the two
+ * termination conditions the shared brain enforces into words the agent can act
+ * on itself: the turn cap (always) and the stop signal (when configured). This
+ * is the Claude counterpart to `decideContinuation` — for `/loop` the agent owns
+ * the per-turn decision, so the config has to travel as instruction, not code.
+ */
+export function composeLoopInstruction(config: AgentLoopConfig): string {
+	const prompt = config.prompt?.trim() ?? "";
+	const max = resolveMaxIterations(config);
+	const parts = [prompt, `Keep going until the task is complete, then stop.`];
+	if (config.stopSignal) {
+		parts.push(`When it is complete, output exactly "${config.stopSignal}" and stop.`);
+	}
+	parts.push(`Do not run more than ${max} turns; stop and report if you reach that limit.`);
+	return parts.filter(Boolean).join(" ");
+}
+
+function stopReasonMessage(reason: StopReason, max?: number, signal?: string): string {
+	switch (reason) {
+		case "goal_reached":
+			return `loop finished — agent emitted its stop signal${signal ? ` (${signal})` : ""}`;
+		case "max_iterations":
+			return `loop finished — reached the ${max}-turn cap`;
+		case "empty_prompt":
+			return "loop stopped — no prompt configured";
+	}
+}

--- a/apps/desktop/src/main/loops/agent-loops.design.md
+++ b/apps/desktop/src/main/loops/agent-loops.design.md
@@ -1,0 +1,205 @@
+# Agent-driven loops — design
+
+Status: **foundation landed** (`agent-loop.ts` + tests). Bindings pending.
+Grounded against primary-source docs 2026-07-03 (links inline).
+
+## Two different things are both called "loops" — keep them apart
+
+| | Reconciler loop (shipped, v1) | Agent loop (this design) |
+|---|---|---|
+| What runs | an app-side timer | the **agent itself**, another turn |
+| Touches the agent? | never | that's the whole point |
+| Examples | board-reconciler, auto-merge-when-green, pr-ci-watcher | "keep fixing tests until green", TODO burndown |
+| Owns | `LoopRunner` + `loops` table | this doc |
+
+The v1 `LoopRunner` stays exactly as-is for reconcilers. Agent loops are **not**
+a second scheduler — see below.
+
+## Why we do NOT build a scheduler for agent loops
+
+The deferred-v1 note said agent loops "need headless exec because the registry
+is interactive-PTY only." That was the wrong turn. Every agent we target already
+exposes a **native** way to keep going after a turn — building an external clock
+that re-injects prompts into the TUI reinvents a primitive the host already
+owns (and the one PTY-injection path we considered is undocumented and fragile
+on all three). So the rule is: **delegate execution to each agent's native seam;
+share only the decision.**
+
+## The one thing that IS shared: the decision (`agent-loop.ts`)
+
+`decideContinuation(config, state, lastOutput?)` — pure, agent-agnostic:
+
+- stop if the prompt is blank,
+- **stop at the iteration cap** (mandatory backstop — no agent guarantees
+  termination for us; see notes below),
+- stop if the goal sentinel appears in the last turn's output,
+- else continue, re-sending the configured prompt.
+
+`AgentLoopConfig { prompt, maxIterations?, stopSignal? }` is persisted as the
+loop row's `config` JSON and reused by every binding.
+
+## The provider matrix — one concept, three native bindings
+
+There is **no single native mechanism common to all three agents**, which is
+exactly what justifies a thin per-agent adapter (the greybeard-`install.js` /
+`agent-setup` pattern) and nothing more.
+
+| Agent | Native seam | Ateam already has | Binding |
+|---|---|---|---|
+| **Claude Code** | native `/loop` skill (self-paced; carries into backgrounded sessions) — [docs](https://code.claude.com/docs/en/scheduled-tasks.md) | launch args / PTY | Launch the session with `/loop <prompt>`. Cadence + self-pacing live in the agent; Ateam holds the record + a hard cap. The Stop-hook "continue" is **undocumented** for Claude, so we use the native command, not a hook. |
+| **Codex** | `Stop` hook returns `{"decision":"block","reason":"…"}` to keep going — [docs](https://developers.openai.com/codex/hooks) (its in-session `/loop`/cron is only [proposed #25466](https://github.com/openai/codex/issues/25466), **not shipped**) | writes `.codex/hooks.json` + runs the hook server | On `Stop`, a hook script GETs `/loop/decide` → server runs `decideContinuation` → returns `block`+prompt to continue, or allows the stop. **Zero PTY injection.** Lowest-effort native win. |
+| **OpenCode** | `session.idle` plugin event + plugin API to inject a prompt (no native loop/cron at all) — [docs](https://opencode.ai/docs/plugins/); community proof: [opencode-loop](https://github.com/ByBrawe/opencode-loop) | plugin registration | A small plugin: on `session.idle`, call `/loop/decide`; if continue, inject the prompt. Same shared decision. |
+
+The "brain" (continue? next prompt?) is one shared function; only the *binding*
+differs — and for Codex/OpenCode the binding is a hook/plugin file Ateam already
+knows how to write, so the cross-agent layer is cheap.
+
+## Termination is mandatory (why the cap is not optional)
+
+None of the three stops the loop for us:
+- Codex docs: *"infinite loops would have to be prevented by your own logic."*
+- Claude `/loop`: tasks expire only after **7 days**.
+- OpenCode: no native stop.
+
+So `decideContinuation` enforces an iteration cap **before** anything else, and
+it's clamped to `HARD_MAX_ITERATIONS`. A user can also give a `stopSignal` for
+early, goal-based exit — but the cap is the floor of safety.
+
+## First loop (CHOSEN): the Board Organizer — Claude, write-capable
+
+Decision (user, 2026-07-03): the first loop is a **dedicated Claude `/loop` that
+reads AND mutates the board** through an Ateam board tool ("agent full
+organizer"). Chosen over a deterministic reconciler because done-vs-ongoing
+needs *judgment/context the reconciler misses* — see below. Accepted risk: an
+LLM moving cards can misfile, so it runs behind two hard rails.
+
+Architecture (mirrors the existing notify.sh / gh-shim pattern — agents talk to
+the app over the localhost hook server; a thin MCP server wraps that as tools):
+
+```
+Claude /loop (organizer session)
+   │  get_board  → hook-server /board/get     → rich per-task signals
+   │  set_status → hook-server /board/set-status
+   ▼
+[MCP stdio server]  ── registered via agent-setup (like .claude hooks) ──┐
+   │                                                                     │
+   ▼                                                                     ▼
+validateSetStatus (board-organizer.ts)  ◄── guardrail       triageWorktree (worktree-triage.ts)
+   • never assign running/merged (ground truth)                • done-detection the agent reasons with
+   • never move a card out of them                             • fed into get_board so the LLM sees context
+   • never touch a live-agent card                             • NOT a merged-PR check
+   • every move → audit BoardChange
+```
+
+### Done-detection — why the reconciler was wrong (`worktree-triage.ts` ✅)
+
+The reconciler called tasks done from one thin signal (merged PR). The
+`triage-worktrees` / `cleanup-worktrees` skills (pallaoro/dotfiles) encode the
+real logic, now ported and tested here. `done` is true **only** when a PR is
+genuinely merged/patch-equivalent AND the session wrapped up; every ongoing
+signal is checked first and wins:
+
+- recent activity (freshest of index/transcript/creation mtime) → in-flight;
+- merged but transcript touched ≥ 4 min after `mergedAt` → conversation
+  continued, not done;
+- dirty / commits-ahead / open-PR → ongoing;
+- patch-equivalence (`git cherry`) so squash/rebase merges aren't missed;
+- no work yet ≠ done.
+
+Callers gather signals (git/gh/stat/transcript mtime) and feed them to
+`triageWorktree`; it stays pure. This is what `/board/get` surfaces so the
+organizer LLM inherits the same context.
+
+### Safety rail (`board-organizer.ts` ✅)
+
+`validateSetStatus` gates every agent-proposed move: `running`/`merged` are
+ground-truth (real events only), live-agent cards are untouchable, and each
+approved move yields a `BoardChange` for an audit log. The agent proposes; this
+disposes.
+
+## Status detection — learn from `claude agents` (research 2026-07-03)
+
+Claude Code does NOT infer agent status from lifecycle hooks (which is what
+Ateam does, and why cards get stuck). Its supervisor maintains status by polling
+`pid` + reading `~/.claude/jobs/<id>/state.json`, exposed via `claude agents
+--json` with states `working | blocked | done | failed | stopped` and a
+`waitingFor` field (`permission prompt` | `input needed`).
+
+Lesson for Ateam: **poll `claude agents --json` / state.json as ground truth**
+instead of relying on hooks alone. `waitingFor` distinguishes permission-block
+from input-needed directly (no PreToolUse/Notification guessing), and the
+polled state catches transitions hooks miss between fires — the exact failure
+the board reconciler exists to patch. Fold this into `/board/get` and the
+reconciler's liveness check.
+[docs: agent-view.md, cli-reference.md `--json`]
+
+## Column ownership (refined 2026-07-03)
+
+- ASSIGNABLE (a tool caller may set): `todo`, `review`.
+- PROGRAMMATIC (real events / hooks only, never a tool target): `running`
+  (launch), `needs_attention` (**"requires input" is set programmatically by the
+  input hooks, not judgment**), `merged` (real merge). "Done" is the display
+  label for `merged`.
+
+## Two tool callers (refined 2026-07-03)
+
+The MCP tools are not organizer-only — a task's OWN session can move its OWN
+card too (`if we have an mcp … the session itself could move the task status`):
+
+- **Organizer** (external): re-triages among assignable columns; never touches a
+  live-agent card or a programmatic column.
+- **Self** (`bySelf`): the session bound to the card moves its own card (e.g.
+  "I'm done" → `review`), allowed even while live; can't un-`merged`; can only
+  move ITS OWN task. Identified by the caller's terminal id (an `x-ateam-
+  terminal-id` header on the MCP request), audited as `source=session`.
+
+Manual **Done button** (user authority, bypasses the guardrail): a review task's
+terminal toolbar shows Done → `tasks.setColumn(id, "merged")` (emits an update).
+
+## Build order
+
+1. ✅ Shared brain + tests (`agent-loop.ts`).
+2. ✅ Done-detection (`worktree-triage.ts`) + safety rail (`board-organizer.ts`).
+3. ✅ `/board/get` + `/board/set-status` hook-server endpoints + `board-signals.ts`
+   (`buildBoardView` runs `triageWorktree`; `applySetStatus` runs
+   `validateSetStatus` + audit + caller resolution) + `board_changes` table.
+4. ✅ Ateam board **MCP server** — served on the hook server's `/mcp` endpoint
+   (Streamable HTTP: POST→JSON, GET→405, no SSE/SDK/subprocess needed;
+   `board-mcp.ts`). Config helper `ensureBoardMcpConfig` (agent-setup) writes the
+   `.mcp.json` for `claude --mcp-config`. **57 tests green.**
+5. **Launch wiring + organizer loop** (next): pass `--mcp-config` +
+   `--allowedTools mcp__ateam_board__*` when launching sessions (so a session can
+   self-move) and the organizer (`LoopRunner` → headless `claude -p` per tick).
+6. **Ateam skills, greybeard-style** (`and then we add a ateam skills like
+   clawnify/greybeard`) — the "instruct" layer: ship per-agent skill/guidance
+   files (via the provider matrix) teaching the agent WHEN to call the board
+   tools ("when you finish, set_status → review"; the organizer's job). This is
+   the greybeard `install.js` PROVIDERS pattern applied to Ateam's own skills —
+   distribution layer on top of the MCP capability layer.
+7. UI: show organizer moves + the `board_changes` audit trail in the Loops panel.
+
+### Which engine drives the organizer — NOT Claude's `/loop`
+
+Two loop families, two engines — don't conflate:
+
+- **In-session code loops** ("keep fixing tests") live in a task's own pane and
+  the agent self-paces → use Claude's **native `/loop`** (`agent-loop.ts`).
+- **App-level judgment loops** (this organizer) are cross-task reconcilers with
+  an LLM in the run step → use Ateam's **`LoopRunner`**, ticking a **headless
+  `claude -p`** turn. Each tick: read board → re-triage → guarded moves → exit.
+
+`-p` beats native `/loop` here on every axis: Ateam keeps cadence/enable/audit
+(existing infra, no second scheduler); `-p` *documents* slash-command + MCP-tool
+support (positional-slash in interactive mode is undocumented, and `--bg`
+backgrounds with no pane + 7-day expiry); fresh context each tick suits a
+reconciler (no multi-day drift/cost); clean one-turn lifecycle, no PTY
+injection, no supervisor. The organizer is a reconciler whose judgment is
+delegated to a headless turn — nothing more.
+
+## Later: extract the provider matrix
+
+The Codex (`Stop` block-and-continue) and OpenCode (`session.idle` plugin)
+bindings are the same shape as `agent-setup/index.ts` and greybeard's
+`bin/install.js` (detect agent → its hook/settings/event names). Once a second
+binding exists, extract that seam into a small adapter — not a new runtime;
+OpenClaw already is the runtime.

--- a/apps/desktop/src/main/loops/board-organizer.ts
+++ b/apps/desktop/src/main/loops/board-organizer.ts
@@ -1,0 +1,129 @@
+/**
+ * Board organizer — safety rail for board moves made through the MCP `set_status`
+ * tool, whether by the write-capable organizer loop OR by a task's own agent
+ * session (see agent-loops.design.md). An LLM mutating board state is the
+ * accepted risk, so every move is validated here before it touches the DB. The
+ * caller proposes; this disposes.
+ *
+ * The column model has two kinds:
+ *   • ASSIGNABLE (`todo`, `review`) — judgment columns a caller may set.
+ *   • PROGRAMMATIC (`running`, `needs_attention`, `merged`) — set only by real
+ *     events / lifecycle hooks: `running` on agent launch, `needs_attention`
+ *     when the agent blocks on input (programmatic, not a judgment call),
+ *     `merged` on a real merge. Nobody targets these through the tool.
+ *
+ * Two callers, two trust levels:
+ *   • ORGANIZER (external, board-level): may re-triage cards among the assignable
+ *     columns, but never touches a card with a LIVE agent or one sitting in a
+ *     programmatic column — those belong to real events, not the organizer.
+ *   • SELF (`bySelf`): a task's own session moving its OWN card. It IS the live
+ *     agent, so the live-agent guard doesn't apply — it may retarget its card
+ *     (e.g. "I'm done" → `review`). It still cannot un-`merged` a card.
+ *
+ * Every approved move yields a `BoardChange` for the audit log, so a misfile is
+ * always traceable and reversible.
+ *
+ * Pure module: no db, no I/O, no clock. Unit-tested in
+ * apps/desktop/test/board-organizer.test.ts.
+ */
+
+import type { KanbanColumn } from "@ateam/db";
+
+/** Columns a caller MAY set through the tool — the judgment columns. */
+export const ASSIGNABLE_COLUMNS = ["todo", "review"] as const;
+
+/** Columns set only by real events / hooks; never a tool target. */
+export const PROGRAMMATIC_COLUMNS = ["running", "needs_attention", "merged"] as const;
+
+export type AssignableColumn = (typeof ASSIGNABLE_COLUMNS)[number];
+
+export function isAssignable(col: KanbanColumn): col is AssignableColumn {
+	return (ASSIGNABLE_COLUMNS as readonly string[]).includes(col);
+}
+
+export function isProgrammatic(col: KanbanColumn): boolean {
+	return (PROGRAMMATIC_COLUMNS as readonly string[]).includes(col);
+}
+
+/** A proposed move. `from` is server-supplied (read from the DB), not taken from
+ *  the caller — the caller only names the target and its reason. */
+export interface SetStatusRequest {
+	taskId: string;
+	/** The card's current column, read from the DB (not from the caller). */
+	from: KanbanColumn;
+	/** Where the caller wants the card to go. */
+	to: KanbanColumn;
+	/** Whether a live agent is currently working this task. */
+	agentAlive: boolean;
+	/** True when the caller is the task's OWN session moving its OWN card. */
+	bySelf?: boolean;
+	/** The caller's justification — recorded in the audit trail. */
+	reason?: string;
+}
+
+/** An approved change, ready to apply + audit. Timestamped at persistence. */
+export interface BoardChange {
+	taskId: string;
+	from: KanbanColumn;
+	to: KanbanColumn;
+	reason: string;
+}
+
+export type SetStatusVerdict = { ok: true; change: BoardChange } | { ok: false; reason: string };
+
+/**
+ * Validate one proposed move. Checks are ordered most-fundamental first so the
+ * reason returned is the most relevant. A rejected move is a no-op the caller
+ * records as skipped — never an error that stops the loop.
+ */
+export function validateSetStatus(req: SetStatusRequest): SetStatusVerdict {
+	if (req.to === req.from) {
+		return { ok: false, reason: `no-op: card already in "${req.from}"` };
+	}
+	if (!isAssignable(req.to)) {
+		return {
+			ok: false,
+			reason: `cannot set "${req.to}" — it is set only by real events (launch / awaiting-input / merge)`,
+		};
+	}
+	// Terminal state: even the card's own session can't un-merge it.
+	if (req.from === "merged") {
+		return { ok: false, reason: `cannot move a card out of "merged" — the merge is real` };
+	}
+
+	// A session moving its OWN card owns it — the live-agent / programmatic-column
+	// guards below are about protecting a card from OTHER movers, so skip them.
+	if (req.bySelf) {
+		return { ok: true, change: approved(req, "session self-move") };
+	}
+
+	// Organizer / external path.
+	if (isProgrammatic(req.from)) {
+		return {
+			ok: false,
+			reason: `cannot move a card out of "${req.from}" — it is owned by ${ownerOf(req.from)}, not the organizer`,
+		};
+	}
+	if (req.agentAlive) {
+		return {
+			ok: false,
+			reason: "task has a live agent — the agent and its hooks own this card",
+		};
+	}
+	return { ok: true, change: approved(req, "organizer re-triage") };
+}
+
+function approved(req: SetStatusRequest, fallbackReason: string): BoardChange {
+	return {
+		taskId: req.taskId,
+		from: req.from,
+		to: req.to,
+		reason: req.reason?.trim() || fallbackReason,
+	};
+}
+
+function ownerOf(col: KanbanColumn): string {
+	if (col === "merged") return "the merge queue";
+	if (col === "needs_attention") return "the input-request hooks";
+	return "the running agent";
+}

--- a/apps/desktop/src/main/loops/board-reconciler.ts
+++ b/apps/desktop/src/main/loops/board-reconciler.ts
@@ -1,6 +1,7 @@
-import type { AgentSession, AteamDb, Task } from "@ateam/db";
+import type { Task } from "@ateam/db";
 import { repo } from "@ateam/db";
 import { detectMerged } from "@ateam/git-core";
+import { agentAlive } from "./session-liveness";
 import type { LoopContext, LoopDefinition } from "./types";
 
 const ID = "board-reconciler";
@@ -10,33 +11,6 @@ const NET_THROTTLE_MS = 60_000;
 /** Self-paced bounds: tight while agents work, loose when the board is quiet. */
 const MIN_MS = 5_000;
 const MAX_MS = 120_000;
-
-/** A pid is "alive" if it exists — EPERM means it exists but isn't ours. */
-function pidAlive(pid: number | null | undefined): boolean {
-	if (!pid) return false;
-	try {
-		process.kill(pid, 0);
-		return true;
-	} catch (err) {
-		return (err as NodeJS.ErrnoException).code === "EPERM";
-	}
-}
-
-/**
- * A session counts as live if its pid is still running. When no pid was
- * recorded (older sessions) fall back to the DB flags. This is deliberately
- * pid-first: the PTY exit path doesn't always write `exitedAt`, so a killed
- * agent can sit in the db as "running" forever — pid liveness is the ground
- * truth that catches exactly that.
- */
-function sessionAlive(s: AgentSession): boolean {
-	if (s.pid != null) return pidAlive(s.pid);
-	return s.exitedAt == null && s.status !== "stopped";
-}
-
-function agentAlive(db: AteamDb, taskId: string): boolean {
-	return repo.listSessionsByTask(db, taskId).some(sessionAlive);
-}
 
 /** Has this task produced something worth reviewing? */
 function hasReviewableWork(task: Task): boolean {

--- a/apps/desktop/src/main/loops/board-signals.ts
+++ b/apps/desktop/src/main/loops/board-signals.ts
@@ -1,0 +1,158 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { AteamDb, KanbanColumn, Task } from "@ateam/db";
+import { repo } from "@ateam/db";
+import { validateSetStatus } from "./board-organizer";
+import { agentAlive } from "./session-liveness";
+import { type TriageResult, triageWorktree, type WorktreeSignals } from "./worktree-triage";
+
+/**
+ * I/O adapter between the board and the organizer's tools. Gathers the per-task
+ * signals `triageWorktree` needs, exposes the board as the `get_board` payload,
+ * and applies a guarded `set_status`. All impurity (git/gh/pid/db) lives here;
+ * the judgment (`triageWorktree`) and the guardrail (`validateSetStatus`) stay
+ * pure and tested next door.
+ *
+ * NOTE (status detection): `claude agents --json` is the richest liveness/
+ * blocking signal (see agent-loops.design.md), but it covers backgrounded
+ * agents, not Ateam's interactive PTY sessions — so we key liveness off pid
+ * here and leave agents-polling for the backgrounded-organizer path.
+ */
+
+const pexec = promisify(execFile);
+
+/** One task as the organizer sees it — its board column plus the triage verdict. */
+export interface BoardTaskView {
+	taskId: string;
+	name: string;
+	projectId: string;
+	column: KanbanColumn;
+	branch: string;
+	prNumber: number | null;
+	agentAlive: boolean;
+	/** The done-vs-ongoing judgment the organizer reasons with. */
+	triage: TriageResult;
+}
+
+export interface BoardView {
+	generatedAt: number;
+	tasks: BoardTaskView[];
+}
+
+/** PR state + merge time in one gh call; null on any failure (offline / no PR). */
+async function prMergeInfo(
+	worktreePath: string,
+): Promise<{ state: WorktreeSignals["prState"]; mergedAtMs: number | null }> {
+	try {
+		const { stdout } = await pexec("gh", ["pr", "view", "--json", "state,mergedAt"], {
+			cwd: worktreePath,
+		});
+		const p = JSON.parse(stdout) as { state?: string; mergedAt?: string | null };
+		const state =
+			p.state === "OPEN" || p.state === "MERGED" || p.state === "CLOSED" ? p.state : null;
+		const mergedAtMs = p.mergedAt ? Date.parse(p.mergedAt) : null;
+		return { state, mergedAtMs: Number.isNaN(mergedAtMs) ? null : mergedAtMs };
+	} catch {
+		return { state: null, mergedAtMs: null };
+	}
+}
+
+/** Gather the signals for one task. Cheap fields come from the DB snapshot;
+ *  the gh call is made only when a PR could plausibly exist. */
+async function gatherSignals(db: AteamDb, task: Task): Promise<WorktreeSignals> {
+	const gs = task.gitStatus;
+	const mightHavePr = task.prNumber != null || task.column === "review" || task.column === "merged";
+	const pr = mightHavePr ? await prMergeInfo(task.worktreePath) : { state: null, mergedAtMs: null };
+
+	return {
+		agentAlive: agentAlive(db, task.id),
+		createdAtMs: task.createdAt ?? null,
+		// gitStatus.updatedAt tracks the last git refresh; lastEventAt tracks the
+		// last hook activity (our best proxy for conversation activity).
+		indexMtimeMs: gs?.updatedAt ?? null,
+		transcriptMtimeMs: task.lastEventAt ?? null,
+		dirtyRealCount: gs?.dirty ?? 0,
+		commitsAhead: gs?.ahead ?? 0,
+		prState: pr.state,
+		mergedAtMs: pr.mergedAtMs,
+	};
+}
+
+/**
+ * Build the `get_board` payload: every non-merged task with its triage verdict.
+ * `merged` is terminal ground truth, so those are excluded — the organizer acts
+ * on what's still in play.
+ */
+export async function buildBoardView(db: AteamDb, now = Date.now()): Promise<BoardView> {
+	const tasks: BoardTaskView[] = [];
+	for (const project of repo.listProjects(db)) {
+		for (const task of repo.listTasks(db, project.id)) {
+			if (task.column === "merged") continue;
+			const signals = await gatherSignals(db, task);
+			tasks.push({
+				taskId: task.id,
+				name: task.name,
+				projectId: project.id,
+				column: task.column,
+				branch: task.branch,
+				prNumber: task.prNumber ?? null,
+				agentAlive: signals.agentAlive ?? false,
+				triage: triageWorktree(signals, { now }),
+			});
+		}
+	}
+	return { generatedAt: now, tasks };
+}
+
+export interface ApplySetStatusResult {
+	ok: boolean;
+	/** Human-readable outcome — the move made, or why it was refused. */
+	reason: string;
+}
+
+/**
+ * Apply one proposed move. `to`/`reason` come from the caller (untrusted);
+ * `from` is read from the DB (trusted). The caller is identified by its terminal:
+ * a session whose terminal maps to THIS task is a self-move (may move its own
+ * card even while live); anything else is the organizer (external). A session
+ * may only move its OWN task. The guardrail decides; an approved move updates
+ * the card AND writes an audit row.
+ */
+export function applySetStatus(
+	db: AteamDb,
+	input: { taskId: string; to: string; reason?: string; callerTerminalId?: string },
+	onTaskUpdated: (taskId: string) => void,
+): ApplySetStatusResult {
+	const task = repo.getTask(db, input.taskId);
+	if (!task) return { ok: false, reason: `unknown task: ${input.taskId}` };
+
+	// Who's calling? A terminal that belongs to a task makes this a session move.
+	const callerTaskId = input.callerTerminalId
+		? repo.getSessionByTerminal(db, input.callerTerminalId)?.taskId
+		: undefined;
+	if (callerTaskId != null && callerTaskId !== task.id) {
+		return { ok: false, reason: "a session may only change its own task" };
+	}
+	const bySelf = callerTaskId != null && callerTaskId === task.id;
+
+	const verdict = validateSetStatus({
+		taskId: task.id,
+		from: task.column,
+		to: input.to as KanbanColumn,
+		agentAlive: agentAlive(db, task.id),
+		bySelf,
+		reason: input.reason,
+	});
+	if (!verdict.ok) return { ok: false, reason: verdict.reason };
+
+	repo.updateTask(db, task.id, { column: verdict.change.to });
+	repo.recordBoardChange(db, {
+		taskId: task.id,
+		fromColumn: verdict.change.from,
+		toColumn: verdict.change.to,
+		reason: verdict.change.reason,
+		source: bySelf ? "session" : "organizer",
+	});
+	onTaskUpdated(task.id);
+	return { ok: true, reason: `moved "${verdict.change.from}" → "${verdict.change.to}"` };
+}

--- a/apps/desktop/src/main/loops/session-liveness.ts
+++ b/apps/desktop/src/main/loops/session-liveness.ts
@@ -1,0 +1,32 @@
+import type { AgentSession, AteamDb } from "@ateam/db";
+import { repo } from "@ateam/db";
+
+/**
+ * Is an agent process still running? Shared by the board reconciler and the
+ * board organizer's signal-gathering — both need the same ground-truth answer
+ * to "does a live agent own this card?".
+ *
+ * pid-first because the PTY exit path doesn't always write `exitedAt`, so a
+ * killed agent can sit in the DB as "running" forever; pid liveness catches
+ * exactly that. `EPERM` means the pid exists but isn't ours — still alive.
+ */
+export function pidAlive(pid: number | null | undefined): boolean {
+	if (!pid) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+/** A session is live if its pid runs; older sessions with no pid fall back to flags. */
+export function sessionAlive(s: AgentSession): boolean {
+	if (s.pid != null) return pidAlive(s.pid);
+	return s.exitedAt == null && s.status !== "stopped";
+}
+
+/** Does any session for this task have a live agent process? */
+export function agentAlive(db: AteamDb, taskId: string): boolean {
+	return repo.listSessionsByTask(db, taskId).some(sessionAlive);
+}

--- a/apps/desktop/src/main/loops/worktree-triage.ts
+++ b/apps/desktop/src/main/loops/worktree-triage.ts
@@ -1,0 +1,179 @@
+/**
+ * Worktree triage — "is this task actually done, or still ongoing?"
+ *
+ * The board reconciler mislabels tasks as done because it judges from one thin
+ * signal (a merged PR). This module encodes the richer done-vs-ongoing logic
+ * from the user's `triage-worktrees` / `cleanup-worktrees` skills
+ * (pallaoro/dotfiles) so the board organizer stops calling work finished when it
+ * isn't. It is the "context" the deterministic reconciler was missing, made
+ * explicit and testable.
+ *
+ * The rules that matter (each one is a way the naive "PR merged → done" check
+ * gets it wrong):
+ *   • RECENT ACTIVITY = in-flight. Any activity within `recentHours` (freshest
+ *     of index / transcript / creation mtime) means a session may still hold it
+ *     — never done, whatever git says.
+ *   • MERGED ≠ DONE if the conversation continued. A transcript touched ≥ 4 min
+ *     after the PR merged means follow-up work — still ongoing.
+ *   • DIRTY / AHEAD / OPEN-PR = ongoing.
+ *   • PATCH-EQUIVALENCE. "commits ahead" lies about squash/rebase/cherry-pick
+ *     merges; a caller that ran `git cherry` sets `patchEquivalent` to mean
+ *     "already in main".
+ *   • NO WORK ≠ DONE. A fresh card with no commits, no PR, clean tree hasn't
+ *     started — it is not finished.
+ *
+ * Pure module: callers gather the signals (git / gh / stat / transcript mtime);
+ * this only classifies. No db, no I/O; `now` is injected. Unit-tested in
+ * apps/desktop/test/worktree-triage.test.ts.
+ */
+
+/** Activity within this window means a live session may still own the tree. */
+export const DEFAULT_RECENT_HOURS = 2;
+/** A transcript touched this long after mergedAt means the talk continued. */
+export const CONVERSATION_GAP_MS = 4 * 60 * 1000;
+
+/** Signals a caller gathers per worktree. All times are epoch ms. */
+export interface WorktreeSignals {
+	/** Live agent process attached (pid alive)? Overrides everything → active. */
+	agentAlive?: boolean;
+	/** Worktree creation time. */
+	createdAtMs?: number | null;
+	/** `.git/worktrees/<n>/index` mtime — moves on git ops/commits. */
+	indexMtimeMs?: number | null;
+	/** Newest session-transcript mtime — moves on conversation activity. */
+	transcriptMtimeMs?: number | null;
+	/** Count of REAL dirty files (caller has already excluded node_modules/dist/junk). */
+	dirtyRealCount: number;
+	/** Commits ahead of the base branch. */
+	commitsAhead: number;
+	/** Every ahead-commit is patch-equivalent to one already in main (git cherry `-`). */
+	patchEquivalent?: boolean;
+	/** PR state for this branch, if any. */
+	prState?: "OPEN" | "MERGED" | "CLOSED" | null;
+	/** When the PR merged (epoch ms), if MERGED. */
+	mergedAtMs?: number | null;
+	/** On disk but not in `git worktree list` (broken/foreign git link). */
+	isOrphan?: boolean;
+}
+
+/** Buckets, ordered by urgency — the first that matches wins (as in the skill). */
+export type WorktreeBucket =
+	| "active" // recent activity or live agent — in-flight, do not touch
+	| "uncommitted" // real dirty files
+	| "open_pr" // PR is OPEN
+	| "unmerged_no_pr" // commits ahead, not merged, not patch-equivalent
+	| "merged_unfinished" // MERGED but the conversation continued past the merge
+	| "merged_done" // MERGED (or patch-equivalent) and the session wrapped up
+	| "orphan" // on disk but not a tracked worktree
+	| "not_started"; // no work yet — NOT done, just untouched
+
+/** Board column this bucket maps to, or null to leave the card where it is. */
+export type SuggestedColumn = "todo" | "needs_attention" | "review" | "merged" | null;
+
+export interface TriageResult {
+	bucket: WorktreeBucket;
+	/** The single question that started this: is the task actually finished? */
+	done: boolean;
+	/** Where the organizer should file it (null = leave as-is / in-flight). */
+	suggestedColumn: SuggestedColumn;
+	reason: string;
+}
+
+/** Freshest activity signal across creation / index / transcript. */
+export function lastActivityMs(s: WorktreeSignals): number {
+	return Math.max(s.createdAtMs ?? 0, s.indexMtimeMs ?? 0, s.transcriptMtimeMs ?? 0);
+}
+
+export interface TriageOptions {
+	now: number;
+	recentHours?: number;
+}
+
+/**
+ * Classify one worktree. Checks run in urgency order so the first matching
+ * bucket wins — and, crucially, every "ongoing" signal is checked BEFORE any
+ * path that could return done, so the classifier errs toward "not done" exactly
+ * where the reconciler errs toward "done".
+ */
+export function triageWorktree(s: WorktreeSignals, opts: TriageOptions): TriageResult {
+	const recentHours = opts.recentHours ?? DEFAULT_RECENT_HOURS;
+
+	// 1. Live agent or recent activity → in-flight. Never done.
+	if (s.agentAlive) {
+		return { bucket: "active", done: false, suggestedColumn: null, reason: "live agent attached" };
+	}
+	const idleMs = opts.now - lastActivityMs(s);
+	if (idleMs < recentHours * 3600_000) {
+		return {
+			bucket: "active",
+			done: false,
+			suggestedColumn: null,
+			reason: `activity within ${recentHours}h — in-flight`,
+		};
+	}
+
+	// 2. Real uncommitted work → ongoing.
+	if (s.dirtyRealCount > 0) {
+		return {
+			bucket: "uncommitted",
+			done: false,
+			suggestedColumn: "needs_attention",
+			reason: `${s.dirtyRealCount} uncommitted file(s)`,
+		};
+	}
+
+	// 3. Open PR → ongoing (needs review/merge).
+	if (s.prState === "OPEN") {
+		return { bucket: "open_pr", done: false, suggestedColumn: "review", reason: "PR is open" };
+	}
+
+	const merged = s.prState === "MERGED" || (s.patchEquivalent ?? false);
+
+	// 4. Commits ahead, not merged/patch-equivalent → unmerged work.
+	if (!merged && s.commitsAhead > 0) {
+		return {
+			bucket: "unmerged_no_pr",
+			done: false,
+			suggestedColumn: "review",
+			reason: `${s.commitsAhead} commit(s) ahead, no merge`,
+		};
+	}
+
+	// 5. Merged: done ONLY if the conversation wrapped up with the merge.
+	if (merged) {
+		const gap =
+			s.transcriptMtimeMs != null && s.mergedAtMs != null ? s.transcriptMtimeMs - s.mergedAtMs : 0;
+		if (gap >= CONVERSATION_GAP_MS) {
+			return {
+				bucket: "merged_unfinished",
+				done: false,
+				suggestedColumn: "review",
+				reason: `merged, but conversation continued ${Math.round(gap / 60000)}m past merge`,
+			};
+		}
+		return {
+			bucket: "merged_done",
+			done: true,
+			suggestedColumn: "merged",
+			reason: s.prState === "MERGED" ? "PR merged, session wrapped up" : "patch-equivalent to main",
+		};
+	}
+
+	// 6. On disk but untracked → needs a human.
+	if (s.isOrphan) {
+		return {
+			bucket: "orphan",
+			done: false,
+			suggestedColumn: "needs_attention",
+			reason: "orphaned worktree dir",
+		};
+	}
+
+	// 7. No commits, no PR, clean, quiet → hasn't started. NOT done.
+	return {
+		bucket: "not_started",
+		done: false,
+		suggestedColumn: null,
+		reason: "no work yet — not started",
+	};
+}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -979,7 +979,15 @@ function TaskPanel({
 				    changes view is open — just hide it. */}
 				<div className="term-wrap" style={{ display: changesOpen ? "none" : "flex" }}>
 					{terminalId ? (
-						<TerminalView terminalId={terminalId} />
+						<TerminalView
+							terminalId={terminalId}
+							showDone={task.column === "review"}
+							onDone={() =>
+								run(async () => {
+									await window.ateam.tasks.setColumn(task.id, "merged");
+								})
+							}
+						/>
 					) : (
 						<div className="term" style={{ display: "grid", placeItems: "center" }}>
 							<span className="muted">Launch an agent or shell to start a terminal</span>

--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -1,7 +1,8 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
-import { FileUp, ImageUp, Plus } from "lucide-react";
+import { Check, FileUp, ImageUp, Plus } from "lucide-react";
 import { useEffect, useRef } from "react";
+import { IconButton } from "./IconButton";
 import { Menu } from "./Menu";
 
 /**
@@ -21,7 +22,17 @@ const IMAGE_RE = /\.(png|jpe?g|gif|webp|bmp|tiff?|heic|heif|avif|ico)$/i;
  * streams live output, and forwards keystrokes + resize back to the PTY.
  * A slim toolbar underneath offers a `+` menu (e.g. attach files by path).
  */
-export function TerminalView({ terminalId }: { terminalId: string }) {
+export function TerminalView({
+	terminalId,
+	showDone,
+	onDone,
+}: {
+	terminalId: string;
+	/** Show a "Done" action in the toolbar (e.g. task is in Review). */
+	showDone?: boolean;
+	/** Called when Done is clicked — the parent owns the status change. */
+	onDone?: () => void;
+}) {
 	const ref = useRef<HTMLDivElement>(null);
 	const termRef = useRef<Terminal | null>(null);
 
@@ -305,6 +316,9 @@ export function TerminalView({ terminalId }: { terminalId: string }) {
 						{ label: "Files…", icon: FileUp, onClick: addFiles },
 					]}
 				/>
+				{showDone && (
+					<IconButton icon={Check} label="Mark task Done" variant="primary" onClick={onDone} />
+				)}
 			</div>
 		</div>
 	);

--- a/apps/desktop/test/agent-loop.test.ts
+++ b/apps/desktop/test/agent-loop.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type AgentLoopConfig,
+	DEFAULT_MAX_ITERATIONS,
+	decideContinuation,
+	HARD_MAX_ITERATIONS,
+	resolveMaxIterations,
+} from "../src/main/loops/agent-loop";
+
+const cfg = (over: Partial<AgentLoopConfig> = {}): AgentLoopConfig => ({
+	prompt: "keep fixing failing tests",
+	...over,
+});
+
+describe("resolveMaxIterations", () => {
+	it("defaults when unset", () => {
+		expect(resolveMaxIterations(cfg())).toBe(DEFAULT_MAX_ITERATIONS);
+	});
+	it("clamps to the hard ceiling and floor", () => {
+		expect(resolveMaxIterations(cfg({ maxIterations: 10_000 }))).toBe(HARD_MAX_ITERATIONS);
+		expect(resolveMaxIterations(cfg({ maxIterations: 0 }))).toBe(1);
+		expect(resolveMaxIterations(cfg({ maxIterations: -5 }))).toBe(1);
+	});
+	it("floors fractional and rejects non-finite", () => {
+		expect(resolveMaxIterations(cfg({ maxIterations: 3.9 }))).toBe(3);
+		expect(resolveMaxIterations(cfg({ maxIterations: Number.NaN }))).toBe(DEFAULT_MAX_ITERATIONS);
+	});
+});
+
+describe("decideContinuation", () => {
+	it("continues with the prompt while under the cap", () => {
+		const d = decideContinuation(cfg({ maxIterations: 3 }), { iterations: 0 });
+		expect(d.continue).toBe(true);
+		if (d.continue) {
+			expect(d.prompt).toBe("keep fixing failing tests");
+			expect(d.reason).toBe("turn 1/3");
+		}
+	});
+
+	it("stops exactly at the cap (backstop)", () => {
+		const d = decideContinuation(cfg({ maxIterations: 3 }), { iterations: 3 });
+		expect(d.continue).toBe(false);
+		if (!d.continue) expect(d.reason).toContain("3-turn cap");
+	});
+
+	it("the cap wins even when there is no stop signal", () => {
+		// A loop with no stopSignal must still terminate — the cap is the backstop.
+		const d = decideContinuation(cfg({ maxIterations: 1 }), { iterations: 1 });
+		expect(d.continue).toBe(false);
+	});
+
+	it("stops when the goal sentinel appears in the last output", () => {
+		const c = cfg({ stopSignal: "LOOP_DONE", maxIterations: 50 });
+		const d = decideContinuation(c, { iterations: 2 }, "all green now. LOOP_DONE");
+		expect(d.continue).toBe(false);
+		if (!d.continue) expect(d.reason).toContain("stop signal");
+	});
+
+	it("keeps going when the sentinel is absent from the output", () => {
+		const c = cfg({ stopSignal: "LOOP_DONE", maxIterations: 50 });
+		const d = decideContinuation(c, { iterations: 2 }, "still two tests failing");
+		expect(d.continue).toBe(true);
+	});
+
+	it("cap is checked before the goal signal (safety over completion)", () => {
+		const c = cfg({ stopSignal: "LOOP_DONE", maxIterations: 2 });
+		// At the cap AND the signal is present — must stop for the cap reason,
+		// but either way it stops; assert it does not continue.
+		const d = decideContinuation(c, { iterations: 2 }, "not done yet");
+		expect(d.continue).toBe(false);
+		if (!d.continue) expect(d.reason).toContain("cap");
+	});
+
+	it("refuses to drive a turn with a blank prompt", () => {
+		const d = decideContinuation(cfg({ prompt: "   " }), { iterations: 0 });
+		expect(d.continue).toBe(false);
+		if (!d.continue) expect(d.reason).toContain("no prompt");
+	});
+
+	it("trims the prompt it sends", () => {
+		const d = decideContinuation(cfg({ prompt: "  do it  " }), { iterations: 0 });
+		if (d.continue) expect(d.prompt).toBe("do it");
+	});
+});

--- a/apps/desktop/test/board-mcp.test.ts
+++ b/apps/desktop/test/board-mcp.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import { type BoardHandlers, dispatchMcp } from "../src/main/hooks/board-mcp";
+
+// A fake board that records what it was called with.
+function fakeBoard() {
+	const calls: { setStatus: unknown[] } = { setStatus: [] };
+	const board: BoardHandlers = {
+		get: async () => ({ tasks: [{ taskId: "t1" }] }),
+		setStatus: async (req) => {
+			calls.setStatus.push(req);
+			return { ok: true, reason: `moved ${req.taskId}` };
+		},
+	};
+	return { board, calls };
+}
+
+const rpc = (method: string, params?: unknown, id: number | null = 1) => ({
+	jsonrpc: "2.0" as const,
+	id,
+	method,
+	params,
+});
+
+describe("dispatchMcp", () => {
+	it("initialize echoes the client protocol version and advertises tools", async () => {
+		const { board } = fakeBoard();
+		const r = await dispatchMcp(rpc("initialize", { protocolVersion: "2025-06-18" }), board);
+		expect(r.kind).toBe("json");
+		if (r.kind === "json") {
+			const body = r.body as { result: { protocolVersion: string; capabilities: unknown } };
+			expect(body.result.protocolVersion).toBe("2025-06-18");
+			expect(body.result.capabilities).toHaveProperty("tools");
+		}
+	});
+
+	it("acknowledges the initialized notification with 202 (no reply)", async () => {
+		const { board } = fakeBoard();
+		const r = await dispatchMcp({ jsonrpc: "2.0", method: "notifications/initialized" }, board);
+		expect(r.kind).toBe("accepted");
+	});
+
+	it("tools/list returns get_board and set_status", async () => {
+		const { board } = fakeBoard();
+		const r = await dispatchMcp(rpc("tools/list"), board);
+		if (r.kind === "json") {
+			const names = (r.body as { result: { tools: { name: string }[] } }).result.tools.map(
+				(t) => t.name,
+			);
+			expect(names).toEqual(["get_board", "set_status"]);
+		}
+	});
+
+	it("set_status only offers the assignable columns in its schema", async () => {
+		const { board } = fakeBoard();
+		const r = await dispatchMcp(rpc("tools/list"), board);
+		if (r.kind === "json") {
+			const set = (
+				r.body as {
+					result: {
+						tools: { name: string; inputSchema: { properties: { to: { enum: string[] } } } }[];
+					};
+				}
+			).result.tools.find((t) => t.name === "set_status");
+			expect(set?.inputSchema.properties.to.enum).toEqual(["todo", "review"]);
+		}
+	});
+
+	it("tools/call get_board returns the board JSON as text content", async () => {
+		const { board } = fakeBoard();
+		const r = await dispatchMcp(rpc("tools/call", { name: "get_board", arguments: {} }, 2), board);
+		if (r.kind === "json") {
+			const result = (r.body as { result: { content: { type: string; text: string }[] } }).result;
+			expect(result.content[0].type).toBe("text");
+			expect(result.content[0].text).toContain("t1");
+		}
+	});
+
+	it("tools/call set_status threads the caller terminal id through as a self-move", async () => {
+		const { board, calls } = fakeBoard();
+		await dispatchMcp(
+			rpc("tools/call", { name: "set_status", arguments: { taskId: "t1", to: "review" } }, 3),
+			board,
+			{ callerTerminalId: "term-9" },
+		);
+		expect(calls.setStatus[0]).toMatchObject({
+			taskId: "t1",
+			to: "review",
+			callerTerminalId: "term-9",
+		});
+	});
+
+	it("set_status requires taskId and to", async () => {
+		const { board } = fakeBoard();
+		const r = await dispatchMcp(rpc("tools/call", { name: "set_status", arguments: {} }, 4), board);
+		if (r.kind === "json") {
+			const result = (r.body as { result: { isError: boolean } }).result;
+			expect(result.isError).toBe(true);
+		}
+	});
+
+	it("unknown method → JSON-RPC method-not-found", async () => {
+		const { board } = fakeBoard();
+		const r = await dispatchMcp(rpc("frobnicate"), board);
+		if (r.kind === "json") {
+			expect((r.body as { error: { code: number } }).error.code).toBe(-32601);
+		}
+	});
+
+	it("unknown tool → invalid params error", async () => {
+		const { board } = fakeBoard();
+		const r = await dispatchMcp(rpc("tools/call", { name: "nope", arguments: {} }, 5), board);
+		if (r.kind === "json") {
+			expect((r.body as { error: { code: number } }).error.code).toBe(-32602);
+		}
+	});
+});

--- a/apps/desktop/test/board-organizer.test.ts
+++ b/apps/desktop/test/board-organizer.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import { type SetStatusRequest, validateSetStatus } from "../src/main/loops/board-organizer";
+
+const req = (over: Partial<SetStatusRequest>): SetStatusRequest => ({
+	taskId: "t1",
+	from: "todo",
+	to: "review",
+	agentAlive: false,
+	...over,
+});
+
+describe("validateSetStatus — the guardrail", () => {
+	it("allows a legit organizer triage move between assignable columns", () => {
+		const v = validateSetStatus(req({ from: "review", to: "todo", reason: "stale" }));
+		expect(v.ok).toBe(true);
+		if (v.ok) {
+			expect(v.change.to).toBe("todo");
+			expect(v.change.reason).toBe("stale");
+		}
+	});
+
+	it("defaults the organizer's reason so the audit trail is never empty", () => {
+		const v = validateSetStatus(req({ reason: "  " }));
+		if (v.ok) expect(v.change.reason).toBe("organizer re-triage");
+	});
+
+	it("refuses non-assignable targets — running / merged / needs_attention", () => {
+		expect(validateSetStatus(req({ to: "running" })).ok).toBe(false);
+		expect(validateSetStatus(req({ to: "merged" })).ok).toBe(false);
+		// needs_attention is programmatic (set when the agent blocks on input).
+		expect(validateSetStatus(req({ to: "needs_attention" })).ok).toBe(false);
+	});
+
+	it("organizer cannot move a card out of a programmatic column", () => {
+		for (const from of ["running", "needs_attention", "merged"] as const) {
+			const v = validateSetStatus(req({ from, to: "review" }));
+			expect(v.ok).toBe(false);
+		}
+	});
+
+	it("organizer never touches a card with a live agent", () => {
+		const v = validateSetStatus(req({ from: "todo", to: "review", agentAlive: true }));
+		expect(v.ok).toBe(false);
+		if (!v.ok) expect(v.reason).toContain("live agent");
+	});
+
+	it("rejects a no-op move", () => {
+		const v = validateSetStatus(req({ from: "review", to: "review" }));
+		expect(v.ok).toBe(false);
+		if (!v.ok) expect(v.reason).toContain("no-op");
+	});
+
+	describe("self-moves (a session moving its own card)", () => {
+		it("lets a live session move its own running card to review", () => {
+			const v = validateSetStatus({
+				taskId: "t1",
+				from: "running",
+				to: "review",
+				agentAlive: true,
+				bySelf: true,
+				reason: "finished",
+			});
+			expect(v.ok).toBe(true);
+			if (v.ok) expect(v.change.reason).toBe("finished");
+		});
+
+		it("defaults a self-move reason distinctly from the organizer's", () => {
+			const v = validateSetStatus({
+				taskId: "t1",
+				from: "running",
+				to: "review",
+				agentAlive: true,
+				bySelf: true,
+			});
+			if (v.ok) expect(v.change.reason).toBe("session self-move");
+		});
+
+		it("still cannot un-merge its own card", () => {
+			const v = validateSetStatus({
+				taskId: "t1",
+				from: "merged",
+				to: "review",
+				agentAlive: true,
+				bySelf: true,
+			});
+			expect(v.ok).toBe(false);
+			if (!v.ok) expect(v.reason).toContain("merged");
+		});
+
+		it("still cannot set a programmatic target", () => {
+			const v = validateSetStatus({
+				taskId: "t1",
+				from: "running",
+				to: "needs_attention",
+				agentAlive: true,
+				bySelf: true,
+			});
+			expect(v.ok).toBe(false);
+		});
+	});
+});

--- a/apps/desktop/test/board-signals.test.ts
+++ b/apps/desktop/test/board-signals.test.ts
@@ -1,0 +1,132 @@
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, it } from "bun:test";
+import { type AteamDb, bootstrap, repo } from "@ateam/db";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import * as schema from "../../../packages/db/src/schema";
+import { applySetStatus } from "../src/main/loops/board-signals";
+
+function createTestDb(): AteamDb {
+	const sqlite = new Database(":memory:");
+	sqlite.exec("PRAGMA foreign_keys = ON;");
+	bootstrap(sqlite);
+	return drizzle(sqlite, { schema }) as unknown as AteamDb;
+}
+
+function makeTask(db: AteamDb, column: schema.KanbanColumn) {
+	const project = repo.upsertProject(db, { repoPath: "/tmp/repo", name: "repo" });
+	return repo.createTask(db, {
+		projectId: project.id,
+		name: "a task",
+		slug: "a-task",
+		branch: "feat/a",
+		baseBranch: "main",
+		worktreePath: "/tmp/repo/.ateam/worktrees/a",
+		column,
+	});
+}
+
+let db: AteamDb;
+let updated: string[];
+const onUpdated = (id: string) => updated.push(id);
+
+beforeEach(() => {
+	db = createTestDb();
+	updated = [];
+});
+
+describe("applySetStatus — endpoint integration (guardrail + audit + db)", () => {
+	it("applies a legal move, updates the card, writes one audit row, notifies", () => {
+		const t = makeTask(db, "todo");
+		const r = applySetStatus(db, { taskId: t.id, to: "review", reason: "PR open" }, onUpdated);
+		expect(r.ok).toBe(true);
+		expect(repo.getTask(db, t.id)?.column).toBe("review");
+		const audit = repo.listBoardChanges(db, { taskId: t.id });
+		expect(audit).toHaveLength(1);
+		expect(audit[0]).toMatchObject({ fromColumn: "todo", toColumn: "review", reason: "PR open" });
+		expect(updated).toEqual([t.id]);
+	});
+
+	it("refuses a ground-truth target and leaves the card + audit untouched", () => {
+		const t = makeTask(db, "todo");
+		const r = applySetStatus(db, { taskId: t.id, to: "running" }, onUpdated);
+		expect(r.ok).toBe(false);
+		expect(repo.getTask(db, t.id)?.column).toBe("todo");
+		expect(repo.listBoardChanges(db, { taskId: t.id })).toHaveLength(0);
+		expect(updated).toEqual([]);
+	});
+
+	it("the organizer never moves a card that has a live agent", () => {
+		const t = makeTask(db, "review");
+		// A session whose pid is this test process — guaranteed alive.
+		repo.createSession(db, {
+			taskId: t.id,
+			agentId: "claude",
+			terminalId: "term-1",
+			cwd: t.worktreePath,
+			pid: process.pid,
+		});
+		// No callerTerminalId → organizer; live agent → refused.
+		const r = applySetStatus(db, { taskId: t.id, to: "todo" }, onUpdated);
+		expect(r.ok).toBe(false);
+		expect(r.reason).toContain("live agent");
+		expect(repo.getTask(db, t.id)?.column).toBe("review");
+	});
+
+	it("rejects an unknown task", () => {
+		const r = applySetStatus(db, { taskId: "nope", to: "review" }, onUpdated);
+		expect(r.ok).toBe(false);
+		expect(r.reason).toContain("unknown task");
+	});
+
+	it("lets a session move its OWN live card (self-move), audited as source=session", () => {
+		const t = makeTask(db, "running");
+		repo.createSession(db, {
+			taskId: t.id,
+			agentId: "claude",
+			terminalId: "term-self",
+			cwd: t.worktreePath,
+			pid: process.pid, // alive
+		});
+		const r = applySetStatus(
+			db,
+			{ taskId: t.id, to: "review", reason: "done", callerTerminalId: "term-self" },
+			onUpdated,
+		);
+		expect(r.ok).toBe(true);
+		expect(repo.getTask(db, t.id)?.column).toBe("review");
+		expect(repo.listBoardChanges(db, { taskId: t.id })[0].source).toBe("session");
+	});
+
+	it("forbids a session from moving a DIFFERENT task", () => {
+		const mine = makeTask(db, "running");
+		const other = repo.createTask(db, {
+			projectId: mine.projectId,
+			name: "other",
+			slug: "other",
+			branch: "feat/b",
+			baseBranch: "main",
+			worktreePath: "/tmp/repo/.ateam/worktrees/b",
+			column: "todo",
+		});
+		repo.createSession(db, {
+			taskId: mine.id,
+			agentId: "claude",
+			terminalId: "term-mine",
+			cwd: mine.worktreePath,
+			pid: process.pid,
+		});
+		const r = applySetStatus(
+			db,
+			{ taskId: other.id, to: "review", callerTerminalId: "term-mine" },
+			onUpdated,
+		);
+		expect(r.ok).toBe(false);
+		expect(r.reason).toContain("only change its own task");
+	});
+
+	it("defaults the audit reason when the organizer gives none", () => {
+		const t = makeTask(db, "todo");
+		applySetStatus(db, { taskId: t.id, to: "review" }, onUpdated);
+		expect(repo.listBoardChanges(db, { taskId: t.id })[0].reason).toBe("organizer re-triage");
+	});
+});

--- a/apps/desktop/test/worktree-triage.test.ts
+++ b/apps/desktop/test/worktree-triage.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "bun:test";
+import {
+	CONVERSATION_GAP_MS,
+	triageWorktree,
+	type WorktreeSignals,
+} from "../src/main/loops/worktree-triage";
+
+const NOW = 1_000_000_000_000;
+const HOUR = 3_600_000;
+// A baseline "quiet" tree: last activity well outside the recent window.
+const quiet = (over: Partial<WorktreeSignals> = {}): WorktreeSignals => ({
+	indexMtimeMs: NOW - 10 * HOUR,
+	transcriptMtimeMs: NOW - 10 * HOUR,
+	dirtyRealCount: 0,
+	commitsAhead: 0,
+	...over,
+});
+
+const triage = (s: WorktreeSignals) => triageWorktree(s, { now: NOW, recentHours: 2 });
+
+describe("triageWorktree — the false-done cases the reconciler gets wrong", () => {
+	it("recent activity is in-flight, never done — even if merged", () => {
+		const r = triage(
+			quiet({
+				prState: "MERGED",
+				mergedAtMs: NOW - 5 * HOUR,
+				transcriptMtimeMs: NOW - 10 * 60_000,
+			}),
+		);
+		expect(r.bucket).toBe("active");
+		expect(r.done).toBe(false);
+		expect(r.suggestedColumn).toBeNull();
+	});
+
+	it("live agent is active regardless of git state", () => {
+		const r = triage(quiet({ agentAlive: true, prState: "MERGED", mergedAtMs: NOW - 5 * HOUR }));
+		expect(r.bucket).toBe("active");
+		expect(r.done).toBe(false);
+	});
+
+	it("merged but the conversation continued past merge is NOT done", () => {
+		const r = triage(
+			quiet({
+				prState: "MERGED",
+				mergedAtMs: NOW - 9 * HOUR,
+				// transcript touched well after the merge, but outside the recent window
+				transcriptMtimeMs: NOW - 9 * HOUR + CONVERSATION_GAP_MS + 60_000,
+			}),
+		);
+		expect(r.bucket).toBe("merged_unfinished");
+		expect(r.done).toBe(false);
+		expect(r.suggestedColumn).toBe("review");
+	});
+
+	it("merged with the session wrapped up at merge IS done", () => {
+		const r = triage(
+			quiet({
+				prState: "MERGED",
+				mergedAtMs: NOW - 9 * HOUR,
+				transcriptMtimeMs: NOW - 9 * HOUR + 60_000, // 1m gap < 4m
+			}),
+		);
+		expect(r.bucket).toBe("merged_done");
+		expect(r.done).toBe(true);
+		expect(r.suggestedColumn).toBe("merged");
+	});
+
+	it("a fresh untouched card is NOT done (no work ≠ done)", () => {
+		const r = triage(quiet());
+		expect(r.bucket).toBe("not_started");
+		expect(r.done).toBe(false);
+		expect(r.suggestedColumn).toBeNull();
+	});
+
+	it("uncommitted real work is ongoing", () => {
+		const r = triage(quiet({ dirtyRealCount: 3 }));
+		expect(r.bucket).toBe("uncommitted");
+		expect(r.done).toBe(false);
+		expect(r.suggestedColumn).toBe("needs_attention");
+	});
+
+	it("open PR is ongoing", () => {
+		const r = triage(quiet({ prState: "OPEN", commitsAhead: 2 }));
+		expect(r.bucket).toBe("open_pr");
+		expect(r.done).toBe(false);
+		expect(r.suggestedColumn).toBe("review");
+	});
+
+	it("commits ahead without a merge is unmerged work", () => {
+		const r = triage(quiet({ commitsAhead: 4 }));
+		expect(r.bucket).toBe("unmerged_no_pr");
+		expect(r.done).toBe(false);
+	});
+
+	it("patch-equivalent commits count as merged (squash/rebase truth)", () => {
+		const r = triage(
+			quiet({ commitsAhead: 4, patchEquivalent: true, transcriptMtimeMs: NOW - 10 * HOUR }),
+		);
+		expect(r.bucket).toBe("merged_done");
+		expect(r.done).toBe(true);
+	});
+
+	it("orphan dir needs a human, not done", () => {
+		const r = triage(quiet({ isOrphan: true }));
+		expect(r.bucket).toBe("orphan");
+		expect(r.done).toBe(false);
+		expect(r.suggestedColumn).toBe("needs_attention");
+	});
+
+	it("dirty beats merged — ongoing signals are checked first", () => {
+		const r = triage(quiet({ dirtyRealCount: 1, prState: "MERGED", mergedAtMs: NOW - 9 * HOUR }));
+		expect(r.bucket).toBe("uncommitted");
+		expect(r.done).toBe(false);
+	});
+});

--- a/packages/db/src/bootstrap.ts
+++ b/packages/db/src/bootstrap.ts
@@ -116,6 +116,17 @@ export function bootstrap(db: SqliteExecutor): void {
 			updated_at INTEGER
 		);
 		CREATE INDEX IF NOT EXISTS loops_definition_idx ON loops (definition_id);
+
+		CREATE TABLE IF NOT EXISTS board_changes (
+			id TEXT PRIMARY KEY,
+			task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+			from_column TEXT NOT NULL,
+			to_column TEXT NOT NULL,
+			reason TEXT NOT NULL,
+			source TEXT NOT NULL DEFAULT 'organizer',
+			created_at INTEGER
+		);
+		CREATE INDEX IF NOT EXISTS board_changes_task_idx ON board_changes (task_id);
 	`);
 
 	// Migrations for databases created before a column existed. SQLite has no

--- a/packages/db/src/repo.ts
+++ b/packages/db/src/repo.ts
@@ -2,8 +2,11 @@ import { desc, eq } from "drizzle-orm";
 import {
 	agentEvents,
 	agentSessions,
+	type BoardChange,
+	boardChanges,
 	type Loop,
 	loops,
+	type NewBoardChange,
 	type NewLoop,
 	type NewProject,
 	type NewTask,
@@ -154,5 +157,19 @@ export const repo = {
 
 	deleteLoop(db: AteamDb, id: string) {
 		db.delete(loops).where(eq(loops.id, id)).run();
+	},
+
+	// ---- board changes (organizer audit trail) ----
+	recordBoardChange(db: AteamDb, c: NewBoardChange): BoardChange {
+		return db.insert(boardChanges).values(c).returning().get();
+	},
+
+	/** Most-recent-first audit of organizer moves; optionally scoped to one task. */
+	listBoardChanges(db: AteamDb, opts: { taskId?: string; limit?: number } = {}): BoardChange[] {
+		const q = db.select().from(boardChanges);
+		const rows = (opts.taskId ? q.where(eq(boardChanges.taskId, opts.taskId)) : q)
+			.orderBy(desc(boardChanges.createdAt))
+			.all();
+		return opts.limit ? rows.slice(0, opts.limit) : rows;
 	},
 };

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -202,6 +202,30 @@ export const loops = sqliteTable(
 	(t) => [index("loops_definition_idx").on(t.definitionId)],
 );
 
+/**
+ * Audit trail for board moves made by the agent-driven Board Organizer loop.
+ * Every applied `set_status` writes one row so a misfiled card is always
+ * traceable (and reversible): what moved, from where to where, and the
+ * organizer's stated reason. Only APPROVED moves land here — rejections are
+ * dropped by the guardrail before this point.
+ */
+export const boardChanges = sqliteTable(
+	"board_changes",
+	{
+		id: pk(),
+		taskId: text("task_id")
+			.notNull()
+			.references(() => tasks.id, { onDelete: "cascade" }),
+		fromColumn: text("from_column").$type<KanbanColumn>().notNull(),
+		toColumn: text("to_column").$type<KanbanColumn>().notNull(),
+		reason: text("reason").notNull(),
+		/** Who made the move — the organizer today; leaves room for other sources. */
+		source: text("source").notNull().default("organizer"),
+		createdAt: epochMs("created_at"),
+	},
+	(t) => [index("board_changes_task_idx").on(t.taskId)],
+);
+
 export { sql };
 
 export type Project = typeof projects.$inferSelect;
@@ -214,3 +238,5 @@ export type AgentEvent = typeof agentEvents.$inferSelect;
 export type Settings = typeof settings.$inferSelect;
 export type Loop = typeof loops.$inferSelect;
 export type NewLoop = typeof loops.$inferInsert;
+export type BoardChange = typeof boardChanges.$inferSelect;
+export type NewBoardChange = typeof boardChanges.$inferInsert;


### PR DESCRIPTION
Foundation for native agent-driven loops (distinct from the reconciler loops):

- Board MCP server on the hook server's /mcp endpoint (Streamable HTTP:
  POST→JSON, GET→405, no SSE/SDK/subprocess). Exposes get_board + set_status.
- Guardrail (board-organizer.ts): only todo/review are tool-assignable;
  running/needs_attention/merged are programmatic. The organizer can't touch a
  live-agent card; a session may move its OWN card (self-move, keyed off its
  terminal id). Every applied move is audited in a new board_changes table.
- Done-detection (worktree-triage.ts): richer done-vs-ongoing than the
  reconciler's merged-PR check — recent activity, conversation-past-merge,
  dirty / ahead / open-PR, patch-equivalence, not-started. Ported from the
  triage-worktrees skill.
- Shared agent-loop brain (agent-loop.ts) for the in-session loop family.
- Done button: a Review task's terminal toolbar moves it to Done; setColumn
  now broadcasts a task update.
- Extract session-liveness helper; board-reconciler reuses it.

Backend smoke-tested end-to-end over real HTTP; full desktop typecheck + tests green.
