### PR TITLE
chore: release 0.1.28

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {


### PR DESCRIPTION
Bump to 0.1.28. Ships #44 (detached project header), #45–48, #49 (remote-terminal over SSH), #50 (daemon single-instance).