### PR TITLE
Docs: a providers directory, so the README stops growing per provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,69 +146,15 @@ Some services create a box for you and write an SSH alias straight into your
 `~/.ssh/config`. Ateam offers any alias it finds there, so a box provider needs **no
 Ateam-side integration** — the recipe is always the same: create a box with the
 provider's CLI, run Ateam's `install.sh` on it over that alias, sign into `gh` and your
-agent, then pick the alias in the connection switcher. **[boxd](https://boxd.sh)** is the
-first such provider; the same steps fit any service that registers an ssh_config host.
+agent, then pick the alias in the connection switcher.
+
+Per-provider recipes live in [`docs/providers/`](docs/providers/) — what's
+preinstalled, how git credentials work, whether the phone can reach it, and the
+gotchas. **[boxd](https://boxd.sh)** is the first one
+([recipe](docs/providers/boxd.md)); the same steps fit any service that registers an
+ssh_config host, and [adding one](docs/providers/#adding-a-provider) is a docs-only PR.
 
 <a href="https://boxd.sh"><img src="./assets/boxd.png" alt="boxd" width="99" /></a>
-
-[boxd](https://boxd.sh) rents persistent Linux microVMs that boot in milliseconds and
-already ship `git`, `gh`, `node`, `docker` and `claude` — so there's no user, firewall
-or Tailscale setup to do. Unlike the VPS recipe above, the box is reached over boxd's
-own authenticated SSH proxy rather than your tailnet.
-
-**On your Mac,** install the CLI and create a box:
-
-```bash
-curl -fsSL https://boxd.sh/downloads/install.sh | sh
-boxd auth login
-boxd new mybox
-```
-
-boxd writes the `mybox.boxd` host alias — hostname, port and key — straight into your
-`~/.ssh/config`, so `ssh mybox.boxd` works immediately and the box shows up in Ateam's
-connection switcher with nothing else to configure.
-
-**Give boxd access to your repos once, on your Mac** — not per box:
-
-```bash
-boxd manage integrations connect github
-```
-
-boxd's images ship a git credential helper wired in `/etc/gitconfig`
-(`helper = boxd`), so every machine — and every fork of one — gets authenticated git
-without a token ever being written inside the VM. Disconnecting revokes it centrally.
-**Don't run `gh auth setup-git` on a boxd box:** it writes a *global* helper that
-resets the inherited chain, replacing boxd's with its own.
-
-**Then set the box up for agents,** over that alias. Ateam commits, pushes and opens
-PRs as this user, so it needs a git identity, and a logged-in `gh` for the PR and
-merge-queue operations that go through the `gh` API rather than git:
-
-```bash
-ssh mybox.boxd 'git config --global user.name "you" && git config --global user.email "you@example.com"'
-ssh -t mybox.boxd 'gh auth login'      # device code — works over SSH
-ssh -t mybox.boxd claude               # `claude` is preinstalled; log in once, then exit
-
-ssh mybox.boxd 'curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash'
-```
-
-Public repos clone with no credentials at all; the setup above is what private repos
-need. If adding a project fails with `RPC connection closed`, that's not a credential
-problem — a missing credential fails fast and loudly with
-`could not read Username for 'https://github.com'`. Check the desktop app is up to
-date instead; a client older than the box's protocol version drops the connection.
-
-The readiness report ends with `[--] tailscale`. That one is expected here — boxd
-provides the private path itself.
-
-Finally, pick **`mybox.boxd`** in Ateam's connection switcher. boxd registers more
-than one alias per machine (`mybox.boxd`, `mybox.boxd.sh`, plus a shared `boxd.sh`
-defaults entry) — pick `mybox.boxd`; `boxd.sh` is not a machine.
-
-**The iOS app does not work with boxd.** The phone reaches a box over Tailscale, and
-boxd's kernel is built without a TUN device (`/lib/modules` is empty and `modprobe
-tun` fails), so `tailscaled` can't run in its normal mode. Use the VPS recipe above
-for the iOS app.
 
 </details>
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -1,0 +1,105 @@
+# Box providers
+
+A **box provider** is any service that hands you a Linux box you can SSH into.
+Ateam offers every `Host` alias it finds in your `~/.ssh/config`, so a provider
+needs **no Ateam-side integration at all** — if their CLI writes an alias (or you
+add one yourself), the box shows up in the connection switcher.
+
+That makes the recipe the same everywhere:
+
+1. Create a box with the provider's own tooling.
+2. Run [`install.sh`](../../packages/server/scripts/install.sh) on it over that alias.
+3. Give it a git identity, sign into `gh`, and log into an agent CLI once.
+4. Pick the alias in Ateam's connection switcher.
+
+What differs between providers is the boring, unguessable detail — what's
+preinstalled, how git credentials work, whether there's an `sshd` in the box at
+all. That's what the pages here record.
+
+## Providers
+
+| Provider | Kind | Desktop | iOS |
+| --- | --- | --- | --- |
+| [boxd](boxd.md) | persistent KVM microVMs | ✅ via boxd's SSH proxy | ⚠️ works, but needs manual Tailscale setup |
+| Your own VPS | Hetzner, EC2, a home server… | ✅ | ✅ | 
+
+For a VPS from scratch, see [`../online-ateam.md`](../online-ateam.md) — that's the
+reference walkthrough these pages assume you've skimmed.
+
+> **Not the same as "Create a box" in the app.** The desktop can *provision* a VPS
+> for you (currently Hetzner) via the `BoxProvider` interface in
+> `packages/server/src/provision.ts`. That's a code integration holding your API
+> token, and it's maintained in-tree rather than contributed — each one is a live
+> API client whose breakage looks like an Ateam bug. This directory is for the
+> other kind: services you drive with their own CLI, which need no code from us.
+
+## Adding a provider
+
+Open a PR with `docs/providers/<name>.md` using the template below, and add a row
+to the table above. Docs only — no code changes are needed or wanted.
+
+**Every page must carry a `Verified against` line.** These pages rot fast: ours
+was wrong within eight days of being written, and confidently-wrong setup
+instructions are worse than none, because people follow them. If you can't say
+when you last ran the steps, don't publish the page.
+
+### Template
+
+```markdown
+# <Provider>
+
+<One paragraph: what kind of box, what it costs, what's unusual about it.>
+
+**Verified against** Ateam vX.Y.Z · <provider CLI version> · YYYY-MM-DD
+
+## Create a box
+
+<The provider's CLI commands, from install to a running box.>
+
+<What lands in ~/.ssh/config, and exactly which alias to pick.>
+
+## What's preinstalled
+
+<git, gh, node, docker, agent CLIs — and what's missing that you'd expect.>
+
+## GitHub credentials
+
+<Does the provider supply git credentials, or do you run `gh auth login`?
+Anything that would clash with the provider's own mechanism?>
+
+## Install the engine
+
+<The install.sh one-liner, plus any provider-specific flags or env.>
+
+## Connect
+
+<Which alias to pick in the switcher; anything surprising in the list.>
+
+## iOS
+
+<Can the phone reach it? The phone needs a WebSocket over Tailscale, so: can the
+box join a tailnet, and can an arbitrary TCP port be reached on it?>
+
+## Gotchas
+
+<The things that cost you an hour. Be specific — quote the error text.>
+```
+
+### What each section is really asking
+
+These aren't arbitrary headings; each one is a thing that silently differed on a
+real provider and cost real time:
+
+- **Which alias** — one provider writes *three* `~/.ssh/config` entries per
+  machine, one of which isn't a machine at all.
+- **What's preinstalled** — a microVM image may already have `git`, `gh`, `node`,
+  `docker` and `claude`; a bare VPS has none of them.
+- **GitHub credentials** — a provider may supply a git credential helper of its
+  own, in which case the usual `gh auth setup-git` *replaces* it and quietly
+  breaks the better mechanism.
+- **Is there an `sshd` in the box?** Not always. A provider can terminate SSH at
+  its own proxy, so anything assuming a local SSH service fails in a confusing
+  way.
+- **iOS** — the phone has no SSH; it needs a WebSocket over Tailscale. Whether
+  that's possible is the single biggest capability difference between providers,
+  and it depends on details as obscure as whether the kernel ships `/dev/net/tun`.

--- a/docs/providers/boxd.md
+++ b/docs/providers/boxd.md
@@ -1,0 +1,126 @@
+# boxd
+
+<a href="https://boxd.sh"><img src="../../assets/boxd.png" alt="boxd" width="99" /></a>
+
+[boxd](https://boxd.sh) rents persistent Linux microVMs — KVM, own kernel, real
+root — that boot in milliseconds and fork in ~160ms carrying disk, memory and
+running processes. The images already ship `git`, `gh`, `node`, `docker` and
+`claude`, so there's no user, firewall or Tailscale setup to do. Unlike a VPS, the
+box is reached over boxd's own authenticated SSH proxy rather than your tailnet.
+
+**Verified against** Ateam v0.1.39 · boxd CLI 0.2.5 · 2026-08-12
+
+## Create a box
+
+```bash
+curl -fsSL https://boxd.sh/downloads/install.sh | sh
+boxd auth login
+boxd new mybox
+```
+
+boxd writes the `mybox.boxd` host alias — hostname, port and key — straight into
+your `~/.ssh/config`, so `ssh mybox.boxd` works immediately and the box appears in
+Ateam's connection switcher with nothing else to configure.
+
+Note the installer also drops `boxd-*` skills into `~/.claude/skills`, wires them
+into Codex and OpenCode, and enables zsh completion.
+
+## What's preinstalled
+
+`git`, `gh`, `node`, `npm`, `docker`, `claude`, `codex`.
+
+**Not** present, and worth knowing: `tailscale`, and — surprisingly — **`sshd`**.
+Nothing listens on port 22 inside the VM; boxd terminates SSH at its proxy.
+
+## GitHub credentials
+
+Connect once on your Mac, not per box:
+
+```bash
+boxd manage integrations connect github
+```
+
+boxd's images ship a git credential helper wired at **system scope** in
+`/etc/gitconfig` (`helper = boxd`, backed by `/usr/local/bin/boxd-github-token`),
+plus a `url.insteadOf` rewrite so `git@github.com:` remotes go through it too. The
+helper fetches the token on demand, so **no token is stored inside the VM** — which
+means snapshots and forks get working git access without inheriting a credential.
+Disconnecting revokes it centrally.
+
+**Don't run `gh auth setup-git` on a boxd box.** It writes a *global* helper and
+emits an empty `helper =` first, which resets the inherited chain — silently
+replacing boxd's mechanism with gh's. If it's already been run:
+
+```bash
+git config --global --unset-all credential.https://github.com.helper
+```
+
+Still run `gh auth login`: Ateam's PR and merge-queue operations go through the
+`gh` API rather than git.
+
+## Install the engine
+
+```bash
+ssh mybox.boxd 'git config --global user.name "you" && git config --global user.email "you@example.com"'
+ssh -t mybox.boxd 'gh auth login'      # device code — works over SSH
+ssh -t mybox.boxd claude               # preinstalled; log in once, then exit
+
+ssh mybox.boxd 'curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash'
+```
+
+The readiness report ends with `[--] tailscale`. That one is expected — boxd
+provides the private path itself.
+
+## Connect
+
+Pick **`mybox.boxd`** in the connection switcher.
+
+boxd registers more than one alias per machine (`mybox.boxd`, `mybox.boxd.sh`,
+plus a shared `boxd.sh` defaults entry). Ateam collapses aliases that reach the
+same engine, so you should see one entry — but if you're on an older build you'll
+see all three, and `boxd.sh` is not a machine.
+
+## iOS
+
+The phone reaches a box over a WebSocket on your tailnet, and a boxd VM **can't run
+`tailscaled` normally**: the kernel is monolithic with no TUN device (`/lib/modules`
+is empty and loading `tun` fails). boxd is building a proxy-based Tailscale
+integration — proxy nodes join *your* tailnet and route to your VMs — which will
+make this automatic. Until that ships, it works via Tailscale's
+**userspace-networking** mode, which needs no TUN:
+
+```bash
+# on the box
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo sed -i 's|^FLAGS=.*|FLAGS="--tun=userspace-networking"|' /etc/default/tailscaled
+sudo systemctl restart tailscaled
+sudo tailscale up --hostname=mybox        # prints a sign-in URL
+
+# keep the engine on loopback and let Tailscale bridge to it
+sudo loginctl enable-linger "$USER"
+ATEAM_WS_ADDR=127.0.0.1:8787 \
+  curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash -s -- --service
+sudo tailscale serve --bg --tcp 8787 tcp://localhost:8787
+```
+
+Then point the phone at `<tailnet-ip>:8787`. The engine only ever binds loopback,
+so it's reachable from your tailnet and nowhere else — the same posture as a VPS.
+
+Two caveats: traffic relays through DERP rather than a direct path (fine for
+JSON-RPC, laggier for PTY output), and this is manual per box.
+
+## Gotchas
+
+- **`RPC connection closed` is not a credential error.** A missing credential fails
+  fast and loudly with `could not read Username for 'https://github.com'`, and
+  public repos clone with no credentials at all. If provisioning drops the
+  connection, the desktop app is out of date relative to the box's protocol
+  version.
+- **`boxd env set` defaults to `--scope shared`** — the org's shared VMs. Pass
+  `--scope private` deliberately.
+- **Snapshots capture memory + disk**, including Ateam's engine database at
+  `~/.ateam/ateam.sqlite`. Ateam routes by globally-unique ids, so forks sharing a
+  database silently mis-route git operations and hide one fork's tasks. Delete it
+  before `boxd snapshots save`, and log `gh` out first — forks inherit credentials
+  too.
+- **`boxd snapshots save`**, not `create`.


### PR DESCRIPTION
Ateam offers every ~/.ssh/config alias it finds, so a box provider needs no
Ateam-side integration — the recipe is identical everywhere. What differs is the
unguessable detail, and that's what these pages record.

- docs/providers/README.md: how the pattern works, an index, a page template, and
  what each section is really asking. Every heading in that template is a thing
  that silently differed on a real provider and cost real time — which alias to
  pick, what's preinstalled, whose credential helper wins, whether there's an
  sshd in the box at all, and whether the phone can reach it.
- docs/providers/boxd.md: the boxd recipe, moved out of the README.
- README: the boxd <details> block drops from 70 lines to 12 — the general
  pattern and a pointer.

Two corrections carried in from testing on a live box:

- iOS is no longer "does not work with boxd". A boxd VM can't run tailscaled
  normally (monolithic kernel, no /dev/net/tun), but Tailscale's
  userspace-networking mode needs no TUN, and with the engine bound to loopback
  and `tailscale serve --tcp` bridging to it, the phone's WebSocket connects.
  Verified against a real box: handshake returned protocolVersion 2. The page
  carries the recipe, and the caveats — DERP-relayed, manual per box.
- boxd VMs ship no sshd, which is why anything assuming a local SSH service
  fails confusingly. Now stated rather than discovered.

Every page must carry a `Verified against` line. These rot fast: ours was wrong
within eight days, and confidently-wrong setup instructions are worse than none,
because people follow them.

Scope note: this is deliberately not the in-app "Create a box" flow. That path
(BoxProvider in packages/server/src/provision.ts) is a live API client holding a
user's token and stays maintained in-tree; this directory is for services you
drive with their own CLI, which need no code from us.
