### PR TITLE
chore: release 0.1.37

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "private": true,
   "main": "./out/main/bootstrap.js",
   "scripts": {


### PR DESCRIPTION
Ships the crash-recovery work from #100 (and the packaging gate from #99, already live in 0.1.36).

- **#100** — crash-safe bootstrap. A load-time failure in main, or a post-ready startup failure, now shows a dialog offering **Download latest version** instead of Electron's bare stack-trace box. Both paths share one handler (`showStartupFailure`), so the data-dependent branch — the one no build gate can prevent — gets the same way out as the build-broken one.
- **#99** — already in 0.1.36: `ws` ships, the staging dependency set is derived from the built bundle, and publishing is blocked if any `require()`d package is missing from the signed `.app`.

No functional changes to the app itself.