### PR TITLE
Server: one-line VPS installer, optional systemd service, and a public setup skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+	"name": "ateam",
+	"description": "Skills for Ateam — running its coding agents on your own server.",
+	"owner": {
+		"name": "Clawnify",
+		"url": "https://github.com/clawnify"
+	},
+	"plugins": [
+		{
+			"name": "ateam",
+			"description": "Prepare a Linux VPS to run Ateam's agents and connect the desktop app to it.",
+			"source": "./",
+			"category": "productivity"
+		}
+	]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+	"name": "ateam",
+	"description": "Skills for running Ateam's agents on your own server.",
+	"version": "0.1.0",
+	"author": {
+		"name": "Clawnify",
+		"url": "https://github.com/clawnify"
+	},
+	"homepage": "https://github.com/clawnify/ateam",
+	"license": "GPL-3.0-or-later"
+}

--- a/README.md
+++ b/README.md
@@ -71,6 +71,61 @@ public ports. On the box:
 curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash
 ```
 
+<details>
+<summary><b>Start to finish on a fresh Hetzner box</b></summary>
+
+Create a **CX23** (x86) or **CAX11** (Arm64) — both 2 vCPU / 4 GB / 40 GB — on
+Ubuntu, with your SSH key attached. Agents are what eat the RAM: roughly a gigabyte
+per concurrent session, plus whatever your project's dev server and tests need.
+
+**As `root`,** make a user for the agents and join the tailnet:
+
+```bash
+adduser --gecos "" you && usermod -aG sudo you
+install -d -m 700 -o you -g you /home/you/.ssh
+cp ~/.ssh/authorized_keys /home/you/.ssh/ && chown you:you /home/you/.ssh/authorized_keys
+
+curl -fsSL https://tailscale.com/install.sh | sh && tailscale up
+tailscale ip -4                       # → 100.x.y.z
+```
+
+**Reconnect as that user over the tailnet** — `ssh you@100.x.y.z` — and only once
+that works, close the public door. Allow the whole `tailscale0` interface, not just
+port 22: `ufw`'s default input policy is DROP, so a port-22-only rule would block the
+port the iOS app needs.
+
+```bash
+sudo ufw allow in on tailscale0 && sudo ufw deny 22 && sudo ufw enable
+```
+
+**Then set the box up for agents.** Ateam commits, pushes and opens PRs as this user,
+so it needs a real git identity and a logged-in `gh`:
+
+```bash
+sudo apt install -y git gh
+git config --global user.name "you" && git config --global user.email "you@example.com"
+git config --global init.defaultBranch main
+gh auth login                                     # device code — works over SSH
+
+curl -fsSL https://claude.ai/install.sh | bash    # then run `claude` once to log in
+
+curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash
+```
+
+The installer ends with a readiness report — every line should be `[ok]`. Finally, on
+your **Mac**, add the box to `~/.ssh/config` with `HostName 100.x.y.z` and pick it in
+Ateam's connection switcher.
+
+**Also using the iOS app?** The phone can't start a daemon the way the desktop does
+over SSH, so install a service to keep one running:
+
+```bash
+export ATEAM_WS_ADDR=100.x.y.z:8787               # the box's OWN Tailscale IP
+curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash -s -- --service
+```
+
+</details>
+
 Full walkthrough, from a freshly bought VPS to a connected board:
 [`docs/online-ateam.md`](docs/online-ateam.md). If you use Claude Code, it can do the
 whole setup with you:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,26 @@ packages/server     Headless engine + daemon: run agents on a box over SSH / Web
 packages/panes      Pane/split layout types
 apps/desktop        Electron + React app (main · preload · renderer)
 apps/mobile         iOS client (Expo / React Native) — drive a box from your phone
+skills/             Claude Code skills for Ateam users (installable, see below)
+```
+
+## Run your agents on a server
+
+Ateam is local-first, but the same desktop app can point at a Linux box that runs the
+agents while your Mac stays a thin UI — over SSH on your Tailscale network, with no
+public ports. On the box:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash
+```
+
+Full walkthrough, from a freshly bought VPS to a connected board:
+[`docs/online-ateam.md`](docs/online-ateam.md). If you use Claude Code, it can do the
+whole setup with you:
+
+```
+/plugin marketplace add clawnify/ateam
+/plugin install ateam@ateam
 ```
 
 ## Develop

--- a/docs/online-ateam.md
+++ b/docs/online-ateam.md
@@ -31,47 +31,95 @@ and you re-attach to the same live sessions.
 ## Prerequisites
 
 - A Linux box you can SSH into (Hetzner, EC2, a home server, …).
-- **Node ≥ 22** on the box (`node --version`).
 - **Tailscale** installed on both the Mac and the box, joined to the **same tailnet**.
 - The **Ateam desktop app** on your Mac.
 
+## 0. Preparing a freshly bought VPS
+
+Skip this if you already have a box you work on. Starting from a provider's
+"create server" screen:
+
+**Size it for agents, not for the app.** Ubuntu 22.04/24.04, **4 GB RAM, 2 vCPU,
+40 GB disk** is a comfortable starting point (a Hetzner CX22 or equivalent). Each
+concurrent agent session wants roughly a gigabyte, plus whatever your project's own
+dev server and test runs need. x86_64 and arm64 both work.
+
+**Create a non-root user.** Agents run as this user, in its login shell, with its
+git and `gh` credentials — don't give them root.
+
+```bash
+adduser you && usermod -aG sudo you
+install -d -m 700 -o you -g you /home/you/.ssh
+cp ~/.ssh/authorized_keys /home/you/.ssh/ && chown you:you /home/you/.ssh/authorized_keys
+```
+
+**Close the public door.** A fresh VPS answers on port 22 from the entire internet.
+Once Tailscale is up (step 2), restrict SSH to the tailnet:
+
+```bash
+sudo ufw allow in on tailscale0    # everything, but only over the tailnet
+sudo ufw deny 22                   # nothing from the public internet
+sudo ufw enable
+```
+
+Two details matter. Allow the **whole `tailscale0` interface**, not just port 22 —
+`ufw enable` sets the default incoming policy to deny, so a port-22-only rule would
+also silently block the WebSocket port the iOS app needs (step 5). And run this only
+**after** confirming Tailscale works, or you'll lock yourself out of your own server.
+
+This is what makes the "no public ports" property below actually true.
+
+**Give the box a git identity and a GitHub login.** Ateam's agents commit, push, and
+open PRs as this user. Without an identity, every commit fails:
+
+```bash
+git config --global user.name  "you"
+git config --global user.email "you@example.com"
+git config --global init.defaultBranch main
+gh auth login          # device-code flow — works fine over SSH
+```
+
+**Install the agent CLIs you want** (e.g. `claude`) and log into each one once, in an
+interactive SSH session. The daemon only offers agents that are installed and on its
+**login-shell** PATH.
+
 ## 1. Install the `ateam` server on the box
 
-The server ships as a small standalone bundle. Build it on your Mac from the repo,
-copy it over, and install the two native modules on the box (they're prebuilt — the
-box needs no compiler).
-
-**On your Mac** (in the repo):
+One command, run **on the box as your non-root user**:
 
 ```bash
-cd packages/server
-bun run build                       # → dist/{cli.js, daemon.js, package.json}
-scp -r dist "<box>:~/ateam-app"     # <box> = your ssh host (see step 3)
+curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash
 ```
 
-**On the box:**
+It downloads the server bundle from the latest release, installs the two native
+modules (prebuilt — the box needs no compiler), puts an `ateam` launcher on your
+login-shell PATH, verifies the handshake, and finishes with a readiness report of
+the things it can't do for you (git identity, `gh`, agent CLIs, Tailscale). Nothing
+needs sudo; everything lands under your home directory.
+
+If the box has no Node, or one too new for the native module prebuilds, the installer
+installs **Node 22** via nvm into your home directory and uses that — the launcher
+pins the exact interpreter the modules were built for, so a later `nvm use` can't
+break it.
+
+Re-run the same command to upgrade. Three knobs, all optional:
+
+| Knob | Effect |
+| --- | --- |
+| `--service` | also install a `systemd --user` unit so the daemon survives logout and reboot (`… \| bash -s -- --service`). Required for the iOS app — see step 5. |
+| `ATEAM_VERSION=v0.1.30` | install a specific release instead of the latest |
+| `ATEAM_TARBALL=<url\|path>` | install from your own `ateam-server.tar.gz` (dev builds, air-gapped boxes) |
+
+<details>
+<summary>Installing from a local checkout instead</summary>
+
+If you're working on Ateam itself, `packages/server/scripts/install-remote.sh` builds
+the dist on your Mac and pushes it over SSH in one shot:
 
 ```bash
-cd ~/ateam-app
-npm install                         # fetches better-sqlite3 + prebuilt node-pty
-
-# put `ateam` on your login-shell PATH
-mkdir -p ~/.local/bin
-printf '#!/usr/bin/env bash\nexec node "$HOME/ateam-app/cli.js" "$@"\n' > ~/.local/bin/ateam
-chmod +x ~/.local/bin/ateam
+SSH_FLAGS="-i ~/.ssh/mykey" packages/server/scripts/install-remote.sh you@your-box
 ```
-
-Make sure `~/.local/bin` is on the PATH of a **login** shell (most distros add it in
-`~/.profile`). The desktop invokes the box as `bash -lc 'ateam …'`, so this is what
-matters. Verify from your Mac:
-
-```bash
-ssh <box> "bash -lc 'ateam'"
-# → usage: ateam <daemon | attach --stdio>
-```
-
-> Also install the agent CLIs you want to run on the box (e.g. `claude`) — the daemon
-> only exposes agents that are installed and on its PATH.
+</details>
 
 ## 2. Put the box on your tailnet
 
@@ -113,6 +161,68 @@ ssh my-ateam-box "bash -lc 'ateam'"
 4. Work as usual — new tasks, agents, terminals, and git all run **on the box**.
 5. Switch back to your Mac anytime via **This Mac**.
 
+## 5. Same box, from the iOS app
+
+The phone can't run `ssh`, so it speaks to the **same daemon** over a WebSocket
+instead — same engine, same agents, same worktrees, still only over your tailnet. The
+listener is **off by default**, and the phone needs the daemon to be **already
+running**: unlike the desktop it can't start one on demand, because the WebSocket only
+exists once a daemon is up.
+
+So the phone path is one install with both: the address to listen on, and a service
+to keep something listening.
+
+```bash
+export ATEAM_WS_ADDR=100.x.y.z:8787     # the box's OWN Tailscale IP
+curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash -s -- --service
+```
+
+That writes a `systemd --user` unit carrying `ATEAM_WS_ADDR`, enables lingering so it
+survives logout **and reboot**, and starts it. No sudo — enabling lingering for your
+own user is unprivileged.
+
+The address **must be the box's own `100.x`**: a wildcard bind (`0.0.0.0` / `::`) is
+refused and the daemon exits. This socket carries no auth of its own, exactly like
+the unix socket — the tailnet is the auth boundary.
+
+If a daemon is already running outside systemd, the installer will **not** kill it. It
+enables the service for next boot and prints the handover for you to run when it
+suits — your agents keep running across it:
+
+```bash
+pkill -f 'ateam-app/cli.js daemon' && systemctl --user start ateam
+```
+
+From then on, systemd owns the daemon:
+
+```bash
+systemctl --user restart ateam     # instead of pkill
+systemctl --user status ateam
+journalctl --user -u ateam -f      # → daemon also listening on ws://…
+```
+
+Restarting does **not** kill your running agents. The unit is `KillMode=process`, so
+only the RPC daemon is replaced; the detached PTY daemon holding every live session is
+deliberately left alone.
+
+**On the phone:** install **Tailscale** from the App Store, sign into the *same*
+tailnet, and make sure its VPN toggle is on. Then open Ateam Go, enter the box's
+Tailscale IP and port `8787`, and connect — the connection is remembered across
+launches. Allow the iOS **Local Network** prompt if it appears.
+
+Two things worth doing before you rely on this:
+
+- **Scope a Tailscale ACL** to just the devices that should reach the box. Every node
+  on your tailnet can reach an open port by default, and this port is an
+  unauthenticated engine.
+- **Understand what the phone holds.** There is no app lock yet, so an unlocked,
+  stolen phone on your tailnet is shell access to the box. Treat the tailnet as the
+  only thing standing between the two.
+
+> **Without `--service`**, nothing re-launches the daemon after a reboot. That's fine
+> for desktop-only use — `ssh … ateam attach` starts one on demand — but it strands a
+> phone, which has no way to start one. Install the service if you use the app.
+
 ## Troubleshooting
 
 The connection menu surfaces the real error inline. Common ones:
@@ -121,15 +231,18 @@ The connection menu surfaces the real error inline. Common ones:
 | --- | --- |
 | **"No servers in ~/.ssh/config"** in the menu | Add a `Host` entry (step 3). |
 | Connect hangs or fails | Check `ssh <box>` works, Tailscale is up on **both** ends (`tailscale status`), and `ateam` is on the box's login PATH: `ssh <box> "bash -lc 'command -v ateam'"`. |
-| **"Protocol mismatch"** | The Mac app and box server are different versions — rebuild & redeploy the box dist (step 1), or update the desktop app, so both speak the same protocol. |
+| **"Protocol mismatch"** | The Mac app and box server are different versions — re-run the installer on the box (step 1), or update the desktop app, so both speak the same protocol. |
 | Board is empty after connecting | The box has no registered projects yet — add one from the box's filesystem via **Add project** (or register a repo path on the box). |
+| Agents run but commits fail | The box has no git identity — `git config --global user.name/user.email` (step 0). |
+| The agent picker is empty | The agent CLI isn't on the box's **login** PATH: `ssh <box> "bash -lc 'command -v claude'"`. |
+| The iOS app won't connect | In order: is Tailscale's VPN toggle on on the phone; is a daemon running at all (`systemctl --user status ateam`); does it say `also listening on ws://…` (if not it started before `ATEAM_WS_ADDR` was set — `systemctl --user restart ateam`); does `sudo ufw status` allow the **tailscale0 interface**, not just port 22. |
 
 ## Notes
 
-- **Nothing is exposed publicly.** The box is reachable only over your tailnet; there
-  are no open ports and no inbound firewall rules to manage.
-- **The same box also backs the iOS app** — the phone connects to the daemon over a
-  WebSocket (`ATEAM_WS_ADDR`) instead of SSH, but it's the same daemon, agents, and
-  worktrees. Both transports ride Tailscale.
+- **Nothing is exposed publicly.** Both transports are reachable only over your
+  tailnet — no port is open to the internet, and neither carries auth of its own
+  because the tailnet *is* the auth boundary.
+- **The same box also backs the iOS app** — see step 5. Same daemon, agents, and
+  worktrees; a WebSocket instead of SSH, both riding Tailscale.
 - **Sessions persist.** The daemon keeps agents and PTYs alive across disconnects;
   reconnecting re-attaches to the exact running sessions.

--- a/docs/online-ateam.md
+++ b/docs/online-ateam.md
@@ -211,6 +211,17 @@ tailnet, and make sure its VPN toggle is on. Then open Ateam Go, enter the box's
 Tailscale IP and port `8787`, and connect — the connection is remembered across
 launches. Allow the iOS **Local Network** prompt if it appears.
 
+**What still needs a computer.** Everything above — don't try to defer it. The phone
+has nothing to connect to until a daemon is listening, and once connected the app can
+only add a project by browsing the box for a repo that is **already cloned there**
+(`projects.register` rejects a path that isn't a git repo). Its terminal lives inside
+a task's worktree, so there is no free-standing shell to clone that first repo with.
+Do steps 0–4 in one SSH session.
+
+After that, the phone is enough: its terminal is a real login shell on the box, so
+re-logging into `claude` when a session expires, `gh auth refresh`, and cloning
+further repos all work from the app.
+
 Two things worth doing before you rely on this:
 
 - **Scope a Tailscale ACL** to just the devices that should reach the box. Every node

--- a/docs/online-ateam.md
+++ b/docs/online-ateam.md
@@ -39,10 +39,11 @@ and you re-attach to the same live sessions.
 Skip this if you already have a box you work on. Starting from a provider's
 "create server" screen:
 
-**Size it for agents, not for the app.** Ubuntu 22.04/24.04, **4 GB RAM, 2 vCPU,
-40 GB disk** is a comfortable starting point (a Hetzner CX22 or equivalent). Each
-concurrent agent session wants roughly a gigabyte, plus whatever your project's own
-dev server and test runs need. x86_64 and arm64 both work.
+**Size it for agents, not for the app.** A recent Ubuntu LTS with **4 GB RAM, 2 vCPU,
+40 GB disk** is a comfortable starting point — a Hetzner **CX23** (x86) or **CAX11**
+(Arm64), or the equivalent elsewhere. Each concurrent agent session wants roughly a
+gigabyte, plus whatever your project's own dev server and test runs need. x86_64 and
+arm64 both work.
 
 **Create a non-root user.** Agents run as this user, in its login shell, with its
 git and `gh` credentials — don't give them root.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "bun run scripts/build.ts",
+    "build:release": "bun run scripts/build.ts && tar --no-xattrs -czf dist/ateam-server.tar.gz -C dist cli.js daemon.js package.json",
     "test": "bun test",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/server/scripts/install-remote.sh
+++ b/packages/server/scripts/install-remote.sh
@@ -1,70 +1,27 @@
 #!/usr/bin/env bash
-# One-shot installer: build the `ateam` server dist locally and install it on a
-# remote box over SSH, then verify the handshake. Proven against a Hetzner box
-# (Ubuntu, node via nvm).
+# Install the `ateam` server on a remote box FROM THIS CHECKOUT — the dev
+# counterpart to the public installer, for testing a build before it's released.
 #
 #   scripts/install-remote.sh <ssh-destination>
 #   SSH_FLAGS="-i ~/.ssh/mykey" scripts/install-remote.sh user@host
 #
-# The box needs a node 22.x (via nvm): better-sqlite3 ships node-22 prebuilds and
-# node-pty is the prebuilt fork, so NO compiler is required. Agent CLIs (claude,
-# codex, …) are discovered at connect time from a login shell, so they can live
-# anywhere on the login PATH — the installer doesn't need to know where.
+# It only builds the tarball and ships it: the actual install is `install.sh`
+# run on the box against that local tarball, so there is ONE install code path
+# (node selection, native modules, launcher, login PATH, handshake) and a dev
+# deploy exercises exactly what a user's `curl … | bash` does.
 #
 # Files/dirs are only ever created or overwritten, never removed.
 set -euo pipefail
 
 HOST="${1:?usage: install-remote.sh <ssh-destination> (user@host or an ssh_config alias)}"
 SSH_FLAGS="${SSH_FLAGS:-}"
-APP_DIR="ateam-app" # under the remote home
 HERE="$(cd "$(dirname "$0")/.." && pwd)" # packages/server
-run() { ssh ${SSH_FLAGS} "$HOST" "$@"; }
 
-echo "==> [1/6] build dist (bun bundle)"
-(cd "$HERE" && bun run build >/dev/null)
+echo "==> build dist + tarball (bun bundle)"
+(cd "$HERE" && bun run build:release >/dev/null)
 
-echo "==> [2/6] locate node 22 on $HOST"
-N22="$(run 'ls -d "$HOME"/.nvm/versions/node/v22* 2>/dev/null | tail -1')/bin/node"
-run "test -x '$N22'" || {
-	echo "!! node 22 not found on $HOST — run 'nvm install 22' there first"
-	exit 1
-}
-echo "    node: $N22"
+echo "==> ship to $HOST"
+scp ${SSH_FLAGS} -q "$HERE/dist/ateam-server.tar.gz" "$HERE/scripts/install.sh" "$HOST:/tmp/"
 
-echo "==> [3/6] copy dist to ~/$APP_DIR"
-run "mkdir -p ~/$APP_DIR ~/.local/bin"
-scp ${SSH_FLAGS} -q "$HERE/dist/cli.js" "$HERE/dist/daemon.js" "$HERE/dist/package.json" "$HOST:$APP_DIR/"
-
-echo "==> [4/6] install native modules (node 22 prebuilds; no compiler)"
-run "PATH=\"$(dirname "$N22")\":\$PATH; cd ~/$APP_DIR && npm install --omit=dev --no-audit --no-fund >/dev/null 2>&1"
-
-echo "==> [5/6] install the 'ateam' launcher on the login PATH (~/.local/bin/ateam)"
-# Generated locally (with node 22 pinned) and copied, to sidestep ssh quoting.
-# It runs cli.js under node 22 (matching the native ABI); a login shell around it
-# supplies the PATH that resolves agent CLIs.
-WRAP="$(mktemp)"
-printf '#!/bin/sh\nexec %s "$HOME/%s/cli.js" "$@"\n' "$N22" "$APP_DIR" >"$WRAP"
-scp ${SSH_FLAGS} -q "$WRAP" "$HOST:.local/bin/ateam"
-rm -f "$WRAP"
-run "chmod +x ~/.local/bin/ateam"
-
-echo "==> [6/6] verify handshake over a login shell (~10s)"
-REQ="$(mktemp)"
-printf '{"t":"req","id":1,"method":"system:hello","args":[]}\n' >"$REQ"
-# `attach` is a persistent relay — it won't self-exit after the reply, so cap it
-# with `timeout` and tolerate that non-zero exit (|| true); we only need the one
-# reply line. A persistent client (the desktop) keeps the connection open and is
-# unaffected by this one-shot pattern.
-OUT="$(ssh ${SSH_FLAGS} "$HOST" "bash -lc 'timeout 12 ateam attach --stdio'" <"$REQ" 2>/dev/null | head -1 || true)"
-rm -f "$REQ"
-case "$OUT" in
-*protocolVersion*) echo "    OK  $OUT" ;;
-*)
-	echo "!! handshake failed: ${OUT:-<no reply>}"
-	exit 1
-	;;
-esac
-
-echo
-echo "Installed. A client connects to this host with:"
-echo "    bash -lc 'exec ateam attach --stdio'"
+echo "==> install on $HOST"
+ssh ${SSH_FLAGS} "$HOST" 'ATEAM_TARBALL=/tmp/ateam-server.tar.gz bash /tmp/install.sh'

--- a/packages/server/scripts/install.sh
+++ b/packages/server/scripts/install.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# Install the `ateam` server on a Linux box, straight from a GitHub Release:
+#
+#   curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash
+#
+# Run it AS THE USER that will own the agents (not root) — everything lands under
+# that user's home and no step needs sudo. It is idempotent: re-running upgrades
+# the dist in place. Files are only ever created or overwritten, never removed.
+#
+# Env knobs:
+#   ATEAM_VERSION   release tag to install (default: the latest release)
+#   ATEAM_TARBALL   URL *or* local path to an ateam-server.tar.gz, bypassing the
+#                   release lookup (dev/air-gapped installs)
+#
+# Node: the dist externalizes two native modules — better-sqlite3 and the
+# prebuilt node-pty fork — so the box needs a Node whose ABI both ship binaries
+# for, and NO compiler. Node 22 is the version this is proven on; if the box has
+# nothing suitable, nvm + node 22 are installed into the user's home.
+set -euo pipefail
+
+REPO="clawnify/ateam"
+APP_DIR="$HOME/ateam-app"
+BIN_DIR="$HOME/.local/bin"
+WANT_SERVICE=0
+if [ "${1:-}" = "--service" ]; then WANT_SERVICE=1; fi
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+step() { printf '\n==> %s\n' "$1"; }
+info() { printf '    %s\n' "$1"; }
+die() {
+	printf '\n!! %s\n' "$1" >&2
+	exit 1
+}
+
+if [ "$(id -u)" = 0 ]; then die "run this as the user that will own the agents, not as root"; fi
+command -v curl >/dev/null || die "curl is required"
+command -v tar >/dev/null || die "tar is required"
+
+# ---------------------------------------------------------------- node -------
+
+# Print the major version of a node binary, or nothing if it can't run.
+node_major() { "$1" -p 'process.versions.node.split(".")[0]' 2>/dev/null || true; }
+
+# Echo the best node on the box, preferring an existing v22 (the ABI both native
+# modules are proven against) over a newer one.
+find_node() {
+	local best="" cand major
+	for cand in "$HOME"/.nvm/versions/node/v22*/bin/node "$(command -v node || true)" \
+		"$HOME"/.nvm/versions/node/v*/bin/node; do
+		[ -x "${cand:-}" ] || continue
+		major="$(node_major "$cand")"
+		[ -n "$major" ] && [ "$major" -ge 22 ] 2>/dev/null || continue
+		if [ "$major" = 22 ]; then
+			echo "$cand"
+			return 0
+		fi
+		[ -n "$best" ] || best="$cand"
+	done
+	echo "$best"
+}
+
+install_node22() {
+	step "installing node 22 (nvm, into \$HOME — no sudo, no system packages)"
+	curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash >/dev/null
+	# nvm's shell functions are not written for `set -eu`; relax around them only.
+	set +eu
+	# shellcheck disable=SC1091
+	. "$HOME/.nvm/nvm.sh"
+	nvm install 22 >/dev/null
+	nvm alias default 22 >/dev/null
+	set -eu
+}
+
+step "[1/6] locate a Node ≥ 22"
+NODE="$(find_node)"
+if [ -z "$NODE" ]; then
+	install_node22
+	NODE="$(find_node)"
+	[ -n "$NODE" ] || die "node 22 install failed"
+fi
+info "node: $NODE ($("$NODE" --version))"
+
+# ------------------------------------------------------------- download ------
+
+step "[2/6] fetch the server dist"
+TARBALL="$TMP/ateam-server.tar.gz"
+if [ -n "${ATEAM_TARBALL:-}" ] && [ -f "$ATEAM_TARBALL" ]; then
+	info "source: $ATEAM_TARBALL (local)"
+	cp "$ATEAM_TARBALL" "$TARBALL"
+else
+	if [ -n "${ATEAM_TARBALL:-}" ]; then
+		URL="$ATEAM_TARBALL"
+	elif [ -n "${ATEAM_VERSION:-}" ]; then
+		URL="https://github.com/$REPO/releases/download/$ATEAM_VERSION/ateam-server.tar.gz"
+	else
+		URL="https://github.com/$REPO/releases/latest/download/ateam-server.tar.gz"
+	fi
+	info "source: $URL"
+	curl -fsSL -o "$TARBALL" "$URL" ||
+		die "download failed — no ateam-server.tar.gz on that release. See https://github.com/$REPO/releases"
+fi
+
+tar -xzf "$TARBALL" -C "$TMP"
+# Only clobber a working install once we know the payload is intact.
+for f in cli.js daemon.js package.json; do
+	[ -f "$TMP/$f" ] || die "malformed tarball: missing $f"
+done
+
+step "[3/6] install to $APP_DIR"
+mkdir -p "$APP_DIR" "$BIN_DIR"
+cp "$TMP/cli.js" "$TMP/daemon.js" "$TMP/package.json" "$APP_DIR/"
+
+# ------------------------------------------------------------- natives -------
+
+# npm ships with node; use the one beside the node we picked so the modules are
+# built/downloaded for that exact ABI.
+NPM="$(dirname "$NODE")/npm"
+[ -x "$NPM" ] || NPM="$(command -v npm || true)"
+[ -n "$NPM" ] || die "npm not found beside $NODE"
+
+natives_load() { (cd "$APP_DIR" && "$NODE" -e 'require("better-sqlite3");require("node-pty")' >/dev/null 2>&1); }
+
+step "[4/6] install native modules (prebuilt — no compiler needed)"
+(cd "$APP_DIR" && PATH="$(dirname "$NODE"):$PATH" "$NPM" install --omit=dev --no-audit --no-fund >/dev/null 2>&1) ||
+	die "npm install failed in $APP_DIR"
+
+if ! natives_load; then
+	# The known failure: a Node newer than the prebuilds cover (node-pty has no
+	# binary for it). Fall back to 22, which both modules ship for.
+	info "native modules don't load under $("$NODE" --version) — falling back to node 22"
+	install_node22
+	NODE="$(find_node)"
+	NPM="$(dirname "$NODE")/npm"
+	(cd "$APP_DIR" && PATH="$(dirname "$NODE"):$PATH" "$NPM" install --omit=dev --no-audit --no-fund >/dev/null 2>&1)
+	natives_load || die "native modules still fail to load under $("$NODE" --version)"
+fi
+info "better-sqlite3 + node-pty load OK"
+
+# -------------------------------------------------------------- launcher ----
+
+step "[5/6] install the 'ateam' launcher on the login PATH"
+# Node is pinned by absolute path: the launcher must use the SAME runtime the
+# natives were installed for, whatever a login shell's PATH happens to resolve.
+printf '#!/bin/sh\nexec %s "%s/cli.js" "$@"\n' "$NODE" "$APP_DIR" >"$BIN_DIR/ateam"
+chmod +x "$BIN_DIR/ateam"
+
+# Clients connect with `bash -lc 'exec ateam attach --stdio'`, so what matters is
+# the LOGIN shell's PATH. Bash reads only the first of these that exists.
+if ! bash -lc 'command -v ateam' >/dev/null 2>&1; then
+	PROFILE="$HOME/.profile"
+	for f in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do
+		if [ -f "$f" ]; then
+			PROFILE="$f"
+			break
+		fi
+	done
+	{
+		echo ''
+		echo '# added by the ateam installer'
+		echo 'case ":$PATH:" in *":$HOME/.local/bin:"*) ;; *) PATH="$HOME/.local/bin:$PATH" ;; esac'
+	} >>"$PROFILE"
+	info "added ~/.local/bin to the login PATH via $PROFILE"
+	bash -lc 'command -v ateam' >/dev/null 2>&1 || die "ateam still not on the login PATH ($PROFILE)"
+fi
+info "login shell resolves: $(bash -lc 'command -v ateam')"
+
+# -------------------------------------------------------------- verify ------
+
+step "[6/6] verify the handshake"
+# `attach` is a persistent relay — it never self-exits after replying, so cap it
+# and keep the first line. A real client holds the connection open instead.
+HELLO="$(printf '{"t":"req","id":1,"method":"system:hello","args":[]}\n' |
+	timeout 25 bash -lc 'ateam attach --stdio' 2>/dev/null | head -1 || true)"
+case "$HELLO" in
+*protocolVersion*) info "OK  $HELLO" ;;
+*) die "handshake failed: ${HELLO:-<no reply>}" ;;
+esac
+
+# -------------------------------------------------------------- service ----
+
+# Opt-in (`install.sh --service`). Without it the daemon is started on demand by
+# the first `ateam attach`, which is enough for the desktop but NOT for the phone:
+# the WebSocket only exists once a daemon is already running, and nothing brings
+# one back after a reboot.
+if [ "$WANT_SERVICE" = 1 ]; then
+	step "install the user service"
+	if ! command -v systemctl >/dev/null; then
+		die "no systemd on this box — start 'ateam daemon' from your own init instead"
+	fi
+	UNIT_DIR="$HOME/.config/systemd/user"
+	mkdir -p "$UNIT_DIR"
+	{
+		echo '[Unit]'
+		echo 'Description=Ateam engine daemon'
+		echo ''
+		echo '[Service]'
+		# A LOGIN shell: agent CLIs are discovered with `which` against this
+		# process's own PATH, and a bare unit PATH resolves none of them.
+		echo "ExecStart=/bin/bash -lc 'exec ateam daemon'"
+		echo 'WorkingDirectory=%h'
+		# The PTY daemon is a DETACHED child holding every live agent session.
+		# `detached` escapes the process group, NOT the cgroup — under the default
+		# KillMode=control-group a restart would kill every running agent. Kill
+		# only the main process so sessions survive, exactly as they do today.
+		echo 'KillMode=process'
+		# NOT `always`: `ateam daemon` exits 0 when another daemon already owns the
+		# socket, and always-restart would turn that into a hot loop.
+		echo 'Restart=on-failure'
+		echo 'RestartSec=2'
+		if [ -n "${ATEAM_WS_ADDR:-}" ]; then echo "Environment=ATEAM_WS_ADDR=$ATEAM_WS_ADDR"; fi
+		echo ''
+		echo '[Install]'
+		echo 'WantedBy=default.target'
+	} >"$UNIT_DIR/ateam.service"
+	info "wrote $UNIT_DIR/ateam.service"
+
+	# Keep the user manager alive with no login session, so the daemon comes back
+	# after a reboot. Unprivileged: polkit's set-self-linger allows this for your
+	# OWN user (set-user-linger, for someone else's, is the one needing admin).
+	loginctl enable-linger 2>/dev/null || info "could not enable linger — the service won't start on boot"
+	systemctl --user daemon-reload
+	systemctl --user enable ateam.service >/dev/null 2>&1 || true
+
+	# Never kill a daemon out from under running agents. If one is already up
+	# outside systemd, hand over deliberately rather than silently.
+	if [ -S "$HOME/.ateam/rpc.sock" ] && ! systemctl --user is-active --quiet ateam.service; then
+		info "a daemon is already running outside systemd — enabled for next boot."
+		info "to hand it over now (agents keep running; the PTY daemon is untouched):"
+		info "     pkill -f 'ateam-app/cli.js daemon' && systemctl --user start ateam"
+	else
+		systemctl --user start ateam.service
+		sleep 2
+		systemctl --user is-active --quiet ateam.service &&
+			info "service active; starts on boot" ||
+			die "service failed to start — systemctl --user status ateam"
+	fi
+fi
+
+# ------------------------------------------------------------ readiness -----
+
+# Everything below needs a human (a name, a browser login), so it is reported,
+# never guessed at.
+step "readiness"
+have() { bash -lc "command -v $1" >/dev/null 2>&1; }
+mark() { [ "$1" = ok ] && printf '    [ok] %s\n' "$2" || printf '    [--] %s\n' "$2"; }
+
+if [ -n "$(git config --global user.email || true)" ] && [ -n "$(git config --global user.name || true)" ]; then
+	mark ok "git identity ($(git config --global user.name) <$(git config --global user.email)>)"
+else
+	mark no 'git identity — REQUIRED, agent commits fail without it:'
+	info '     git config --global user.name "you"; git config --global user.email "you@example.com"'
+fi
+
+if have gh && [ -n "$(gh auth token 2>/dev/null)" ]; then
+	mark ok "gh authenticated"
+else
+	mark no 'gh — needed for PRs and the merge queue:  gh auth login'
+fi
+
+AGENTS=""
+for a in claude codex; do
+	if have "$a"; then AGENTS="$AGENTS $a"; fi
+done
+if [ -n "$AGENTS" ]; then
+	mark ok "agent CLIs on the login PATH:$AGENTS"
+else
+	mark no 'no agent CLI found — install at least one (e.g. claude) and log into it'
+fi
+
+if command -v tailscale >/dev/null && tailscale status >/dev/null 2>&1; then
+	mark ok "tailscale up ($(tailscale ip -4 2>/dev/null | head -1))"
+else
+	mark no 'tailscale — how the desktop/phone reach this box privately'
+fi
+
+cat <<EOF
+
+Installed. From your Mac, add this box to ~/.ssh/config, then pick it in Ateam's
+connection switcher. Clients connect with:
+
+    bash -lc 'exec ateam attach --stdio'
+EOF

--- a/skills/setup-vps/SKILL.md
+++ b/skills/setup-vps/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: setup-vps
+description: Prepare a Linux VPS to run Ateam's agents, and connect the desktop app to it over SSH. Use when the user has bought (or is about to buy) a server for Ateam, says "set up my VPS", "run agents on my server", "connect Ateam to my box", "run agents 24/7", or wants the same box to back the iOS app.
+---
+
+# Set up a VPS for Ateam
+
+Takes a box from "just bought it" to "the desktop app's connection switcher lists it
+and agents run there". The mechanical half is one installer script; your job is the
+half that needs judgment and a human at a browser.
+
+The connection is **SSH over [Tailscale](https://tailscale.com)** — the box ends up
+with no public ports at all. Reference docs: `docs/online-ateam.md` in this repo.
+
+## Before you touch anything
+
+Ask the user what they have, and don't assume:
+
+- **A box already, or shopping?** If shopping: Ubuntu 22.04/24.04, 4 GB RAM, 2 vCPU,
+  40 GB disk is the comfortable floor. Agents are the RAM consumer — roughly a
+  gigabyte per concurrent session, plus their project's own dev server and tests.
+  x86_64 and arm64 both work.
+- **Can they SSH in as a non-root user?** Providers hand you `root`. Agents must not
+  run as root — they get a login shell, git credentials, and a `gh` token.
+- **Is Tailscale already on their Mac?** If not, that's a prerequisite on *both* ends,
+  and it's the thing that lets them close port 22 afterwards.
+- **Which agent CLIs do they want on the box** (e.g. `claude`)? Each needs its own
+  interactive login there.
+
+## 1. Non-root user
+
+Skip if they already have one. As root on the box:
+
+```bash
+adduser <user> && usermod -aG sudo <user>
+install -d -m 700 -o <user> -g <user> /home/<user>/.ssh
+cp ~/.ssh/authorized_keys /home/<user>/.ssh/ && chown <user>:<user> /home/<user>/.ssh/authorized_keys
+```
+
+Confirm `ssh <user>@<box>` works before going further.
+
+## 2. Tailscale, then close port 22
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+tailscale ip -4          # note the 100.x.y.z address
+```
+
+**Verify the tailnet address works from the Mac before firewalling** — get an
+`ssh <user>@100.x.y.z` in, then:
+
+```bash
+sudo ufw allow in on tailscale0    # everything, but only over the tailnet
+sudo ufw deny 22                   # nothing from the public internet
+sudo ufw enable
+```
+
+Allow the **whole `tailscale0` interface**, not a single port: `ufw`'s default input
+policy is DROP, so a port-22-only rule silently blocks the WebSocket port the iOS app
+needs later.
+
+Do these in this order or the user locks themselves out of their own server. If they
+would rather not run Tailscale, everything else still works — but say plainly that
+they are then choosing to leave SSH exposed to the internet, and key-only auth
+(`PasswordAuthentication no`) becomes mandatory rather than advisable.
+
+## 3. Install the server
+
+As the non-root user, on the box:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash
+```
+
+The installer handles Node (installing Node 22 via nvm if the box has none or one too
+new for the native-module prebuilds), the dist, the two native modules, the
+`~/.local/bin/ateam` launcher, the login-shell PATH, and a real `system:hello`
+handshake. It needs no sudo and is safe to re-run to upgrade.
+
+It ends with a **readiness report** of what it deliberately does not do for the user.
+Work that list — it is the whole point of the next step.
+
+## 4. The things the installer reports but can't do
+
+**Git identity** — without it, every agent commit fails:
+
+```bash
+git config --global user.name "<name>"
+git config --global user.email "<email>"
+git config --global init.defaultBranch main
+```
+
+**GitHub** — Ateam's merge queue and PR flow shell out to `gh`:
+
+```bash
+gh auth login        # device-code flow, works over SSH
+```
+
+**Agent CLIs** — install each one the user wants and log into it **interactively over
+SSH**. Auth is a browser round-trip; it cannot be scripted, and an agent that isn't
+logged in fails at first use, not at install. The daemon only advertises agents on
+its **login-shell** PATH — check with `ssh <box> "bash -lc 'command -v claude'"`, not
+a plain `ssh <box> "command -v claude"`.
+
+## 5. Connect the Mac
+
+Add the box to `~/.ssh/config` **using its tailnet address** — the desktop lists
+whatever it finds there:
+
+```sshconfig
+Host <alias>
+    HostName 100.x.y.z
+    User <user>
+    IdentityFile ~/.ssh/<key>
+```
+
+Then in Ateam: the connection button (top-right, shows **Local**) → pick `<alias>`.
+The board reloads with the box's projects and the button turns green.
+
+## Done means
+
+All four, verified — not just "the installer printed OK":
+
+1. `ssh <alias> "bash -lc 'ateam'"` prints the usage line.
+2. The installer's readiness report is all `[ok]`.
+3. The desktop connects and the connection button shows the host name.
+4. A task actually runs on the box: create one, watch the agent start in its terminal.
+
+Anything short of 4 means it isn't set up — a green connection with no working agent
+is the common half-finished state.
+
+## Common failures
+
+| Symptom | Cause |
+| --- | --- |
+| Install fails on native modules | Node too new for the prebuilds. The installer falls back to Node 22 itself; if it still fails, the box is on an unsupported libc or arch. |
+| `ateam` not found over SSH, works when logged in | It's on the interactive PATH but not the **login** PATH. The installer edits the first of `~/.bash_profile`, `~/.bash_login`, `~/.profile` that exists — check which one bash actually reads there. |
+| Connect hangs | Tailscale down on one end (`tailscale status` on both), or the host key rotated after a box rebuild (`ssh-keygen -R <ip>`, then reconnect). |
+| "Protocol mismatch" | Desktop and box are different versions — re-run the installer, or update the app. |
+| Agent picker empty | No agent CLI on the login PATH, or the daemon was started from a non-login shell. |
+| Commits fail | No git identity on the box (step 4). |
+
+## If they also want the iOS app (Ateam Go)
+
+Same box, same daemon — the phone can't run `ssh`, so it uses a WebSocket. Opt-in,
+off by default. Do this only when asked; it opens a port on the tailnet.
+
+A phone needs the daemon **already running** — it can't start one the way the desktop
+does over SSH, since the WebSocket only exists once a daemon is up. So the phone path
+requires the service:
+
+```bash
+export ATEAM_WS_ADDR=<box-tailnet-ip>:8787
+curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash -s -- --service
+```
+
+The unit carries `ATEAM_WS_ADDR`, lingering keeps it alive across logout and reboot,
+and none of it needs sudo. A wildcard bind is refused and the daemon exits — the
+socket has no auth of its own, so the bind address must be the box's own `100.x`.
+
+If a daemon is already running outside systemd the installer will **not** kill it; it
+prints the handover instead. Running agents survive it:
+
+```bash
+pkill -f 'ateam-app/cli.js daemon' && systemctl --user start ateam
+systemctl --user restart ateam    # the restart command from here on
+```
+
+Don't reach for `pkill` afterwards — `systemctl --user restart` is the supported
+path, and the unit is `KillMode=process` so the detached PTY daemon holding live
+agent sessions is deliberately left running across a restart.
+
+**On the phone:** Tailscale from the App Store, signed into the *same* tailnet, VPN
+toggle on. Then in Ateam Go enter the box's Tailscale IP and port `8787`. Allow the
+iOS Local Network prompt if it appears. (`ateamgo://demo` opens an offline demo — it
+does **not** configure a connection.)
+
+Say both of these out loud, don't bury them:
+
+- **Scope a Tailscale ACL** to the devices that should reach the box. Every tailnet
+  node can hit an open port by default, and this one is an unauthenticated engine.
+- **There's no app lock yet.** An unlocked stolen phone on the tailnet is shell
+  access to the box.

--- a/skills/setup-vps/SKILL.md
+++ b/skills/setup-vps/SKILL.md
@@ -16,10 +16,11 @@ with no public ports at all. Reference docs: `docs/online-ateam.md` in this repo
 
 Ask the user what they have, and don't assume:
 
-- **A box already, or shopping?** If shopping: Ubuntu 22.04/24.04, 4 GB RAM, 2 vCPU,
-  40 GB disk is the comfortable floor. Agents are the RAM consumer — roughly a
-  gigabyte per concurrent session, plus their project's own dev server and tests.
-  x86_64 and arm64 both work.
+- **A box already, or shopping?** If shopping: a recent Ubuntu LTS with 4 GB RAM,
+  2 vCPU, 40 GB disk is the comfortable floor — a Hetzner CX23 (x86) or CAX11 (Arm64),
+  or the equivalent elsewhere. Agents are the RAM consumer — roughly a gigabyte per
+  concurrent session, plus their project's own dev server and tests. x86_64 and arm64
+  both work.
 - **Can they SSH in as a non-root user?** Providers hand you `root`. Agents must not
   run as root — they get a login shell, git credentials, and a `gh` token.
 - **Is Tailscale already on their Mac?** If not, that's a prerequisite on *both* ends,

--- a/skills/setup-vps/SKILL.md
+++ b/skills/setup-vps/SKILL.md
@@ -177,6 +177,14 @@ toggle on. Then in Ateam Go enter the box's Tailscale IP and port `8787`. Allow 
 iOS Local Network prompt if it appears. (`ateamgo://demo` opens an offline demo — it
 does **not** configure a connection.)
 
+If the user asks whether they can skip the SSH steps and do the setup from the phone
+instead: **no, and say why.** The phone has nothing to connect to until a daemon is
+listening; the app adds a project only by browsing the box for an already-cloned repo
+(`projects.register` throws `NOT_A_REPO` otherwise); and its terminal only exists
+inside a task's worktree, so there's no shell to clone that first repo with. It's a
+five-minute SSH session, once. Afterwards the phone's terminal *is* a login shell on
+the box — re-auth, `gh auth refresh` and further clones are all fine from it.
+
 Say both of these out loud, don't bury them:
 
 - **Scope a Tailscale ACL** to the devices that should reach the box. Every tailnet


### PR DESCRIPTION
Getting agents onto a box meant cloning the monorepo, installing bun, building the dist and scp'ing it — impossible for anyone who installed the app from the DMG. This replaces that with a `curl` one-liner, adds an opt-in service so the iOS app has something to connect to, and ships the judgement half of the setup as an installable Claude Code skill.

### `packages/server/scripts/install.sh`

Installs the server from the latest release: finds a Node ≥ 22 (installing Node 22 via nvm if the box has none, or if the one it has is too new for the native-module prebuilds), unpacks the dist, installs the two prebuilt natives, drops a launcher pinned to that exact interpreter, fixes the login-shell PATH, verifies a real `system:hello`, and reports what only a human can do (git identity, `gh`, agent CLIs, Tailscale). No sudo, everything under `$HOME`, idempotent.

`--service` additionally installs a `systemd --user` unit. This is what the iOS app needs: the phone can't start a daemon on demand the way the desktop does over SSH, so something has to keep one running. Two non-obvious settings:

- **`KillMode=process`** — the PTY daemon is a detached child holding every live agent session. `detached` escapes the process group, **not** the cgroup, so the default `control-group` kill would take every running agent down on restart.
- **`Restart=on-failure`** — `ateam daemon` exits 0 when another daemon already owns the socket; `Restart=always` would turn that into a hot loop.

`ExecStart` goes through a login shell because agents are discovered with `which` against the daemon's own PATH and the server has no PATH-adoption fallback. Lingering is enabled unprivileged (polkit's `set-self-linger`).

### Everything else

- `install-remote.sh` now only builds the tarball and runs `install.sh` on the box — one install path instead of two copies that drift, and a dev deploy exercises exactly what a user's `curl` gets.
- `build:release` emits `dist/ateam-server.tar.gz`, the asset `install.sh` downloads from `releases/latest`. **The release flow must upload it or every install 404s.**
- The repo becomes a Claude Code plugin marketplace; `skills/setup-vps` covers sizing, the non-root user, Tailscale + firewall ordering, the auth steps that can't be scripted, and the phone path.
- README gains a start-to-finish Hetzner walkthrough; `docs/online-ateam.md` gains fresh-VPS prep and an iOS section.

### Verified

Run end-to-end on a real Ubuntu VPS, including the cold path (no Node at all → nvm + Node 22), idempotent re-run, and the service handover. A month-old PTY daemon survived both the handover and a full `systemctl --user restart`, which is the property `KillMode=process` exists to protect.

Two facts corrected against primary sources while writing the docs: Hetzner's cost-optimized plans are CX23 / CAX11, and `ufw`'s default input policy is DROP — so the earlier port-22-only rule would have silently blocked the iOS app's WebSocket port.