### PR TITLE
chore: release 0.1.25 — fix arm64 native module + startup guard

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {

--- a/apps/desktop/scripts/package-mac.sh
+++ b/apps/desktop/scripts/package-mac.sh
@@ -67,6 +67,20 @@ cp "$DESKTOP_DIR/electron-builder.yml" "$STAGE/"
 echo "==> electron-builder (sign + notarize + dmg + zip)"
 ( cd "$STAGE" && ./node_modules/.bin/electron-builder --mac --arm64 )
 
+# 4b. Fail loudly if the packaged native module isn't arm64. npmRebuild is off
+#     (electron-builder trusts the prebuilt modules), and step 2's rebuild is
+#     skipped whenever the staging node_modules already exists — so a stale
+#     x86_64 better-sqlite3 in the cache silently ships an app that dlopen()s
+#     the wrong arch and launches with no window. This shipped as 0.1.24.
+NODE_MODULE="$STAGE/release/mac-arm64/Ateam.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+if ! file "$NODE_MODULE" | grep -q "arm64"; then
+  echo "ERROR: packaged better_sqlite3.node is not arm64 — refusing to ship." >&2
+  file "$NODE_MODULE" >&2
+  echo "Fix: wipe the staging dir so the arm64 rebuild reruns (rm -rf \"$STAGE/node_modules\")." >&2
+  exit 1
+fi
+echo "==> native module arch OK (arm64)"
+
 echo "==> Gatekeeper check"
 spctl -a -vv -t install "$STAGE/release/mac-arm64/Ateam.app" 2>&1 | tail -2
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -522,6 +522,18 @@ app.whenReady().then(async () => {
 	app.on("activate", () => {
 		if (BrowserWindow.getAllWindows().length === 0) createWindow();
 	});
+}).catch((err) => {
+	// A startup failure (e.g. a native module built for the wrong CPU arch)
+	// would otherwise leave a live process with no window and no feedback —
+	// exactly the "click the app, nothing happens" symptom. Surface it and quit.
+	console.error("[ateam] startup failed:", err);
+	dialog.showErrorBox(
+		"Ateam failed to start",
+		`${APP_NAME} couldn't start and needs to close.\n\n${
+			err instanceof Error ? (err.stack ?? err.message) : String(err)
+		}`,
+	);
+	app.exit(1);
 });
 
 app.on("window-all-closed", () => {


### PR DESCRIPTION
## Why

0.1.24 shipped an **x86_64** `better-sqlite3` native module inside an **arm64** app. On launch, `createDb()` → `dlopen` failed with *incompatible architecture*, the async `initServices()` promise rejected (no `.catch` on `app.whenReady().then(...)`), so `createWindow()` never ran — the app launched with **no window** and no error (a live, windowless process).

## Changes

- **arm64 native module**: rebuilt from a clean staging dir so the packaged `better_sqlite3.node` is arm64.
- **Startup guard**: `app.whenReady().then(...)` now has a `.catch` that shows an error dialog and quits — turns a silent windowless hang into a visible error.
- **Build guard**: `package-mac.sh` now asserts the packaged native module is arm64 and fails the build otherwise. Root cause was the staging cache reusing a stale x86_64 `better-sqlite3` because `npmRebuild` is off and the rebuild step only checked for the builder binaries, not the module arch.

Built, signed, notarized, and verified opening on arm64 before publishing.