### PR TITLE
feat(desktop): open a project in its own window

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -17,8 +17,22 @@ import { MergeQueue } from "./merge-queue";
 import { PtyClient } from "./pty/pty-client";
 import { type Services, toTaskDTO } from "./services";
 
-let win: BrowserWindow | null = null;
+// Every live window and the project it's pinned to: null = the main
+// multi-project dashboard, a projectId = a detached single-project window.
+// Multiplexing projects across windows lets you spread them over macOS Spaces.
+const windowProject = new Map<BrowserWindow, string | null>();
 let services: Services | null = null;
+
+/**
+ * Push an event to every live window. The renderers already filter by their own
+ * state (tasksByProject, mounted terminalIds), so a detached project window and
+ * the dashboard both stay consistent while each keeps only what it cares about.
+ */
+function broadcast(channel: string, ...args: unknown[]): void {
+	for (const w of windowProject.keys()) {
+		if (!w.isDestroyed()) w.webContents.send(channel, ...args);
+	}
+}
 
 const SMOKE = process.env.ATEAM_SMOKE === "1";
 
@@ -278,12 +292,18 @@ function buildAppMenu(): void {
 function sendTaskUpdated(taskId: string): void {
 	if (!services) return;
 	const task = repo.getTask(services.db, taskId);
-	if (task) win?.webContents.send(CH.evtTaskUpdated, toTaskDTO(task));
+	if (task) broadcast(CH.evtTaskUpdated, toTaskDTO(task));
+}
+
+// A task was deleted (single remove or cleanup) — tell every window to drop it,
+// so a stale card can't linger in another window showing the same project.
+function sendTaskRemoved(taskId: string): void {
+	broadcast(CH.evtTaskRemoved, taskId);
 }
 
 function sendLoopsUpdated(): void {
 	if (!services) return;
-	win?.webContents.send(CH.evtLoopsUpdated, services.loopRunner.describe());
+	broadcast(CH.evtLoopsUpdated, services.loopRunner.describe());
 }
 
 async function initServices(): Promise<Services> {
@@ -339,10 +359,12 @@ async function initServices(): Promise<Services> {
 		loopRunner,
 	};
 
-	// PTY output/exit → renderer.
-	pty.on("data", (e) => win?.webContents.send(CH.evtPtyData, e));
+	// PTY output/exit → renderer. shortcut: broadcast to every window; a detached
+	// window ignores terminals it hasn't mounted. If PTY throughput ever makes
+	// this wasteful, route by terminalId → session → project instead.
+	pty.on("data", (e) => broadcast(CH.evtPtyData, e));
 	pty.on("exit", (e) => {
-		win?.webContents.send(CH.evtPtyExit, e);
+		broadcast(CH.evtPtyExit, e);
 		// Record the exit in the DB so a session is never left looking "running"
 		// after its process is gone — the gap that previously stranded cards in
 		// the running column (the board reconciler is the backstop for exits we
@@ -440,8 +462,9 @@ async function initServices(): Promise<Services> {
 	return svc;
 }
 
-function createWindow(): void {
-	win = new BrowserWindow({
+// A detached window is pinned to `projectId`; the dashboard passes undefined.
+function createWindow(projectId?: string): BrowserWindow {
+	const win = new BrowserWindow({
 		width: 1400,
 		height: 900,
 		minWidth: 900,
@@ -455,16 +478,35 @@ function createWindow(): void {
 			contextIsolation: true,
 		},
 	});
+	windowProject.set(win, projectId ?? null);
 
+	// Pin the project by stamping the renderer URL; the preload reads it back via
+	// window.boundProjectId(). A hash keeps loadFile working (no querystring file).
+	const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
 	if (process.env.ELECTRON_RENDERER_URL) {
-		void win.loadURL(process.env.ELECTRON_RENDERER_URL);
+		void win.loadURL(`${process.env.ELECTRON_RENDERER_URL}${query}`);
 	} else {
-		void win.loadFile(join(__dirname, "../renderer/index.html"));
+		void win.loadFile(join(__dirname, "../renderer/index.html"), {
+			search: query || undefined,
+		});
 	}
 
 	win.on("closed", () => {
-		win = null;
+		windowProject.delete(win);
 	});
+	return win;
+}
+
+// Detach a project into its own window, or focus the one already showing it.
+function openProjectWindow(projectId: string): void {
+	for (const [w, pid] of windowProject) {
+		if (pid === projectId && !w.isDestroyed()) {
+			if (w.isMinimized()) w.restore();
+			w.focus();
+			return;
+		}
+	}
+	createWindow(projectId);
 }
 
 app.whenReady().then(async () => {
@@ -491,9 +533,11 @@ app.whenReady().then(async () => {
 	registerIpc({
 		services,
 		sendTaskUpdated,
+		sendTaskRemoved,
 		mergeQueue: services.mergeQueue,
 		loopRunner: services.loopRunner,
 		sendLoopsUpdated,
+		openProjectWindow,
 	});
 
 	if (SMOKE) {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -35,10 +35,14 @@ import { type Services, toProjectDTO, toSessionDTO, toTaskDTO } from "./services
 export interface IpcContext {
 	services: Services;
 	sendTaskUpdated: (taskId: string) => void;
+	/** Broadcast a task removal to every window. */
+	sendTaskRemoved: (taskId: string) => void;
 	mergeQueue: MergeQueue;
 	loopRunner: LoopRunner;
 	/** Push the current loop list to the renderer. */
 	sendLoopsUpdated: () => void;
+	/** Detach a project into its own window (or focus its existing one). */
+	openProjectWindow: (projectId: string) => void;
 }
 
 /** Project display name from the repo's README H1 (md or HTML), if present. */
@@ -104,7 +108,15 @@ function stageImageOnClipboard(path: string | null): boolean {
 }
 
 export function registerIpc(ctx: IpcContext): void {
-	const { services, sendTaskUpdated, mergeQueue, loopRunner, sendLoopsUpdated } = ctx;
+	const {
+		services,
+		sendTaskUpdated,
+		sendTaskRemoved,
+		mergeQueue,
+		loopRunner,
+		sendLoopsUpdated,
+		openProjectWindow,
+	} = ctx;
 	const { db } = services;
 
 	// ---- projects ----
@@ -141,6 +153,10 @@ export function registerIpc(ctx: IpcContext): void {
 		repo.deleteProject(db, id);
 	});
 
+	ipcMain.handle(CH.windowOpenProject, async (_e, projectId: string) => {
+		openProjectWindow(projectId);
+	});
+
 	// ---- tasks ----
 	ipcMain.handle(CH.tasksList, async (_e, projectId: string) =>
 		repo.listTasks(db, projectId).map(toTaskDTO),
@@ -164,6 +180,9 @@ export function registerIpc(ctx: IpcContext): void {
 				baseBranch: created.baseBranch,
 				worktreePath: created.worktreePath,
 			});
+			// Broadcast so any other window showing this project gains the new card
+			// (renderers upsert). The caller also gets it — an idempotent upsert.
+			sendTaskUpdated(row.id);
 			return toTaskDTO(row);
 		},
 	);
@@ -185,6 +204,8 @@ export function registerIpc(ctx: IpcContext): void {
 				force: input.force,
 			});
 			repo.deleteTask(db, task.id);
+			// Drop the card from every window (not just the caller's).
+			sendTaskRemoved(task.id);
 		},
 	);
 
@@ -303,6 +324,7 @@ export function registerIpc(ctx: IpcContext): void {
 					force: false,
 				});
 				repo.deleteTask(db, task.id);
+				sendTaskRemoved(task.id);
 				removed.push({ id: task.id, name: task.name, branch: task.branch });
 			} catch (err) {
 				kept.push({ task, reason: errorMessage(err) });

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -82,6 +82,16 @@ const api: AteamApi = {
 			ipcRenderer.on(CH.evtTaskUpdated, handler);
 			return () => ipcRenderer.off(CH.evtTaskUpdated, handler);
 		},
+		onTaskRemoved: (cb: (taskId: string) => void) => {
+			const handler = (_: unknown, taskId: string) => cb(taskId);
+			ipcRenderer.on(CH.evtTaskRemoved, handler);
+			return () => ipcRenderer.off(CH.evtTaskRemoved, handler);
+		},
+	},
+	window: {
+		openProject: (projectId) => ipcRenderer.invoke(CH.windowOpenProject, projectId),
+		// The main process stamps ?projectId=<id> onto a detached window's URL.
+		boundProjectId: () => new URLSearchParams(window.location.search).get("projectId"),
 	},
 };
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import {
 	ChevronRight,
 	Columns2,
 	Database,
+	ExternalLink,
 	FilePen,
 	FlaskConical,
 	FolderPlus,
@@ -108,6 +109,9 @@ const STATUS_RANK: Record<KanbanColumn, number> = {
 const springy = { type: "spring", stiffness: 550, damping: 42 } as const;
 
 export function App() {
+	// Non-null in a detached window: this window is pinned to one project and
+	// hides the project switcher; null in the main multi-project dashboard.
+	const boundProjectId = useMemo(() => window.ateam.window.boundProjectId(), []);
 	const [projects, setProjects] = useState<ProjectDTO[]>([]);
 	const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
 	const [tasksByProject, setTasksByProject] = useState<Record<string, TaskDTO[]>>({});
@@ -157,23 +161,44 @@ export function App() {
 
 	const loadProjects = useCallback(async () => {
 		const list = await window.ateam.projects.list();
-		setProjects(list);
-		setActiveProjectId((cur) => cur ?? list[0]?.id ?? null);
-	}, []);
+		// A detached window shows only its pinned project.
+		const scoped = boundProjectId ? list.filter((p) => p.id === boundProjectId) : list;
+		setProjects(scoped);
+		setActiveProjectId((cur) => boundProjectId ?? cur ?? scoped[0]?.id ?? null);
+	}, [boundProjectId]);
 
 	useEffect(() => {
 		void loadProjects();
 		void window.ateam.agents.list().then(setAgents);
-		const off = window.ateam.events.onTaskUpdated((updated) => {
+		// Upsert: replace a known task, or add one created in another window (so a
+		// project open in two windows stays consistent). Only for projects this
+		// window tracks — a detached window ignores other projects' tasks.
+		const offUpdated = window.ateam.events.onTaskUpdated((updated) => {
+			setTasksByProject((prev) => {
+				const list = prev[updated.projectId];
+				if (!list) return prev;
+				const nextList = list.some((t) => t.id === updated.id)
+					? list.map((t) => (t.id === updated.id ? updated : t))
+					: [...list, updated];
+				return { ...prev, [updated.projectId]: nextList };
+			});
+		});
+		// Removal (delete/cleanup) from any window — drop the card everywhere and
+		// clear the selection if it was pointing at the now-gone task.
+		const offRemoved = window.ateam.events.onTaskRemoved((taskId) => {
 			setTasksByProject((prev) => {
 				const next: Record<string, TaskDTO[]> = {};
 				for (const [pid, list] of Object.entries(prev)) {
-					next[pid] = list.map((t) => (t.id === updated.id ? updated : t));
+					next[pid] = list.filter((t) => t.id !== taskId);
 				}
 				return next;
 			});
+			setSelectedTaskId((cur) => (cur === taskId ? null : cur));
 		});
-		return off;
+		return () => {
+			offUpdated();
+			offRemoved();
+		};
 	}, [loadProjects]);
 
 	// Load the selected project's tasks whenever it changes.
@@ -186,6 +211,14 @@ export function App() {
 	useEffect(() => {
 		for (const p of projects) void loadTasks(p.id);
 	}, [projects, loadTasks]);
+
+	// A detached window takes its pinned project's name as the OS window title, so
+	// the windows are tellable apart across desktops/Spaces.
+	useEffect(() => {
+		if (!boundProjectId) return;
+		const p = projects.find((x) => x.id === boundProjectId);
+		if (p) document.title = p.name;
+	}, [boundProjectId, projects]);
 
 	// Highest-priority alert among a non-selected project's tasks.
 	const projectAlert = (pid: string): "needs_attention" | "review" | null => {
@@ -362,8 +395,11 @@ export function App() {
 									type="button"
 									key={p.id}
 									className={`rail-tile ${p.id === activeProjectId ? "active" : ""}`}
-									title={p.name}
+									title={boundProjectId ? p.name : `${p.name} — double-click to open in new window`}
 									onClick={() => selectProject(p.id)}
+									onDoubleClick={
+										boundProjectId ? undefined : () => window.ateam.window.openProject(p.id)
+									}
 								>
 									{p.name.charAt(0).toUpperCase()}
 									{alert && <span className={`corner pulse ${alert}`} />}
@@ -422,20 +458,40 @@ export function App() {
 							projects.map((p) => {
 								const alert = projectAlert(p.id);
 								return (
-									<button
-										type="button"
+									// Double-click (or the hover button) detaches the project into its
+									// own window. Row and open-button are siblings so the button's
+									// click can't nest inside the row button.
+									<div
 										key={p.id}
-										className={`proj ${p.id === activeProjectId ? "active" : ""}`}
-										onClick={() => selectProject(p.id)}
+										className="proj-row"
+										onDoubleClick={
+											boundProjectId ? undefined : () => window.ateam.window.openProject(p.id)
+										}
 									>
-										<span
-											className={`dot ${alert ? `alert ${alert}` : ""}`}
-											style={!alert && p.color ? { background: p.color } : undefined}
-										/>
-										<span className="proj-name" title={p.repoPath}>
-											{p.name}
-										</span>
-									</button>
+										<button
+											type="button"
+											className={`proj ${p.id === activeProjectId ? "active" : ""}`}
+											onClick={() => selectProject(p.id)}
+										>
+											<span
+												className={`dot ${alert ? `alert ${alert}` : ""}`}
+												style={!alert && p.color ? { background: p.color } : undefined}
+											/>
+											<span className="proj-name" title={p.repoPath}>
+												{p.name}
+											</span>
+										</button>
+										{!boundProjectId && (
+											<span className="proj-open">
+												<IconButton
+													icon={ExternalLink}
+													label="Open in new window"
+													size={14}
+													onClick={() => window.ateam.window.openProject(p.id)}
+												/>
+											</span>
+										)}
+									</div>
 								);
 							})}
 

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -255,6 +255,23 @@ input {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+/* Project row = the selectable button + a hover-revealed "open in new window"
+   button overlaid at the right. */
+.proj-row {
+	position: relative;
+}
+.proj-open {
+	position: absolute;
+	right: 6px;
+	top: 50%;
+	transform: translateY(-50%);
+	opacity: 0;
+	transition: opacity 0.12s ease;
+}
+.proj-row:hover .proj-open,
+.proj-open:focus-within {
+	opacity: 1;
+}
 
 /* tasks accordion: VSCode-explorer-style file rows */
 .tasks-head {

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -180,6 +180,7 @@ export const CH = {
 	projectsRegister: "projects:register",
 	projectsList: "projects:list",
 	projectsRemove: "projects:remove",
+	windowOpenProject: "window:openProject",
 	tasksList: "tasks:list",
 	tasksCreate: "tasks:create",
 	tasksRemove: "tasks:remove",
@@ -215,6 +216,7 @@ export const CH = {
 	evtPtyData: "evt:pty:data",
 	evtPtyExit: "evt:pty:exit",
 	evtTaskUpdated: "evt:task:updated",
+	evtTaskRemoved: "evt:task:removed",
 	evtLoopsUpdated: "evt:loops:updated",
 } as const;
 
@@ -307,7 +309,23 @@ export interface AteamApi {
 		onExit(cb: (e: PtyExitEvent) => void): () => void;
 	};
 	events: {
+		/** A task was created or changed — upsert it (add if new, replace if known). */
 		onTaskUpdated(cb: (task: TaskDTO) => void): () => void;
+		/** A task was removed (delete or cleanup) — drop it from every window. */
+		onTaskRemoved(cb: (taskId: string) => void): () => void;
+	};
+	window: {
+		/**
+		 * Detach a project into its own OS window (to spread projects across
+		 * desktops/Spaces). If a window is already bound to this project it's
+		 * focused instead of duplicated.
+		 */
+		openProject(projectId: string): Promise<void>;
+		/**
+		 * The project this window is pinned to, or null for the main multi-project
+		 * dashboard. Read once at boot from the window's launch URL.
+		 */
+		boundProjectId(): string | null;
 	};
 	utils: {
 		/**


### PR DESCRIPTION
Detach any project into a separate OS window (hover button or double-click
a project tile) to spread projects across desktops/Spaces. Re-opening a
project focuses its existing window instead of duplicating it. Each detached
window is pinned and scoped to one project via a ?projectId= launch param.

Replaces the single-window singleton with a window→project registry and
broadcasts task/loop/PTY events to every window (renderers filter by their
own state). Completes cross-window task sync: create/remove/cleanup now
broadcast so a project open in two windows stays consistent (renderers
upsert on update, drop on the new evt:task:removed).
