### PR TITLE
fix: 0.1.36 — ship `ws`, and gate on every require() resolving

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {
@@ -15,7 +15,8 @@
   "dependencies": {
     "better-sqlite3": "^11.8.1",
     "electron-updater": "^6.8.3",
-    "node-pty": "^1.0.0"
+    "node-pty": "^1.0.0",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@ateam/agents": "workspace:*",
@@ -45,7 +46,6 @@
     "react-diff-view": "^3.3.3",
     "react-dom": "^18.3.1",
     "simple-git": "^3.27.0",
-    "vite": "^6.0.7",
-    "ws": "^8.21.0"
+    "vite": "^6.0.7"
   }
 }

--- a/apps/desktop/scripts/package-mac.sh
+++ b/apps/desktop/scripts/package-mac.sh
@@ -14,26 +14,28 @@ ELECTRON_VER="$(node -p "require('$DESKTOP_DIR/package.json').devDependencies.el
 BUILDER_VER="$(node -p "require('$DESKTOP_DIR/package.json').devDependencies['electron-builder']")"
 NOTARIZE_VER="$(node -p "require('$DESKTOP_DIR/package.json').devDependencies['@electron/notarize']")"
 REBUILD_VER="$(node -p "require('$DESKTOP_DIR/package.json').devDependencies['@electron/rebuild']")"
-SQLITE_VER="$(node -p "require('$DESKTOP_DIR/package.json').dependencies['better-sqlite3']")"
-PTY_VER="$(node -p "require('$DESKTOP_DIR/package.json').dependencies['node-pty']")"
 
 echo "==> Ateam $VERSION → staging at $STAGE"
 mkdir -p "$STAGE"
 
-# 1. Staging package.json (only runtime native deps live in node_modules; the
-#    rest is bundled into out/ by electron-vite). electron-updater is a runtime
-#    dep and MUST be present so the externalized require resolves.
-cat > "$STAGE/package.json" <<JSON
+# 1. Fresh production bundle. Built FIRST because the staging dependency list is
+#    derived from what the bundle actually require()s — see runtime-deps.mjs.
+echo "==> electron-vite build"
+( cd "$DESKTOP_DIR" && bunx --bun electron-vite build )
+
+# 2. Staging package.json. Only the packages the bundle leaves as external live
+#    in node_modules; everything else electron-vite inlined into out/. That set
+#    is read off the emitted code rather than hardcoded here — a stale hardcoded
+#    list is what shipped 0.1.35 without `ws` and crashed it on launch.
+DEPS="$(node "$DESKTOP_DIR/scripts/runtime-deps.mjs" --deps "$DESKTOP_DIR/out")"
+echo "==> runtime deps: $(node -p "Object.keys($DEPS).join(', ')")"
+cat > "$STAGE/package.json.next" <<JSON
 {
   "name": "ateam",
   "version": "$VERSION",
   "main": "out/main/index.js",
   "author": "Clawnify",
-  "dependencies": {
-    "better-sqlite3": "$SQLITE_VER",
-    "node-pty": "$PTY_VER",
-    "electron-updater": "$(node -p "require('$DESKTOP_DIR/package.json').dependencies['electron-updater']")"
-  },
+  "dependencies": $DEPS,
   "devDependencies": {
     "electron": "$ELECTRON_VER",
     "electron-builder": "$BUILDER_VER",
@@ -42,6 +44,13 @@ cat > "$STAGE/package.json" <<JSON
   }
 }
 JSON
+
+# A changed dependency set must force a reinstall — the completeness check below
+# only looks at the build toolchain and would happily reuse a node_modules that
+# predates a newly added runtime dep.
+DEPS_CHANGED=0
+if ! cmp -s "$STAGE/package.json.next" "$STAGE/package.json"; then DEPS_CHANGED=1; fi
+mv "$STAGE/package.json.next" "$STAGE/package.json"
 
 # Fail unless every compiled native module under $1 is a single-arch arm64
 # binary. Scans only `*/build/Release/*.node` — the electron-rebuild output that
@@ -70,14 +79,18 @@ assert_arm64_nodes() {
   return $bad
 }
 
-# 2. Install + rebuild native modules for Electron's arm64 ABI. Recreated when
-#    the install is missing or incomplete (e.g. a partial install left behind by
-#    a wiped/interrupted run) — checks for the actual binaries it needs.
+# 3. Install + rebuild native modules for Electron's arm64 ABI. A missing or
+#    incomplete install (e.g. left behind by a wiped/interrupted run) is wiped
+#    and redone; a merely changed dependency set only needs npm to reconcile,
+#    which keeps the ~100MB electron download out of the common path.
 if [ ! -x "$STAGE/node_modules/.bin/electron-builder" ] ||
    [ ! -x "$STAGE/node_modules/.bin/electron-rebuild" ] ||
    [ ! -d "$STAGE/node_modules/electron/dist" ]; then
   echo "==> npm install (first run / staging cleared or incomplete)"
   rm -rf "$STAGE/node_modules" "$STAGE/package-lock.json"
+  ( cd "$STAGE" && npm install --no-audit --no-fund )
+elif [ "$DEPS_CHANGED" -eq 1 ]; then
+  echo "==> npm install (runtime dependency set changed)"
   ( cd "$STAGE" && npm install --no-audit --no-fund )
 fi
 
@@ -95,18 +108,25 @@ if ! assert_arm64_nodes "$STAGE/node_modules/better-sqlite3" ||
   exit 1
 fi
 
-# 3. Fresh production bundle, copied into staging.
-echo "==> electron-vite build"
-( cd "$DESKTOP_DIR" && bunx --bun electron-vite build )
+# 4. Copy the bundle built in step 1 into staging.
 rm -rf "$STAGE/out" "$STAGE/build" "$STAGE/scripts" "$STAGE/electron-builder.yml" "$STAGE/release"
 cp -R "$DESKTOP_DIR/out" "$DESKTOP_DIR/build" "$DESKTOP_DIR/scripts" "$STAGE/"
 cp "$DESKTOP_DIR/electron-builder.yml" "$STAGE/"
 
-# 4. Sign + notarize + staple + dmg + zip (no target args: the yml declares both).
+# 5. Sign + notarize + staple + dmg + zip (no target args: the yml declares both).
 echo "==> electron-builder (sign + notarize + dmg + zip)"
 ( cd "$STAGE" && ./node_modules/.bin/electron-builder --mac --arm64 )
 
-# 4b. Hard gate: every native module packaged into the .app must be arm64.
+# 5a. Hard gate: every module the bundle require()s must exist in the .app.
+#     electron-builder prunes devDependencies and can drop a package entirely,
+#     so only reading the signed archive proves what actually made it in.
+echo "==> Runtime dependency check (every require() must resolve)"
+if ! node "$DESKTOP_DIR/scripts/runtime-deps.mjs" --verify-app \
+     "$DESKTOP_DIR/out" "$STAGE/release/mac-arm64/Ateam.app"; then
+  exit 1
+fi
+
+# 5b. Hard gate: every native module packaged into the .app must be arm64.
 #     Signing, notarization and the spctl check below are all arch-agnostic and
 #     will happily bless an x86_64 module that then dlopen()-crashes on every
 #     Apple Silicon Mac — so this is the last line of defense before publish.

--- a/apps/desktop/scripts/runtime-deps.mjs
+++ b/apps/desktop/scripts/runtime-deps.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+// Derive the packaged app's runtime dependencies from the BUILT bundle, instead
+// of hand-maintaining a list in package-mac.sh.
+//
+// electron-vite externalizes some npm packages (they stay `require("x")` in
+// out/) and bundles others. Which is which depends on the package's own shape
+// (CJS/native → external, ESM → inlined), not on where it sits in
+// package.json — so the only reliable source of truth is the emitted code.
+// A hardcoded list silently ships a broken app the moment main imports a new
+// external: `ws` landed in 0.1.35 that way and crashed every launch with
+// "Cannot find module 'ws'" — past signing, notarization AND Gatekeeper, none
+// of which check that a require() resolves.
+//
+// Usage:
+//   node runtime-deps.mjs --deps <outDir>          → {"pkg":"^1.2.3",...} on stdout
+//   node runtime-deps.mjs --verify-app <outDir> <Ateam.app>  → exit 1 if any is missing
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { builtinModules, createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DESKTOP_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BUILTINS = new Set(builtinModules);
+// Provided by the Electron runtime itself — never a node_modules entry.
+const PROVIDED = new Set(["electron"]);
+
+/**
+ * Every bare `require("x")` specifier in the main + preload bundles.
+ *
+ * These bundles are CommonJS — electron-vite emits CJS unless package.json says
+ * `"type": "module"`, which the desktop deliberately does not. So require() is
+ * the only externalization form present, and a file with none of them means the
+ * output format changed underneath us: fail loudly rather than report an empty
+ * dependency set, which would sail through both gates and ship a broken app.
+ */
+function externalPackages(outDir) {
+	const found = new Set();
+	for (const sub of ["main", "preload"]) {
+		const dir = join(outDir, sub);
+		if (!existsSync(dir)) continue;
+		for (const file of readdirSync(dir).filter((f) => f.endsWith(".js"))) {
+			const code = readFileSync(join(dir, file), "utf8");
+			const specs = [...code.matchAll(/require\(\s*["']([^"']+)["']\s*\)/g)];
+			if (specs.length === 0) {
+				console.error(
+					`FATAL: ${sub}/${file} contains no require() — the bundle is no ` +
+						`longer CommonJS and this scanner cannot see its imports.`,
+				);
+				process.exit(1);
+			}
+			for (const [, spec] of specs) {
+				if (spec.startsWith(".") || spec.startsWith("/")) continue;
+				if (spec.startsWith("node:")) continue;
+				// "@scope/name/deep" → "@scope/name"; "pkg/deep" → "pkg"
+				const parts = spec.split("/");
+				const name = spec.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
+				if (BUILTINS.has(name) || PROVIDED.has(name)) continue;
+				found.add(name);
+			}
+		}
+	}
+	return [...found].sort();
+}
+
+const [mode, outDir, appPath] = process.argv.slice(2);
+const names = externalPackages(outDir);
+
+if (mode === "--deps") {
+	const pkg = JSON.parse(readFileSync(join(DESKTOP_DIR, "package.json"), "utf8"));
+	const declared = { ...pkg.devDependencies, ...pkg.dependencies };
+	const deps = {};
+	const missing = [];
+	for (const name of names) {
+		if (declared[name]) deps[name] = declared[name];
+		else missing.push(name);
+	}
+	if (missing.length) {
+		console.error(
+			`FATAL: the built bundle requires ${missing.join(", ")}, which ` +
+				`apps/desktop/package.json does not declare. Add it as a dependency.`,
+		);
+		process.exit(1);
+	}
+	process.stdout.write(JSON.stringify(deps, null, 4));
+} else if (mode === "--verify-app") {
+	// Last gate before publish: prove each require() actually resolves inside the
+	// signed .app. electron-builder prunes devDependencies and can drop a package
+	// entirely; only reading the shipped archive proves what made it in.
+	const resources = join(appPath, "Contents/Resources");
+	// @electron/asar comes free with electron-builder in the staging dir, which is
+	// three levels up from the .app ($STAGE/release/mac-arm64/Ateam.app).
+	const require = createRequire(import.meta.url);
+	const asar = require(join(appPath, "../../..", "node_modules/@electron/asar"));
+	const entries = new Set(asar.listPackage(join(resources, "app.asar")));
+	const missing = names.filter(
+		(name) =>
+			!entries.has(`/node_modules/${name}`) &&
+			!existsSync(join(resources, "app.asar.unpacked/node_modules", name)),
+	);
+	if (missing.length) {
+		console.error(
+			`FATAL: ${missing.join(", ")} ${missing.length > 1 ? "are" : "is"} ` +
+				`require()d by the bundle but absent from the packaged app — it ` +
+				`would crash on launch. Refusing to ship.`,
+		);
+		process.exit(1);
+	}
+	console.log(`   ok: all ${names.length} runtime deps present (${names.join(", ")})`);
+} else {
+	console.error("usage: runtime-deps.mjs --deps <outDir> | --verify-app <outDir> <app>");
+	process.exit(2);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -12,11 +12,12 @@
     },
     "apps/desktop": {
       "name": "@ateam/desktop",
-      "version": "0.1.32",
+      "version": "0.1.35",
       "dependencies": {
         "better-sqlite3": "^11.8.1",
         "electron-updater": "^6.8.3",
         "node-pty": "^1.0.0",
+        "ws": "^8.21.0",
       },
       "devDependencies": {
         "@ateam/agents": "workspace:*",
@@ -47,7 +48,6 @@
         "react-dom": "^18.3.1",
         "simple-git": "^3.27.0",
         "vite": "^6.0.7",
-        "ws": "^8.21.0",
       },
     },
     "packages/agents": {


### PR DESCRIPTION
**0.1.35 is broken for every user.** It crashes at launch with `Cannot find module 'ws'` — before `electron-updater` runs, so nobody can auto-update out of it. They need a manual re-download.

### What happened

#94 (Tailscale transport) added `import WebSocket from "ws"` to `apps/desktop/src/main/host.ts`. electron-vite externalized it, so the built `out/main/index.js` emits `require("ws")`. But `package-mac.sh` wrote the staging `package.json` from a **hardcoded list of three deps** (`better-sqlite3`, `node-pty`, `electron-updater`), so npm never installed `ws` and electron-builder never packaged it.

Signing, notarization and Gatekeeper are all blind to an unresolvable `require()`, so the broken build sailed through every existing gate.

Extracted from the shipped `app.asar` (v0.1.35):

| bundle | external requires | in the .app? |
|---|---|---|
| `out/main/index.js` | better-sqlite3, electron, electron-updater, **ws** | ✅ ✅ ✅ **❌** |
| `out/main/daemon.js` | node-pty | ✅ |
| `out/preload/index.js` | electron | ✅ |

### The fix

1. **`ws` → `dependencies`.** It's a runtime import.
2. **Stop hand-maintaining the staged dep list.** New `scripts/runtime-deps.mjs` reads the actual `require()` specifiers out of `out/{main,preload}`, drops builtins and `electron`, and resolves each version from `apps/desktop/package.json` — failing if one isn't declared. `package-mac.sh` now builds the bundle *first* and generates the staging `dependencies` from that; a changed dep set forces an `npm install`.
3. **A hard gate before publish**, alongside the existing arm64 check: every `require()`d package must actually be present in the signed `.app`, read from `app.asar` itself. electron-builder prunes devDependencies and can drop a package, so only reading the shipped archive proves what made it in.

### Verification

Derivation against a fresh build picks up exactly the right four:

```
{"better-sqlite3":"^11.8.1","electron-updater":"^6.8.3","node-pty":"^1.0.0","ws":"^8.21.0"}
```

And the new gate, run against the **actual broken 0.1.35 artifact**:

```
FATAL: ws is require()d by the bundle but absent from the packaged app —
       it would crash on launch. Refusing to ship.
exit 1
```

`typecheck` and `biome check` pass.
