### PR TITLE
fix: ship arm64 native modules + real arch guard (0.1.27)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {

--- a/apps/desktop/scripts/package-mac.sh
+++ b/apps/desktop/scripts/package-mac.sh
@@ -43,6 +43,33 @@ cat > "$STAGE/package.json" <<JSON
 }
 JSON
 
+# Fail unless every compiled native module under $1 is a single-arch arm64
+# binary. Scans only `*/build/Release/*.node` — the electron-rebuild output that
+# actually gets dlopen()ed on darwin-arm64 — and deliberately skips the
+# `prebuilds/` tree node-pty ships (win32-*/darwin-x64 binaries that are never
+# loaded on this platform). Uses `lipo -archs`, which prints ONLY the arch(s)
+# ("arm64" / "x86_64" / a fat "x86_64 arm64") — never the path. The old check
+# `file "$f" | grep arm64` false-passed because `file` echoes the path, which
+# contains "mac-arm64"; that no-op guard is why x86_64 shipped in 0.1.24 + 0.1.26.
+assert_arm64_nodes() {
+  local root="$1" f archs bad=0 n=0
+  while IFS= read -r f; do
+    n=$((n + 1))
+    archs="$(lipo -archs "$f" 2>/dev/null || true)"
+    if [ "$archs" != "arm64" ]; then
+      echo "   !! $f is [${archs:-unknown}], expected arm64" >&2
+      bad=1
+    fi
+  done < <(find "$root" -path '*/build/Release/*.node' 2>/dev/null)
+  # A zero-match scan means the module layout changed — fail closed rather than
+  # green-light a build we never actually verified.
+  if [ "$n" -eq 0 ]; then
+    echo "   !! no build/Release/*.node found under $root" >&2
+    bad=1
+  fi
+  return $bad
+}
+
 # 2. Install + rebuild native modules for Electron's arm64 ABI. Recreated when
 #    the install is missing or incomplete (e.g. a partial install left behind by
 #    a wiped/interrupted run) — checks for the actual binaries it needs.
@@ -52,8 +79,20 @@ if [ ! -x "$STAGE/node_modules/.bin/electron-builder" ] ||
   echo "==> npm install (first run / staging cleared or incomplete)"
   rm -rf "$STAGE/node_modules" "$STAGE/package-lock.json"
   ( cd "$STAGE" && npm install --no-audit --no-fund )
-  echo "==> electron-rebuild better-sqlite3 + node-pty (arm64)"
-  ( cd "$STAGE" && ./node_modules/.bin/electron-rebuild -f -w better-sqlite3,node-pty --arch arm64 )
+fi
+
+# electron-rebuild is idempotent and cheap once the toolchain is warm, so run it
+# every build — NOT only when node_modules was just created. A pre-existing
+# staging dir can hold a stale/wrong-arch prebuild (npm fetches a host-arch,
+# Node-ABI binary; only electron-rebuild produces the arm64 Electron-ABI one).
+# Then verify: if the staged modules still aren't arm64, abort before we sign.
+echo "==> electron-rebuild better-sqlite3 + node-pty (arm64)"
+( cd "$STAGE" && ./node_modules/.bin/electron-rebuild -f -w better-sqlite3,node-pty --arch arm64 )
+if ! assert_arm64_nodes "$STAGE/node_modules/better-sqlite3" ||
+   ! assert_arm64_nodes "$STAGE/node_modules/node-pty"; then
+  echo "FATAL: staged native modules are not arm64 after electron-rebuild." >&2
+  echo "       Is 'node' running under Rosetta? (arch: $(node -p process.arch))" >&2
+  exit 1
 fi
 
 # 3. Fresh production bundle, copied into staging.
@@ -67,19 +106,17 @@ cp "$DESKTOP_DIR/electron-builder.yml" "$STAGE/"
 echo "==> electron-builder (sign + notarize + dmg + zip)"
 ( cd "$STAGE" && ./node_modules/.bin/electron-builder --mac --arm64 )
 
-# 4b. Fail loudly if the packaged native module isn't arm64. npmRebuild is off
-#     (electron-builder trusts the prebuilt modules), and step 2's rebuild is
-#     skipped whenever the staging node_modules already exists — so a stale
-#     x86_64 better-sqlite3 in the cache silently ships an app that dlopen()s
-#     the wrong arch and launches with no window. This shipped as 0.1.24.
-NODE_MODULE="$STAGE/release/mac-arm64/Ateam.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
-if ! file "$NODE_MODULE" | grep -q "arm64"; then
-  echo "ERROR: packaged better_sqlite3.node is not arm64 — refusing to ship." >&2
-  file "$NODE_MODULE" >&2
+# 4b. Hard gate: every native module packaged into the .app must be arm64.
+#     Signing, notarization and the spctl check below are all arch-agnostic and
+#     will happily bless an x86_64 module that then dlopen()-crashes on every
+#     Apple Silicon Mac — so this is the last line of defense before publish.
+echo "==> Architecture check (native modules must be arm64)"
+if ! assert_arm64_nodes "$STAGE/release/mac-arm64/Ateam.app"; then
+  echo "FATAL: packaged .app contains non-arm64 native modules — refusing to ship." >&2
   echo "Fix: wipe the staging dir so the arm64 rebuild reruns (rm -rf \"$STAGE/node_modules\")." >&2
   exit 1
 fi
-echo "==> native module arch OK (arm64)"
+echo "   ok: all *.node in Ateam.app are arm64"
 
 echo "==> Gatekeeper check"
 spctl -a -vv -t install "$STAGE/release/mac-arm64/Ateam.app" 2>&1 | tail -2


### PR DESCRIPTION
## Problem

v0.1.26 (and 0.1.24) shipped an **x86_64** \`better_sqlite3.node\`. On Apple Silicon the app can't \`dlopen\` it and **crashes on launch** with an "incompatible architecture" error — before any window appears. This affects every arm64 user.

## Root causes

1. **Rebuild skipped on warm cache.** `electron-rebuild --arch arm64` only ran when the staging `node_modules` was first created; on a warm/polluted staging dir a stale wrong-arch prebuild shipped unchanged (`npmRebuild: false` means electron-builder trusts whatever is there).
2. **The arch guard was a no-op.** The post-build check was `file "$path" | grep -q arm64`. Since `file` echoes the path — which contains `mac-arm64` — the grep matched for *any* architecture, so x86_64 sailed through signing, notarization, and the `spctl` Gatekeeper check. This is why the guard added after 0.1.24 didn't stop 0.1.26.

## Fix

- Run `electron-rebuild` on **every** build, then verify the staged `build/Release/*.node` are arm64 before signing (fail-closed, flags Rosetta).
- Replace the broken guard with `lipo -archs` (prints arch only, never the path), scoped to the `build/Release/*.node` that actually loads, and fail-closed if it matches nothing.
- Bump `0.1.26 → 0.1.27`.

## Verification

Built + signed + **notarized + stapled** locally; Gatekeeper = Notarized Developer ID. Independently confirmed every darwin-loadable `*.node` in the packaged `.app` is arm64.