### PR TITLE
chore: release 0.1.26

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {


### PR DESCRIPTION
Release 0.1.26 — bundles the unreleased work on main since v0.1.25: open a project in its own window (#39), compact right-aligned Done button (#40), full-width Mission Control tiles (#41).