### PR TITLE
Server: a system unit for --service, so an OOM kill can't strand the phone

### DIFF
--- a/docs/online-ateam.md
+++ b/docs/online-ateam.md
@@ -120,7 +120,7 @@ Re-run the same command to upgrade. Three knobs, all optional:
 
 | Knob | Effect |
 | --- | --- |
-| `--service` | also install a `systemd --user` unit so the daemon survives logout and reboot (`… \| bash -s -- --service`). Required for the iOS app — see step 5. |
+| `--service` | also install a systemd unit so the daemon survives logout, reboot and an OOM kill (`… \| bash -s -- --service`). Required for the iOS app — see step 5. |
 | `ATEAM_VERSION=v0.1.30` | install a specific release instead of the latest |
 | `ATEAM_TARBALL=<url\|path>` | install from your own `ateam-server.tar.gz` (dev builds, air-gapped boxes) |
 
@@ -277,6 +277,44 @@ thing between the two.
 > for desktop-only use — `ssh … ateam attach` starts one on demand — but it strands a
 > phone, which has no way to start one. Install the service if you use the app.
 
+### Keeping the daemon alive
+
+The desktop and the phone fail very differently when the daemon dies, and it's worth
+knowing which one you're looking at. The desktop starts a daemon on demand over SSH,
+so it repairs the box just by connecting. The phone only has the WebSocket, which
+exists *only while a daemon is already running* — so the phone can't recover a box,
+it can only report that one is down. **If the desktop connects and the phone doesn't,
+suspect the daemon, not the app.** Tailscale showing green proves the network path,
+nothing about what's listening at the other end.
+
+The usual cause is memory. Agents are long-lived and hold 200–450 MB each, so a
+busy 4 GB box reaches the kernel's out-of-memory killer, which then picks a victim
+by score — and a systemd **user** service is scored as a *preferred* victim
+(`user@.service` sets `OOMScoreAdjust=100`, inherited by everything under it) while
+the far larger agents sit at 0. Worse, a user service dies with the systemd user
+manager: if that is killed too, `enable-linger` does not bring it back and only a
+new login does.
+
+So `--service` installs a **system** unit wherever it can escalate without a
+password, which is what the daemon actually is — the box's only ingress for the
+phone, on par with `sshd`. That unit sets `OOMScoreAdjust=-500` (the convention
+distros use for `udevd`, `dbus`, `journald`), so the kernel reaps an agent first,
+and `StartLimitIntervalSec=0`, so systemd never permanently gives up restarting
+after a burst of kills. On a box with no sudo you get the user unit instead, and
+the installer says so — it still can't be protected from the OOM killer, because
+lowering the score needs `CAP_SYS_RESOURCE` and systemd *silently ignores* the
+setting in a user unit rather than failing.
+
+Which one you have:
+
+```bash
+systemctl status ateam          # system unit
+systemctl --user status ateam   # user unit
+```
+
+Re-running the installer on a box that has gained sudo upgrades a user unit to a
+system one, carrying `ATEAM_WS_ADDR` across and leaving running agents untouched.
+
 ## Troubleshooting
 
 The connection menu surfaces the real error inline. Common ones:
@@ -289,7 +327,8 @@ The connection menu surfaces the real error inline. Common ones:
 | Board is empty after connecting | The box has no registered projects yet — add one from the box's filesystem via **Add project** (or register a repo path on the box). |
 | Agents run but commits fail | The box has no git identity — `git config --global user.name/user.email` (step 0). |
 | The agent picker is empty | The agent CLI isn't on the box's **login** PATH: `ssh <box> "bash -lc 'command -v claude'"`. |
-| The iOS app won't connect | In order: is Tailscale's VPN toggle on on the phone; is a daemon running at all (`systemctl --user status ateam`); does it say `also listening on ws://…` (if not it started before `ATEAM_WS_ADDR` was set — `systemctl --user restart ateam`); does `sudo ufw status` allow the **tailscale0 interface**, not just port 22. |
+| The iOS app won't connect (but the desktop does) | The daemon is down — the desktop restarts one over SSH just by connecting, so it hides this. Check `systemctl status ateam` (or `--user`, depending on the unit); if it was OOM-killed, `journalctl -u ateam \| grep oom` shows it. See [Keeping the daemon alive](#keeping-the-daemon-alive). |
+| The iOS app won't connect | In order: is Tailscale's VPN toggle on on the phone (green only proves the path, not that anything is listening); is a daemon running at all (`systemctl status ateam`, or `--user` for a user unit); does it say `also listening on ws://…` (if not it started before `ATEAM_WS_ADDR` was set — restart it); does `sudo ufw status` allow the **tailscale0 interface**, not just port 22. |
 
 ## Notes
 

--- a/docs/providers/boxd.md
+++ b/docs/providers/boxd.md
@@ -97,6 +97,8 @@ sudo systemctl restart tailscaled
 sudo tailscale up --hostname=mybox        # prints a sign-in URL
 
 # keep the engine on loopback and let Tailscale bridge to it
+# (linger only matters if the installer falls back to a --user unit; with sudo
+#  available here it writes a system unit, which needs no login session at all)
 sudo loginctl enable-linger "$USER"
 ATEAM_WS_ADDR=127.0.0.1:8787 \
   curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash -s -- --service

--- a/docs/providers/hetzner.md
+++ b/docs/providers/hetzner.md
@@ -49,8 +49,10 @@ providers, running `gh auth setup-git` here is harmless.
 curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash
 ```
 
-Add `-s -- --service` to install a `systemd --user` unit — required for the iOS app,
-which can't start a daemon on demand the way the desktop does over SSH.
+Add `-s -- --service` to install a systemd unit — required for the iOS app, which
+can't start a daemon on demand the way the desktop does over SSH. With passwordless
+sudo (what this box's cloud-init grants) you get a *system* unit, which also survives
+an out-of-memory kill; see [Keeping the daemon alive](../online-ateam.md#keeping-the-daemon-alive).
 
 ## Connect
 

--- a/packages/server/scripts/install.sh
+++ b/packages/server/scripts/install.sh
@@ -8,9 +8,12 @@
 # the dist in place. Files are only ever created or overwritten, never removed.
 #
 # Options:
-#   --service       also install a `systemd --user` unit so the daemon survives
-#                   logout and reboot (required for the iOS app, which cannot
-#                   start a daemon on demand the way the desktop does over SSH)
+#   --service       also install a systemd unit so the daemon survives logout,
+#                   reboot and an OOM kill (required for the iOS app, which cannot
+#                   start a daemon on demand the way the desktop does over SSH).
+#                   A SYSTEM unit where passwordless sudo is available, a `--user`
+#                   one otherwise — only the former can stop the kernel from
+#                   picking the daemon over the agents it supervises.
 #
 # Env knobs:
 #   ATEAM_VERSION   release tag to install (default: the latest release)
@@ -216,67 +219,161 @@ fi
 # the WebSocket only exists once a daemon is already running, and nothing brings
 # one back after a reboot.
 if [ "$WANT_SERVICE" = 1 ]; then
-	step "install the user service"
 	if ! command -v systemctl >/dev/null; then
 		die "no systemd on this box — start 'ateam daemon' from your own init instead"
 	fi
-	UNIT_DIR="$HOME/.config/systemd/user"
-	UNIT="$UNIT_DIR/ateam.service"
-	mkdir -p "$UNIT_DIR"
+
+	SYS_UNIT=/etc/systemd/system/ateam.service
+	USER_UNIT="$HOME/.config/systemd/user/ateam.service"
+
+	# A SYSTEM unit whenever we can escalate without a password, a user unit otherwise.
+	# A user unit cannot protect this daemon, for three reasons that only bite under
+	# memory pressure — exactly when you need it most:
+	#   1. `user@.service` ships OOMScoreAdjust=100, which every user service inherits.
+	#      That makes a ~40MB daemon a MORE attractive kernel OOM victim than the
+	#      400MB agents it supervises (they sit at 0). Precisely backwards.
+	#   2. A negative OOMScoreAdjust cannot fix that from a user unit: lowering the
+	#      score needs CAP_SYS_RESOURCE, and systemd SILENTLY IGNORES the setting
+	#      rather than failing — the unit starts and the value never lands, so the
+	#      line reads as protection while doing nothing.
+	#   3. A user unit dies with the systemd user manager. If that manager is itself
+	#      OOM-killed, linger does NOT bring it back; only a new login does.
+	# The desktop survives all three — it re-launches a daemon over SSH on demand.
+	# THE PHONE CANNOT: the WebSocket only exists once a daemon is already running,
+	# so for the iOS app this is the difference between a 3s restart and a box that
+	# stays dark until someone opens a laptop.
+	if sudo -n true 2>/dev/null; then
+		SERVICE_SCOPE=system
+		UNIT="$SYS_UNIT"
+		SYSTEMCTL="sudo systemctl"
+		step "install the system service"
+	else
+		SERVICE_SCOPE=user
+		UNIT="$USER_UNIT"
+		SYSTEMCTL="systemctl --user"
+		step "install the user service"
+		mkdir -p "$(dirname "$UNIT")"
+	fi
 
 	# Upgrading IS re-running this script, and a phone user who doesn't re-export
 	# ATEAM_WS_ADDR would otherwise get a rewritten unit without it — silently
 	# removing the phone's only way in, with the daemon still apparently healthy.
-	# An explicit ATEAM_WS_ADDR always wins; otherwise inherit what's already there.
+	# An explicit ATEAM_WS_ADDR always wins; otherwise inherit whichever unit has
+	# one — including the OTHER scope's, so a user→system upgrade keeps the address.
 	WS_ADDR="${ATEAM_WS_ADDR:-}"
-	if [ -z "$WS_ADDR" ] && [ -f "$UNIT" ]; then
-		WS_ADDR="$(sed -n 's/^Environment=ATEAM_WS_ADDR=//p' "$UNIT" | tail -1)"
-		if [ -n "$WS_ADDR" ]; then info "keeping ATEAM_WS_ADDR=$WS_ADDR from the existing unit"; fi
+	if [ -z "$WS_ADDR" ]; then
+		for u in "$UNIT" "$SYS_UNIT" "$USER_UNIT"; do
+			[ -f "$u" ] || continue
+			WS_ADDR="$(sed -n 's/^Environment=ATEAM_WS_ADDR=//p' "$u" | tail -1)"
+			if [ -n "$WS_ADDR" ]; then
+				info "keeping ATEAM_WS_ADDR=$WS_ADDR from $u"
+				break
+			fi
+		done
 	fi
-	{
+
+	emit_unit() {
 		echo '[Unit]'
 		echo 'Description=Ateam engine daemon'
+		if [ "$SERVICE_SCOPE" = system ]; then
+			# The WS listener binds the Tailscale IP, so that address must exist
+			# before the bind. If it doesn't the daemon exits and the restart loop
+			# below retries until Tailscale is up. (Meaningless in a user unit:
+			# network-online.target lives in the SYSTEM manager, not the user one.)
+			echo 'Wants=network-online.target'
+			echo 'After=network-online.target tailscaled.service'
+		fi
+		# systemd gives up PERMANENTLY after 5 starts in 10s by default. A burst of
+		# OOM kills exhausts that budget, and then nothing ever restarts the daemon
+		# — the phone's only ingress stays down until a human logs in. Retry forever.
+		echo 'StartLimitIntervalSec=0'
 		echo ''
 		echo '[Service]'
 		# A LOGIN shell: agent CLIs are discovered with `which` against this
 		# process's own PATH, and a bare unit PATH resolves none of them.
 		echo "ExecStart=/bin/bash -lc 'exec ateam daemon'"
-		echo 'WorkingDirectory=%h'
+		if [ "$SERVICE_SCOPE" = system ]; then
+			echo "User=$(id -un)"
+			# NOT %h: in a system unit that expands to root's home, not User='s.
+			echo "WorkingDirectory=$HOME"
+			# What every distro already does for control-plane daemons (udevd -1000,
+			# dbus -900, journald -250). This one owns the box's only phone ingress,
+			# so the kernel should reap a 400MB agent before it. System scope only —
+			# see the note above on why this line is worthless in a user unit.
+			echo 'OOMScoreAdjust=-500'
+		else
+			echo 'WorkingDirectory=%h'
+		fi
 		# The PTY daemon is a DETACHED child holding every live agent session.
 		# `detached` escapes the process group, NOT the cgroup — under the default
 		# KillMode=control-group a restart would kill every running agent. Kill
 		# only the main process so sessions survive, exactly as they do today.
 		echo 'KillMode=process'
 		# NOT `always`: `ateam daemon` exits 0 when another daemon already owns the
-		# socket, and always-restart would turn that into a hot loop.
+		# socket, and always-restart would turn that into a hot loop — one that
+		# StartLimitIntervalSec=0 above would never brake. An OOM kill is a SIGKILL,
+		# which counts as a failure, so self-healing is unaffected.
 		echo 'Restart=on-failure'
 		echo 'RestartSec=2'
 		if [ -n "$WS_ADDR" ]; then echo "Environment=ATEAM_WS_ADDR=$WS_ADDR"; fi
 		echo ''
 		echo '[Install]'
-		echo 'WantedBy=default.target'
-	} >"$UNIT"
+		if [ "$SERVICE_SCOPE" = system ]; then
+			echo 'WantedBy=multi-user.target'
+		else
+			echo 'WantedBy=default.target'
+		fi
+	}
+	if [ "$SERVICE_SCOPE" = system ]; then
+		emit_unit | sudo tee "$UNIT" >/dev/null
+	else
+		emit_unit >"$UNIT"
+	fi
 	info "wrote $UNIT"
 
-	# Keep the user manager alive with no login session, so the daemon comes back
-	# after a reboot. Unprivileged: polkit's set-self-linger allows this for your
-	# OWN user (set-user-linger, for someone else's, is the one needing admin).
-	loginctl enable-linger 2>/dev/null || info "could not enable linger — the service won't start on boot"
-	systemctl --user daemon-reload
-	systemctl --user enable ateam.service >/dev/null 2>&1 || true
+	# Upgrading an older install: the user unit must stop owning the socket, or the
+	# two race for it. Live agents are unaffected — they sit outside this unit's
+	# cgroup and the PTY daemon holding them is never touched.
+	if [ "$SERVICE_SCOPE" = system ] && [ -f "$USER_UNIT" ]; then
+		if systemctl --user is-active --quiet ateam.service 2>/dev/null ||
+			systemctl --user is-enabled --quiet ateam.service 2>/dev/null; then
+			info "migrating the existing user service to a system service"
+			systemctl --user disable --now ateam.service >/dev/null 2>&1 || true
+		fi
+	fi
+
+	if [ "$SERVICE_SCOPE" = user ]; then
+		# Keep the user manager alive with no login session, so the daemon comes back
+		# after a reboot. Unprivileged: polkit's set-self-linger allows this for your
+		# OWN user (set-user-linger, for someone else's, is the one needing admin).
+		loginctl enable-linger 2>/dev/null || info "could not enable linger — the service won't start on boot"
+	fi
+	$SYSTEMCTL daemon-reload
+	$SYSTEMCTL enable ateam.service >/dev/null 2>&1 || true
 
 	# Never kill a daemon out from under running agents. If one is already up
-	# outside systemd, hand over deliberately rather than silently.
-	if [ -S "$HOME/.ateam/rpc.sock" ] && ! systemctl --user is-active --quiet ateam.service; then
+	# outside systemd, hand over deliberately rather than silently. Test for a live
+	# PROCESS, not for the socket file: a crashed daemon leaves the file behind, and
+	# that stale socket would otherwise make this skip starting the service.
+	if pgrep -f 'ateam-app/cli\.js daemon' >/dev/null 2>&1 && ! $SYSTEMCTL is-active --quiet ateam.service; then
 		info "a daemon is already running outside systemd — enabled for next boot."
 		info "to hand it over now (agents keep running; the PTY daemon is untouched):"
-		info "     pkill -f 'ateam-app/cli.js daemon' && systemctl --user start ateam"
+		info "     pkill -f 'ateam-app/cli.js daemon' && $SYSTEMCTL start ateam"
 	else
-		systemctl --user start ateam.service
+		$SYSTEMCTL start ateam.service
 		sleep 2
-		systemctl --user is-active --quiet ateam.service &&
+		$SYSTEMCTL is-active --quiet ateam.service &&
 			info "service active; starts on boot" ||
-			die "service failed to start — systemctl --user status ateam"
+			die "service failed to start — $SYSTEMCTL status ateam"
+	fi
+
+	if [ "$SERVICE_SCOPE" = user ]; then
+		info ""
+		info "NOTE: installed as a USER service — no passwordless sudo on this box."
+		info "The daemon is then a preferred kernel OOM victim and dies with the"
+		info "systemd user manager, which only a new login restarts. The desktop"
+		info "recovers on its own over SSH; the iOS app cannot. Grant sudo and"
+		info "re-run this installer to upgrade it to a system service."
 	fi
 fi
 

--- a/skills/setup-vps/SKILL.md
+++ b/skills/setup-vps/SKILL.md
@@ -160,16 +160,22 @@ export ATEAM_WS_ADDR=<box-tailnet-ip>:8787
 curl -fsSL https://raw.githubusercontent.com/clawnify/ateam/main/packages/server/scripts/install.sh | bash -s -- --service
 ```
 
-The unit carries `ATEAM_WS_ADDR`, lingering keeps it alive across logout and reboot,
-and none of it needs sudo. A wildcard bind is refused and the daemon exits — the
-socket has no auth of its own, so the bind address must be the box's own `100.x`.
+The unit carries `ATEAM_WS_ADDR`. A wildcard bind is refused and the daemon exits —
+the socket has no auth of its own, so the bind address must be the box's own `100.x`.
+
+Where passwordless sudo exists the installer writes a **system** unit; otherwise a
+`--user` one kept alive by lingering. Prefer the system unit for any box a phone
+uses: only it can set `OOMScoreAdjust=-500`, without which the kernel kills this
+daemon *before* the far larger agents it supervises, and only the phone can't
+recover from that on its own. Check which you have with `systemctl status ateam`
+vs `systemctl --user status ateam`.
 
 If a daemon is already running outside systemd the installer will **not** kill it; it
 prints the handover instead. Running agents survive it:
 
 ```bash
-pkill -f 'ateam-app/cli.js daemon' && systemctl --user start ateam
-systemctl --user restart ateam    # the restart command from here on
+pkill -f 'ateam-app/cli.js daemon' && systemctl start ateam   # --user for a user unit
+systemctl restart ateam    # the restart command from here on
 ```
 
 Don't reach for `pkill` afterwards — `systemctl --user restart` is the supported


### PR DESCRIPTION
## The bug

A box's iOS access went down for ~21 hours while the desktop kept working. Not an app bug — the daemon was dead, and only the phone had no way to say so.

From the box's journal:

```
Aug 14 09:15:53  ateam.service: killed by OOM, restart counter at 2
Aug 14 09:16:18  killed by OOM again (25s later)
Aug 14 09:16:18  user@1001.service: Main process exited, code=killed, status=9/KILL
   ... 21 hours of nothing ...
Aug 15 06:30:44  Started ateam.service   ← a desktop SSH login revived the user manager
```

The unit `install.sh --service` writes has three defects that only bite under memory pressure:

1. **The daemon is scored as the preferred OOM victim.** `user@.service` ships `OOMScoreAdjust=100`, inherited by every user service. The kernel killed a 36 MB daemon (`oom_score_adj:200`) and spared the 442 MB agents it supervises (score 0).
2. **systemd gives up permanently.** Default `StartLimitBurst=5` per 10s; a burst of OOM kills exhausts it and nothing restarts the daemon again.
3. **It dies with the systemd user manager**, which was itself OOM-killed here. `Linger=yes` does not resurrect a killed manager — only a new login does.

The desktop survives all three by starting a daemon over SSH on connect, which is exactly what masks the problem. The phone's WebSocket only exists while a daemon is already running, so the one client `--service` exists to serve is the one that can never recover.

## The fix

`--service` now writes a **system** unit wherever passwordless sudo is available — every box Ateam provisions, since `provision.ts` bakes `NOPASSWD:ALL` into cloud-init:

```ini
OOMScoreAdjust=-500        # what distros already do for udevd/dbus/journald
StartLimitIntervalSec=0    # never permanently give up restarting
Restart=on-failure         # unchanged: exit 0 means another daemon owns the socket
KillMode=process           # unchanged: a restart must not kill live agent PTYs
```

Without sudo it still writes the user unit, plus `StartLimitIntervalSec=0` and a warning naming what stays unprotected. It deliberately does **not** write `OOMScoreAdjust` there — measured: systemd *silently ignores* a negative value in a user unit (the unit starts, `/proc` still reads `100`), so that line would read as protection while doing nothing.

Also fixes a stale-socket false positive in the handover check: it tested for the socket *file*, which a crashed daemon leaves behind, so a stale socket made the installer decline to start the service. Now tests for a live process.

## Verified

- **System path, on a real box:** ran the actual installer block — detected sudo, inherited `ATEAM_WS_ADDR` from the existing unit, wrote the unit, service active with `/proc/<pid>/oom_score_adj = -500`.
- **Self-heal:** `kill -9` the daemon twice → back in ~3s, listening, WebSocket handshake answering `{protocolVersion:2,agents:["claude"]}`.
- **OOM ranking inverted the right way:** daemon `oom_score=337` vs biggest agent `692`.
- **Rootless fallback:** sandboxed run with failing `sudo` → correct user unit, `StartLimitIntervalSec=0` present, zero `OOMScoreAdjust` lines, warning printed.
- **Migration:** user→system upgrade carries `ATEAM_WS_ADDR` across and leaves running agents untouched (they live outside the unit's cgroup; the PTY daemon is never signalled).
- 95 server tests pass.

## Not in scope

This keeps the daemon alive; it does not stop a box from running out of memory. Agents are unbounded (200–450 MB each, weeks-long) and, separately, the PTY daemon and every agent live in whichever **SSH login-session scope** first started them rather than an Ateam-owned cgroup — so agent memory can't be bounded as a group, and reaping that scope would kill every agent at once. The fix is spawning the PTY daemon into an Ateam-owned slice, which is a design change with real UX stakes (throttling a live agent mid-task) and belongs in its own PR.