### PR TITLE
Ship only arm64 node-pty prebuilds in the macOS bundle

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -22,6 +22,12 @@ publish:
   owner: clawnify
   repo: ateam
 mac:
+  # node-pty ships prebuilds for every platform/arch, but only ever loads the one
+  # matching the running process. Shipping its darwin-x64 pty.node + spawn-helper
+  # made macOS flag Ateam as an Intel app ("Support Ending for Intel-Based Apps"),
+  # so keep only this build's own arch and drop the rest as dead weight.
+  files:
+    - "!**/node_modules/node-pty/prebuilds/!(darwin-${arch}){,/**/*}"
   target:
     - target: dmg
       arch:


### PR DESCRIPTION
macOS flagged Ateam with "Support Ending for Intel-Based Apps". The app
itself was already fully arm64 — the only x86_64 Mach-O files in the whole
bundle were node-pty's unused darwin-x64 pty.node and spawn-helper, packed
wholesale by the asarUnpack rule for node_modules/node-pty.

node-pty resolves build/Release first (the arm64 binaries electron-rebuild
produces), so the prebuilds for other platforms were never loaded. Exclude
every prebuild dir except darwin-${arch}, which also drops the win32 ones.
Verified on a real --mac --arm64 build: zero non-arm64 Mach-O in the bundle,
node-pty still loads from build/Release, app boots.
