### PR TITLE
feat: crash-safe bootstrap so a broken build can still be updated

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
 		build: {
 			rollupOptions: {
 				input: {
+					// The entry point electron actually loads: a crash guard that
+					// require()s index.js at runtime. A separate input on purpose —
+					// bundled together, its try/catch could never see index's throw.
+					bootstrap: resolve(__dirname, "src/main/bootstrap.ts"),
 					index: resolve(__dirname, "src/main/index.ts"),
 					// The detached PTY daemon, built alongside main → out/main/daemon.js.
 					// Source lives in @ateam/server (its PTY subsystem); the desktop and

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@ateam/desktop",
   "version": "0.1.36",
   "private": true,
-  "main": "./out/main/index.js",
+  "main": "./out/main/bootstrap.js",
   "scripts": {
     "dev": "bash scripts/brand-dev-electron.sh && bunx --bun electron-vite dev",
     "build": "bunx --bun electron-vite build",

--- a/apps/desktop/scripts/package-mac.sh
+++ b/apps/desktop/scripts/package-mac.sh
@@ -33,7 +33,7 @@ cat > "$STAGE/package.json.next" <<JSON
 {
   "name": "ateam",
   "version": "$VERSION",
-  "main": "out/main/index.js",
+  "main": "out/main/bootstrap.js",
   "author": "Clawnify",
   "dependencies": $DEPS,
   "devDependencies": {

--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -1,0 +1,53 @@
+// The app's real entry point — a crash guard around the main bundle.
+//
+// When main fails at load time the app is unrecoverable from the inside: no
+// window exists, so no in-app button can be reached, and electron-updater never
+// runs, so the app cannot update itself out of a bad release. All the user gets
+// is Electron's default "A JavaScript error occurred in the main process" dialog
+// — a stack trace and an OK button, nothing actionable. 0.1.35 shipped without
+// `ws` and bricked that way; 0.1.24 and 0.1.26 shipped x86_64 native modules and
+// bricked the same way.
+//
+// So the entry point is this file instead, and it catches the whole class:
+// missing module, wrong-arch .node, corrupt asar, a throwing migration — any
+// load-time failure becomes a dialog that offers the one fix that works, a fresh
+// download.
+//
+// Two constraints keep it trustworthy, both enforced by the build:
+//   1. It imports NOTHING but `electron`. A bundled dependency is exactly what
+//      might be missing, and the guard must survive that.
+//   2. It is a separate rollup input, so `require("./index.js")` stays a real
+//      runtime require. Inlined into the main chunk, the throw would happen
+//      before this try block and the guard would never fire.
+//
+// It does not cover async failures after load, or a crash inside Electron's own
+// startup — those never reach JS. Every incident so far has been load-time.
+
+import { app, dialog, shell } from "electron";
+
+const DOWNLOAD_URL = "https://github.com/clawnify/ateam/releases/latest/download/Ateam-macos.dmg";
+
+try {
+	require("./index.js");
+} catch (err) {
+	// First line only — Node folds the whole require stack into .message, which
+	// turns the dialog into a wall of paths nobody reads. The full error goes to
+	// stderr, where a terminal launch or Console.app keeps it for a bug report.
+	const message = (err instanceof Error ? err.message : String(err)).split("\n")[0];
+	console.error("[bootstrap] main process failed to load:", err);
+
+	app.whenReady().then(async () => {
+		const { response } = await dialog.showMessageBox({
+			type: "error",
+			message: `${app.getName()} couldn't start`,
+			detail:
+				`${message}\n\nThis version is broken. Installing the latest ` +
+				`version usually fixes it — your projects and sessions are kept.`,
+			buttons: ["Download latest version", "Quit"],
+			defaultId: 0,
+			cancelId: 1,
+		});
+		if (response === 0) await shell.openExternal(DOWNLOAD_URL);
+		app.quit();
+	});
+}

--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -1,53 +1,35 @@
 // The app's real entry point — a crash guard around the main bundle.
 //
-// When main fails at load time the app is unrecoverable from the inside: no
-// window exists, so no in-app button can be reached, and electron-updater never
-// runs, so the app cannot update itself out of a bad release. All the user gets
-// is Electron's default "A JavaScript error occurred in the main process" dialog
-// — a stack trace and an OK button, nothing actionable. 0.1.35 shipped without
-// `ws` and bricked that way; 0.1.24 and 0.1.26 shipped x86_64 native modules and
-// bricked the same way.
+// When main fails while being require()d the app is unrecoverable from the
+// inside: no window exists, so no in-app button can be reached, and
+// electron-updater never runs, so the app cannot update itself out of a bad
+// release. All the user gets is Electron's default "A JavaScript error occurred
+// in the main process" dialog — a stack trace and an OK button, nothing
+// actionable. 0.1.35 shipped without `ws` and bricked exactly that way, as did
+// 0.1.24 and 0.1.26 on an x86_64 better-sqlite3, which index.js requires at top
+// level.
 //
-// So the entry point is this file instead, and it catches the whole class:
-// missing module, wrong-arch .node, corrupt asar, a throwing migration — any
-// load-time failure becomes a dialog that offers the one fix that works, a fresh
-// download.
+// So the entry point is this file, and load-time failure becomes a dialog that
+// offers the one fix reachable from outside a dead app. Failures *after* load
+// are a different branch — index.ts catches those — but both end up in the same
+// showStartupFailure(), so the two can't drift apart.
 //
-// Two constraints keep it trustworthy, both enforced by the build:
-//   1. It imports NOTHING but `electron`. A bundled dependency is exactly what
-//      might be missing, and the guard must survive that.
+// Two constraints keep the guard trustworthy, both enforced by the build:
+//   1. Nothing here resolves at runtime except `electron`. The local imports are
+//      inlined into this chunk by the bundler, so a missing package — precisely
+//      what the guard exists to survive — is never require()d to reach it.
 //   2. It is a separate rollup input, so `require("./index.js")` stays a real
 //      runtime require. Inlined into the main chunk, the throw would happen
 //      before this try block and the guard would never fire.
 //
-// It does not cover async failures after load, or a crash inside Electron's own
-// startup — those never reach JS. Every incident so far has been load-time.
+// Not covered: crashes inside Electron's own startup, which never reach JS, and
+// the detached PTY daemon, which is its own process (a dead daemon costs
+// terminals, not the app — index.ts degrades rather than blocking on it).
 
-import { app, dialog, shell } from "electron";
-
-const DOWNLOAD_URL = "https://github.com/clawnify/ateam/releases/latest/download/Ateam-macos.dmg";
+import { showStartupFailure } from "./startup-failure";
 
 try {
 	require("./index.js");
 } catch (err) {
-	// First line only — Node folds the whole require stack into .message, which
-	// turns the dialog into a wall of paths nobody reads. The full error goes to
-	// stderr, where a terminal launch or Console.app keeps it for a bug report.
-	const message = (err instanceof Error ? err.message : String(err)).split("\n")[0];
-	console.error("[bootstrap] main process failed to load:", err);
-
-	app.whenReady().then(async () => {
-		const { response } = await dialog.showMessageBox({
-			type: "error",
-			message: `${app.getName()} couldn't start`,
-			detail:
-				`${message}\n\nThis version is broken. Installing the latest ` +
-				`version usually fixes it — your projects and sessions are kept.`,
-			buttons: ["Download latest version", "Quit"],
-			defaultId: 0,
-			cancelId: 1,
-		});
-		if (response === 0) await shell.openExternal(DOWNLOAD_URL);
-		app.quit();
-	});
+	showStartupFailure(err, "load");
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,12 +1,13 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { createEngine, type Engine } from "@ateam/server";
 import { app, BrowserWindow, dialog, Menu } from "electron";
 import { autoUpdater } from "electron-updater";
-import { createEngine, type Engine } from "@ateam/server";
 import { APP_NAME } from "./app-name";
 import { createHost, registerHostIpc } from "./host";
 import { registerIpc } from "./ipc";
+import { showStartupFailure } from "./startup-failure";
 
 // Every live window and the project it's pinned to: null = the main
 // multi-project dashboard, a projectId = a detached single-project window.
@@ -315,80 +316,79 @@ function openProjectWindow(projectId: string): void {
 	createWindow(projectId);
 }
 
-app.whenReady().then(async () => {
-	app.setName(APP_NAME);
-	adoptLoginShellPath();
+app
+	.whenReady()
+	.then(async () => {
+		app.setName(APP_NAME);
+		adoptLoginShellPath();
 
-	// Show the app icon in the macOS dock during dev (packaged builds use the
-	// .icns in build/). Best-effort: the icon lives at build/icon.png.
-	if (process.platform === "darwin" && app.dock) {
-		for (const p of [
-			join(process.cwd(), "build", "icon.png"),
-			join(__dirname, "../../build/icon.png"),
-		]) {
-			try {
-				app.dock.setIcon(p);
-				break;
-			} catch {
-				/* try next path */
+		// Show the app icon in the macOS dock during dev (packaged builds use the
+		// .icns in build/). Best-effort: the icon lives at build/icon.png.
+		if (process.platform === "darwin" && app.dock) {
+			for (const p of [
+				join(process.cwd(), "build", "icon.png"),
+				join(__dirname, "../../build/icon.png"),
+			]) {
+				try {
+					app.dock.setIcon(p);
+					break;
+				} catch {
+					/* try next path */
+				}
 			}
 		}
-	}
 
-	engine = await createEngine({
-		dataDir: app.getPath("userData"),
-		// The detached PTY daemon (out/main/daemon.js) is run via the Electron
-		// binary as node (ELECTRON_RUN_AS_NODE) so node-pty's ABI matches.
-		daemonPath: join(__dirname, "daemon.js"),
-		execPath: process.execPath,
+		engine = await createEngine({
+			dataDir: app.getPath("userData"),
+			// The detached PTY daemon (out/main/daemon.js) is run via the Electron
+			// binary as node (ELECTRON_RUN_AS_NODE) so node-pty's ABI matches.
+			daemonPath: join(__dirname, "daemon.js"),
+			execPath: process.execPath,
+		});
+		// The local engine is the default backend; the host swaps in a remote one (over
+		// SSH) on connect and re-points the IPC bridge + event forwarding at it. Binding
+		// the engine's events to every window is the host's job now (see createHost);
+		// window management (detaching a project) is desktop-native, passed to registerIpc.
+		const host = createHost({ localEngine: engine, broadcast });
+		registerIpc(host.router, { openProjectWindow });
+		registerHostIpc(host);
+
+		if (SMOKE) {
+			// Headless boot check: prove the engine inits (db, hook server, notify
+			// script) without opening a window or the daemon, then exit cleanly.
+			console.log(`ATEAM_READY hookPort=${engine.services.hookPort}`);
+			engine.stopHooks();
+			app.exit(0);
+			return;
+		}
+
+		// Connect to (or launch) the PTY daemon and learn which sessions are still
+		// alive from a previous run, so the renderer can re-attach to them.
+		try {
+			await engine.connectPty();
+		} catch (err) {
+			console.error("[ateam] PTY daemon connect failed:", err);
+		}
+
+		createWindow();
+		buildAppMenu();
+		// Start the board reconciler (and any other registered loops) once the
+		// window exists, so the first pass can push corrections to the renderer.
+		engine.startLoops();
+		setupAutoUpdate();
+		app.on("activate", () => {
+			if (BrowserWindow.getAllWindows().length === 0) createWindow();
+		});
+	})
+	.catch((err) => {
+		// A startup failure (e.g. a corrupt database, or schema DDL that throws)
+		// would otherwise leave a live process with no window and no feedback —
+		// exactly the "click the app, nothing happens" symptom. Unlike a load-time
+		// failure this one is usually data-dependent, so no build gate can prevent
+		// it; it is the branch that will keep firing, and it gets the same dialog
+		// and the same way out as bootstrap.ts's.
+		showStartupFailure(err, "startup");
 	});
-	// The local engine is the default backend; the host swaps in a remote one (over
-	// SSH) on connect and re-points the IPC bridge + event forwarding at it. Binding
-	// the engine's events to every window is the host's job now (see createHost);
-	// window management (detaching a project) is desktop-native, passed to registerIpc.
-	const host = createHost({ localEngine: engine, broadcast });
-	registerIpc(host.router, { openProjectWindow });
-	registerHostIpc(host);
-
-	if (SMOKE) {
-		// Headless boot check: prove the engine inits (db, hook server, notify
-		// script) without opening a window or the daemon, then exit cleanly.
-		console.log(`ATEAM_READY hookPort=${engine.services.hookPort}`);
-		engine.stopHooks();
-		app.exit(0);
-		return;
-	}
-
-	// Connect to (or launch) the PTY daemon and learn which sessions are still
-	// alive from a previous run, so the renderer can re-attach to them.
-	try {
-		await engine.connectPty();
-	} catch (err) {
-		console.error("[ateam] PTY daemon connect failed:", err);
-	}
-
-	createWindow();
-	buildAppMenu();
-	// Start the board reconciler (and any other registered loops) once the
-	// window exists, so the first pass can push corrections to the renderer.
-	engine.startLoops();
-	setupAutoUpdate();
-	app.on("activate", () => {
-		if (BrowserWindow.getAllWindows().length === 0) createWindow();
-	});
-}).catch((err) => {
-	// A startup failure (e.g. a native module built for the wrong CPU arch)
-	// would otherwise leave a live process with no window and no feedback —
-	// exactly the "click the app, nothing happens" symptom. Surface it and quit.
-	console.error("[ateam] startup failed:", err);
-	dialog.showErrorBox(
-		"Ateam failed to start",
-		`${APP_NAME} couldn't start and needs to close.\n\n${
-			err instanceof Error ? (err.stack ?? err.message) : String(err)
-		}`,
-	);
-	app.exit(1);
-});
 
 app.on("window-all-closed", () => {
 	// Do NOT kill PTYs — the daemon keeps them alive across restarts. engine.stop

--- a/apps/desktop/src/main/startup-failure.ts
+++ b/apps/desktop/src/main/startup-failure.ts
@@ -1,0 +1,69 @@
+// The one place a "couldn't start" failure is shown to the user.
+//
+// Startup can fail in two places, and before this they were handled separately
+// with different wording and different capability:
+//
+//   load     the main bundle throws while being require()d — a missing module
+//            (0.1.35 shipped without `ws`) or a wrong-arch better-sqlite3, which
+//            index.js requires at top level. Caught by bootstrap.ts.
+//   startup  the app is ready but createEngine() throws — schema DDL, a corrupt
+//            database, an unreadable data dir. Caught by index.ts.
+//
+// Both leave the user with a dead app and no way forward, so both get the same
+// dialog and the same escape hatch. Keeping them in one function is what stops
+// them drifting apart again: the load path is nearly extinct now that the build
+// gates every require() and every native module's arch, while the startup path
+// is data-dependent and therefore permanent — exactly the one that must not be
+// the neglected branch.
+//
+// Constraint inherited from bootstrap.ts: this module must resolve NOTHING at
+// runtime except `electron`. Its own imports are a bare string constant and
+// electron itself, so the bundler inlines it into both entry chunks and no
+// require() of a possibly-missing package is ever reached.
+
+import { app, dialog, shell } from "electron";
+import { APP_NAME } from "./app-name";
+
+const DOWNLOAD_URL = "https://github.com/clawnify/ateam/releases/latest/download/Ateam-macos.dmg";
+
+type Phase = "load" | "startup";
+
+// A broken build and broken local data need different words. Telling someone
+// already on the newest release that "this version is broken, install the
+// latest" sends them in a circle, so only the load path — which really does
+// mean the build is bad — makes that claim.
+const EXPLANATION: Record<Phase, string> = {
+	load: "This version is broken. Installing the latest version usually fixes it — your projects and sessions are kept.",
+	startup: `${APP_NAME} got as far as starting up, then stopped. Installing the latest version is the usual fix; if it keeps happening, the error above is the detail to report.`,
+};
+
+/**
+ * Show the failure, offer the only remedy that works from outside a dead app,
+ * and exit. Never returns.
+ */
+export function showStartupFailure(err: unknown, phase: Phase): void {
+	// The full error (stack, require stack) goes to stderr, where a terminal
+	// launch or Console.app keeps it for a bug report. The dialog gets the first
+	// line only — Node folds the whole require stack into .message, which turns
+	// the box into a wall of paths nobody reads.
+	console.error(`[ateam] ${phase} failed:`, err);
+	const summary = (err instanceof Error ? err.message : String(err)).split("\n")[0];
+
+	// Safe on both paths: already resolved when index.ts calls it, still pending
+	// when bootstrap.ts does.
+	app.whenReady().then(async () => {
+		const { response } = await dialog.showMessageBox({
+			type: "error",
+			message: `${APP_NAME} couldn't start`,
+			detail: `${summary}\n\n${EXPLANATION[phase]}`,
+			buttons: ["Download latest version", "Quit"],
+			defaultId: 0,
+			cancelId: 1,
+		});
+		if (response === 0) await shell.openExternal(DOWNLOAD_URL);
+		// exit, not quit: quit runs before-quit/window-all-closed handlers, and on
+		// the startup path those belong to a half-initialised app that may throw
+		// again. There is nothing left worth shutting down cleanly.
+		app.exit(1);
+	});
+}


### PR DESCRIPTION
Follow-up to #99. That PR made it impossible to *ship* a build with an unresolvable `require()`. This one makes it survivable if something else ever bricks the main process.

### The gap

When main fails at load time the app is unrecoverable from the inside — no window exists, so no in-app button can be reached, and `electron-updater` never runs, so the app cannot update itself out of a bad release. All the user gets is Electron's default dialog: a stack trace and an OK button.

Someone without a direct line to us had **no way back**. They had to guess a releases page exists and re-download by hand. Three releases have bricked this way — 0.1.35 on a missing `ws`, 0.1.24 and 0.1.26 on x86_64 native modules.

### The change

`package.json` `main` now points at `src/main/bootstrap.ts`, which `require()`s the main bundle inside a try/catch and, on failure, shows a dialog with **Download latest version**. It covers the whole load-time class: missing module, wrong-arch `.node`, corrupt asar, a throwing migration.

Two constraints keep the guard trustworthy, and both are load-bearing:

1. **It imports nothing but `electron`** — a bundled dependency is exactly what might be missing.
2. **It is a separate rollup input**, so `require("./index.js")` stays a real runtime require. Inlined into the main chunk, the throw would happen *before* the try block and the guard would never fire. Confirmed in the emitted output: `bootstrap.js` is 0.88 kB and `index.js` is unchanged at 439.63 kB.

### Verification — both branches, real Electron run

**Failure path** (an `index.js` that throws `Cannot find module 'ws'`, reproducing 0.1.35):

```
[bootstrap] main process failed to load: Error: Cannot find module 'ws'
Require stack:
- .../out/main/index.js
- .../out/main/bootstrap.js
```

…and the dialog renders with the error, the recovery text, and **Quit / Download latest version** (default). Confirmed on screen.

**Happy path** (a working `index.js`):

```
[index] real main loaded
[index] ready, no dialog
```

Loads through untouched, no dialog. `typecheck` and `biome check` pass, and `runtime-deps.mjs` still derives the same four deps with `bootstrap.js` present in `out/main`.

### Not covered

Async failures after load, and crashes inside Electron's own startup — neither reaches JS. Every incident so far has been load-time.

### Note

The bootstrap only takes effect for users who are *already* on a build that has it, so it does nothing for anyone still stranded on 0.1.35. It should go out in the next release.
