### PR TITLE
Desktop: route a never-connected box to set-up instead of a failed connect

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -419,6 +419,9 @@ export function App() {
 				label: c.alias,
 				disabled: !memberAliases.has(c.alias) && !canRemote,
 				transport: c.transport,
+				// `known` is only set by a successful connect, so a config alias we've
+				// never reached is one the engine has probably never been installed on.
+				needsSetup: !c.known,
 			})),
 		];
 	}, [connections, canRemote, hasLocalMember, activeMembers]);

--- a/apps/desktop/src/renderer/src/components/EnvironmentPicker.tsx
+++ b/apps/desktop/src/renderer/src/components/EnvironmentPicker.tsx
@@ -22,6 +22,8 @@ export type EnvOption = {
 	label: string;
 	disabled: boolean;
 	transport?: "ssh" | "ws";
+	/** In ~/.ssh/config but never connected — so almost certainly has no engine yet. */
+	needsSetup?: boolean;
 };
 
 export function EnvironmentPicker({
@@ -90,6 +92,17 @@ export function EnvironmentPicker({
 
 	const pick = (env: EnvOption) => {
 		if (env.disabled) return;
+		// Every ~/.ssh/config alias is offered here, including boxes that have never
+		// run the engine — picking one of those used to just fail to connect. Send it
+		// to the set-up form with the destination filled in instead. Worst case the
+		// box IS already set up (installed by hand, never connected from this Mac):
+		// install.sh is idempotent and ends by connecting, so that path still works.
+		if (env.needsSetup && env.alias && env.transport !== "ws" && onInstall) {
+			setDest(env.alias);
+			setAddMode("ssh");
+			setInstallError(null);
+			return;
+		}
 		onChange(env.alias);
 		close();
 	};
@@ -197,6 +210,8 @@ export function EnvironmentPicker({
 									<span className="conn-title">{env.label}</span>
 									{env.disabled && env.alias !== null ? (
 										<span className="conn-sub">repo needs a git remote to run here</span>
+									) : env.needsSetup ? (
+										<span className="conn-sub">not set up — click to install the engine</span>
 									) : env.transport === "ws" ? (
 										<span className="conn-sub">Tailscale</span>
 									) : null}


### PR DESCRIPTION
`composerEnvs` maps **every** `~/.ssh/config` alias into the Run-on list, and `disabled` only reflects whether the repo can get there — so a box that has never had the engine installed looks identical to a ready one, and picking it just fails to connect. That's the common case for a box provider: `boxd new` writes the alias long before Ateam is involved.

The information needed was already there. `ConnectionDTO.known` is set only by a successful connect, so `!known` marks exactly the aliases the engine has probably never run on. Those rows now read **"not set up — click to install the engine"**, and picking one opens the existing Set-up-over-SSH form with the destination prefilled instead of attempting a connect.

**No provider registry, no new IPC, no new state.** This reuses `host:install` (which already accepts any *"ssh alias or user@host"*) and a flag `listConnections` already computes, so it fixes every provider at once rather than special-casing boxd. 18 lines.

### Edge cases

- `!known` errs in one direction: a box set up by hand and never connected from this Mac reads as needs-setup. Harmless — `install.sh` is idempotent and ends by connecting, which is what picking it would have done.
- `ws` endpoints are excluded; they're typed in and connected in one step, so a saved-but-unknown one should never be handed to an SSH installer.

### Verification

Typecheck clean, 151 tests pass, renderer production build green. The ready/needs-setup split was checked against the real `~/.ssh/config` plus a copy of the app's host records: `hetzner-devbox` and `ateam-probe.boxd` read ready; `hetzner`, `hetzner-ateam` and a siteground host read needs-setup.

Not verified: the rendered popover itself — this needs a look in the running app.