### PR TITLE
make terminal Done action a compact right-aligned text button

### DIFF
--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -1,8 +1,7 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
-import { Check, FileUp, ImageUp, Plus } from "lucide-react";
+import { FileUp, ImageUp, Plus } from "lucide-react";
 import { useEffect, useRef } from "react";
-import { IconButton } from "./IconButton";
 import { Menu } from "./Menu";
 
 /**
@@ -317,7 +316,9 @@ export function TerminalView({
 					]}
 				/>
 				{showDone && (
-					<IconButton icon={Check} label="Mark task Done" variant="primary" onClick={onDone} />
+					<button type="button" className="term-done primary" onClick={onDone}>
+						Done
+					</button>
 				)}
 			</div>
 		</div>

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -579,6 +579,17 @@ input {
 	flex: none;
 }
 
+/* "Done" action: compact so it clears the toolbar's top/bottom edges,
+   pushed to the far right of the bar. */
+.term-done {
+	margin-left: auto;
+	padding: 1px 10px;
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 18px;
+	border-radius: 5px;
+}
+
 /* +N -N stat on the right of the actions bar; opens the changes view */
 .diffstat {
 	display: inline-flex;


### PR DESCRIPTION
Replace the check-icon IconButton in the terminal toolbar with a plain
'Done' text button (no icon), shrink it so it clears the toolbar's top
and bottom edges, and push it to the far right via margin-left:auto.
