### PR TITLE
fix(desktop): swap task status dot and delete icon in a shared slot

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -804,8 +804,9 @@ function TaskRow({
 	onDelete: () => void;
 }) {
 	const Icon = taskIcon(t.name);
-	// Row and delete button are siblings so the trash click can't nest inside
-	// the row button (same pattern as proj-row / proj-open above).
+	// Row and trailing slot are siblings so the trash click can't nest inside the
+	// row button (same pattern as proj-row / proj-open above). The status dot and
+	// delete button share the trailing slot and swap in place on hover.
 	return (
 		<div className="tasknode-row">
 			<button
@@ -821,9 +822,9 @@ function TaskRow({
 					<Icon className="ticon" size={14} strokeWidth={1.75} />
 				)}
 				<span className="tname">{t.name}</span>
-				{t.agentStatus && <span className={`tstatus ${t.agentStatus}`} />}
 			</button>
-			<span className="task-del">
+			<span className="task-trail">
+				{t.agentStatus && <span className={`tstatus ${t.agentStatus}`} />}
 				<IconButton icon={Trash2} label="Delete task" variant="danger" size={14} onClick={onDelete} />
 			</span>
 		</div>

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -299,17 +299,36 @@ input {
 .tasknode-row {
 	position: relative;
 }
-.task-del {
+/* Trailing slot: the status dot and delete button occupy the same cell and swap
+   in place — dot at rest, trash on hover/focus — so neither covers the other. */
+.task-trail {
 	position: absolute;
 	right: 6px;
 	top: 50%;
 	transform: translateY(-50%);
-	opacity: 0;
+	display: grid;
+	place-items: center end;
+}
+.task-trail > * {
+	grid-area: 1 / 1;
 	transition: opacity 0.12s ease;
 }
-.tasknode-row:hover .task-del,
-.task-del:focus-within {
+/* Nudge the small dot off the very edge so it lands where it did before. */
+.task-trail .tstatus {
+	margin-right: 8px;
+}
+.task-trail .iconbtn {
+	opacity: 0;
+	pointer-events: none;
+}
+.tasknode-row:hover .task-trail .iconbtn,
+.task-trail:focus-within .iconbtn {
 	opacity: 1;
+	pointer-events: auto;
+}
+.tasknode-row:hover .task-trail .tstatus,
+.task-trail:focus-within .tstatus {
+	opacity: 0;
 }
 .tasknode {
 	display: flex;


### PR DESCRIPTION
The hover-revealed trash button overlaid the status dot at the row's
right edge. Move both into one trailing grid cell so they occupy the
same spot and swap in place on hover/focus — dot at rest, trash on
hover — with neither covering the other.
