### PR TITLE
Desktop: drop a box when its wire closes, so a dead connection can't hang the board

### DIFF
--- a/apps/desktop/src/main/aggregate.test.ts
+++ b/apps/desktop/src/main/aggregate.test.ts
@@ -102,6 +102,25 @@ test("projectsRemoteUrl routes to the engine that owns the project", async () =>
 	expect(local.calls).not.toContain(CH.projectsRemoteUrl);
 });
 
+// Regression: a box whose wire died silently (laptop sleep, Tailscale flap) stayed in the
+// aggregate, and an RPC into it never settles — so `Promise.all` over the merge reads meant
+// the WHOLE board hung on the dead engine. It must degrade to the engines that answered.
+test("a merge read survives an engine that never answers", async () => {
+	const local = fake("local", { [CH.projectsList]: () => [{ id: "pA" }] });
+	const dead = fake("remote", { [CH.projectsList]: () => new Promise(() => {}) });
+	const agg = createAggregate([local, dead], local, { mergeTimeoutMs: 20 });
+	expect(await agg.handle(CH.projectsList, [])).toEqual([{ id: "pA" }]);
+});
+
+test("a merge read survives an engine that errors", async () => {
+	const local = fake("local", { [CH.projectsList]: () => [{ id: "pA" }] });
+	const broken = fake("remote", {
+		[CH.projectsList]: () => Promise.reject(new Error("RPC connection closed")),
+	});
+	const agg = createAggregate([local, broken], local);
+	expect(await agg.handle(CH.projectsList, [])).toEqual([{ id: "pA" }]);
+});
+
 test("un-routable calls fall back to the local engine", async () => {
 	const { local, agg } = fixtures();
 	await agg.handle(CH.projectsRegister, ["/repo", {}]);

--- a/apps/desktop/src/main/aggregate.ts
+++ b/apps/desktop/src/main/aggregate.ts
@@ -16,9 +16,19 @@
 // slice: hold N backends, route every call correctly, merge the board.
 import { CH } from "@ateam/protocol";
 import type { Backend } from "./backend";
+import { withTimeout } from "./timeout";
 
 /** Collection reads with no entity key — merge the results across every backend. */
 const MERGE = new Set<string>([CH.projectsList, CH.agentsList, CH.loopsList]);
+
+// A merge read is a SQLite select on every engine, so slowness here means the WIRE, not
+// the work: a box that's asleep, half-open, or wedged. The union must degrade to the
+// engines that answered — "the rest of the board never waits for it" — and NOT take the
+// whole board down with the one dead engine, which a bare Promise.all did twice over: it
+// hung forever on a stale backend (an RPC has no per-call timeout), and rejected the
+// entire list if one engine errored. Applies to merge reads only; entity calls still
+// wait as long as their work takes (a clone, a merge, an installer).
+const MERGE_TIMEOUT_MS = 10_000;
 
 /** Entity-scoped calls — route to the backend that owns the id in the args. */
 const ENTITY = new Set<string>([
@@ -106,16 +116,34 @@ export interface Aggregate {
  * writeImageBytes, handshake, loop mutations) to `fallback` — the local engine by
  * convention. `backends` should include `fallback`.
  */
-export function createAggregate(backends: readonly Backend[], fallback: Backend): Aggregate {
+export function createAggregate(
+	backends: readonly Backend[],
+	fallback: Backend,
+	opts: { mergeTimeoutMs?: number } = {},
+): Aggregate {
 	const reg = new Map<string, Backend>();
+	const mergeTimeoutMs = opts.mergeTimeoutMs ?? MERGE_TIMEOUT_MS;
 
 	async function handle(method: string, args: unknown[]): Promise<unknown> {
 		if (MERGE.has(method)) {
 			const results = await Promise.all(
 				backends.map(async (b) => {
-					const r = await b.handle(method, args);
-					learn(reg, b, r);
-					return r;
+					try {
+						// Promise.resolve: a backend may answer synchronously (the local engine's
+						// in-process handler), and only a real promise can be raced against a timer.
+						const r = await withTimeout(
+							Promise.resolve(b.handle(method, args)),
+							mergeTimeoutMs,
+							method,
+						);
+						learn(reg, b, r);
+						return r;
+					} catch {
+						// This engine contributes nothing to the union this time. Its ids stay
+						// learned, so a task already on the board keeps routing to it; the
+						// connection layer is what decides it's gone (host.ts).
+						return [];
+					}
 				}),
 			);
 			return merge(results);

--- a/apps/desktop/src/main/host.ts
+++ b/apps/desktop/src/main/host.ts
@@ -60,6 +60,7 @@ import {
 	type Router,
 	remoteBackend,
 } from "./backend";
+import { withTimeout } from "./timeout";
 
 // The one pre-quoted remote command (ssh space-joins remote args, so `bash -lc`
 // must arrive as a single element): a login shell (agent-CLI PATH) execing the
@@ -164,6 +165,13 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 	// Per-alias health probes (ws only) — cleared on disconnect so a dropped box
 	// stops pinging a socket nobody is listening to.
 	const probes = new Map<string, ReturnType<typeof setInterval>>();
+	// alias → the SystemInfo learned at handshake. A held engine's identity doesn't
+	// change while it's held (its agent list can, and installAgent refreshes it), so
+	// every status read answers from here instead of asking the box again. Asking was
+	// the bug: `connected()` is a system:hello PER BOX on every connect/disconnect/
+	// install, and an RPC never times out — so one stale box hung the whole list, and
+	// with it `connect()`'s already-held path and anything awaiting it.
+	const infos = new Map<string | null, SystemInfo>();
 
 	// One aggregate over a LIVE backend array: connecting pushes onto it (so the
 	// learned id→engine registry survives), disconnecting rebuilds a fresh one (so a
@@ -183,8 +191,36 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 	unbinders.set(null, bindEvents(local));
 
 	async function statusOf(backend: Backend, alias: string | null): Promise<HostStatus> {
+		// The local engine is in-process — asking it can't hang, and its agent list changes
+		// under us (installing a CLI on the Mac), so always ask. A BOX is asked exactly once,
+		// at the handshake; `infos` serves every read after that. The fallback is unreachable
+		// (connect caches before it registers the backend) but capped rather than trusting.
+		if (alias !== null) {
+			const cached = infos.get(alias);
+			if (cached) return { mode: backend.kind, alias, info: cached };
+			await refreshInfo(alias);
+			const info = infos.get(alias);
+			if (!info) throw new Error(`Couldn't read "${alias}" status — it stopped answering.`);
+			return { mode: backend.kind, alias, info };
+		}
 		const info = (await backend.handle(CH.systemHello, [])) as SystemInfo;
 		return { mode: backend.kind, alias, info };
+	}
+
+	/** Re-read a held box's system:hello into the cache (its agent list changed). */
+	async function refreshInfo(alias: string): Promise<void> {
+		const backend = backends.get(alias);
+		if (!backend) return;
+		try {
+			const info = await withTimeout(
+				backend.handle(CH.systemHello, []) as Promise<SystemInfo>,
+				CONNECT_TIMEOUT_MS,
+			);
+			infos.set(alias, info);
+		} catch {
+			// Unreachable mid-refresh: keep the cached info. The probe (ws) or the wire's
+			// own close (ssh) is what decides a box is gone — never a stale agent list.
+		}
 	}
 
 	function connected(): Promise<HostStatus[]> {
@@ -253,9 +289,19 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 		});
 		// The remote's method set matches the local dispatcher's (same contract).
 		const backend = remoteBackend(rpc, local.methods, client.close);
+		infos.set(alias, info); // cached before the backend is reachable — statusOf's invariant
 		backends.set(alias, backend);
 		backendList.push(backend); // the live aggregate now fans out to it too
 		unbinders.set(alias, bindEvents(backend));
+		// A closed wire must take its backend WITH it. Nothing else drops a dead engine:
+		// a call routed into one never settles (no per-call timeout), so it stayed on the
+		// board, green, swallowing every request — the exact opposite of the promise that
+		// "a box that's asleep or unreachable just shows as disconnected". Wire-agnostic
+		// on purpose: the ws probe below only catches a HALF-open socket, while a real
+		// close is all SSH ever gives us (the relay's ssh child exits).
+		client.transport.onClose?.(() => {
+			if (backends.get(alias) === backend) disconnect(alias);
+		});
 		if (wire === "ws") probes.set(alias, startHealthProbe(alias, rpc));
 		broadcastConnections();
 		return { mode: "remote", alias, info };
@@ -292,6 +338,7 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 		unbinders.delete(alias);
 		backend.dispose();
 		backends.delete(alias);
+		infos.delete(alias);
 		const i = backendList.indexOf(backend);
 		if (i >= 0) backendList.splice(i, 1);
 		// Rebuild so the learned registry drops the gone engine's ids (no stale routing).
@@ -462,7 +509,9 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 				`Installing ${agent.label} on "${alias}" failed (exit ${result.code ?? "on a signal"}) — it may have installed but not landed on the login PATH.`,
 			);
 		}
-		// The box's agent list now includes it — refresh so the composer's env-agents update.
+		// The box's agent list now includes it — re-read the cached system:hello (it's what
+		// statusOf serves) so the composer's env-agents update.
+		await refreshInfo(alias);
 		broadcastConnections();
 		return { agentId, loginCommand: agent.loginCommand };
 	}
@@ -563,21 +612,4 @@ export function registerHostIpc(host: Host): void {
 		(_e, patch: { hetznerToken?: string; tailscaleAuthKey?: string }) => host.saveSecrets(patch),
 	);
 	ipcMain.handle(HOST_CH.providerOptions, (_e, token?: string) => host.providerOptions(token));
-}
-
-/** Reject (and clean up) if a promise doesn't settle in time. */
-function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
-	return new Promise<T>((resolve, reject) => {
-		const timer = setTimeout(() => reject(new Error(`connection timed out after ${ms}ms`)), ms);
-		p.then(
-			(v) => {
-				clearTimeout(timer);
-				resolve(v);
-			},
-			(e) => {
-				clearTimeout(timer);
-				reject(e);
-			},
-		);
-	});
 }

--- a/apps/desktop/src/main/timeout.ts
+++ b/apps/desktop/src/main/timeout.ts
@@ -1,0 +1,21 @@
+// One promise cap for the main process. An RPC has no per-call timeout of its own
+// (packages/protocol/src/rpc.ts — deliberately: `projects:clone` and the installer
+// legitimately run for minutes), so every place that CAN'T wait forever — a
+// handshake, a health probe, a board read — caps itself here.
+
+/** Reject (and clean up) if a promise doesn't settle in time. */
+export function withTimeout<T>(p: Promise<T>, ms: number, what = "connection"): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error(`${what} timed out after ${ms}ms`)), ms);
+		p.then(
+			(v) => {
+				clearTimeout(timer);
+				resolve(v);
+			},
+			(e) => {
+				clearTimeout(timer);
+				reject(e);
+			},
+		);
+	});
+}

--- a/docs/online-ateam.md
+++ b/docs/online-ateam.md
@@ -343,3 +343,8 @@ The connection menu surfaces the real error inline. Common ones:
   worktrees; a WebSocket instead of SSH, both riding Tailscale.
 - **Sessions persist.** The daemon keeps agents and PTYs alive across disconnects;
   reconnecting re-attaches to the exact running sessions.
+- **A box that drops mid-session shows as disconnected too.** Sleep the Mac, flip
+  networks, or let the box go away and Ateam drops that box rather than leaving a dead
+  link on the board — the rest of the board keeps working, and reconnecting from the
+  same menu re-attaches to whatever kept running. SSH connections are held open with
+  keepalives so an unreachable box is noticed in ~45s instead of never.

--- a/packages/server/src/transport/ssh.ts
+++ b/packages/server/src/transport/ssh.ts
@@ -19,6 +19,15 @@ export interface SshOptions {
 	sshFlags?: string[];
 }
 
+// OpenSSH's own liveness check, in place of a second app-level probe. ServerAliveInterval
+// defaults to 0 — OFF (ssh_config(5)) — so a black-holed connection (laptop sleep, a
+// Tailscale flap, the box wedged) leaves the ssh child ALIVE with nothing coming back, and
+// every RPC through it pending forever. These are sent through the encrypted channel and
+// answered by sshd itself, so a silent long-running command (an installer, a big clone) is
+// never mistaken for a dead peer. 15 × 3 ≈ 45s to a real exit — which closes the pipe, and
+// a closed pipe is what makes the client drop the box (apps/desktop/src/main/host.ts).
+const KEEPALIVE = ["-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=3"];
+
 /**
  * Open an RPC transport to `host` by running `remoteArgs` over SSH. `host` is an
  * ssh destination (`user@host`, or an ssh_config alias — ProxyJump/keys/known_hosts
@@ -29,7 +38,7 @@ export function sshClientTransport(
 	remoteArgs: string[],
 	opts: SshOptions = {},
 ): SshClient {
-	const child = spawn("ssh", [...(opts.sshFlags ?? []), host, ...remoteArgs], {
+	const child = spawn("ssh", [...KEEPALIVE, ...(opts.sshFlags ?? []), host, ...remoteArgs], {
 		stdio: ["pipe", "pipe", "inherit"],
 	});
 	if (!child.stdout || !child.stdin) {
@@ -66,9 +75,11 @@ export function sshExec(
 	opts: SshExecOptions = {},
 ): Promise<SshExecResult> {
 	return new Promise((resolve, reject) => {
-		const child = spawn("ssh", ["-o", "BatchMode=yes", ...(opts.sshFlags ?? []), host, command], {
-			stdio: ["ignore", "pipe", "pipe"],
-		});
+		const child = spawn(
+			"ssh",
+			["-o", "BatchMode=yes", ...KEEPALIVE, ...(opts.sshFlags ?? []), host, command],
+			{ stdio: ["ignore", "pipe", "pipe"] },
+		);
 		const emit = (b: Buffer) => opts.onData?.(b.toString("utf8"));
 		child.stdout?.on("data", emit);
 		child.stderr?.on("data", emit);


### PR DESCRIPTION
## The bug

A box whose transport died silently — Mac asleep, Tailscale flap, the relay's remote end gone — stayed registered as a live engine. Nothing ever removed it: the health probe that tears down a broken box is `ws`-only, and an RPC has no per-call timeout, so every call routed into that box waited forever. The box stayed green on the board while swallowing requests.

Creating the first task for a repo on such a box left **"Setting up &lt;repo&gt; on &lt;box&gt;…"** on screen indefinitely. It was parked on `connect()`'s already-held path — which asks the box for `system:hello` — so the clone the toast was reporting had not even been requested yet. On the box that clone takes ~3.5s.

## Changes

- **A closed wire drops its backend** — `connect()` wires `transport.onClose → disconnect(alias)`, wire-agnostic on purpose: the ws probe only catches a *half-open* socket, while a real close is all SSH ever gives us.
- **Cache each box's handshake `SystemInfo`** instead of re-asking on every status read. `connected()` was one `system:hello` *per box* on every connect / disconnect / install, so one stale box hung the whole list — and with it `connect()`'s already-held path. The local engine is still asked live (in-process, and its agent list changes under us); `installAgent` refreshes the cached info.
- **Merge reads tolerate an engine that can't answer** — `projects:list` / `agents:list` / `loops:list` get a per-backend cap and drop that engine's slice instead of the union. A bare `Promise.all` over a stale backend hung the entire board's project list, and rejected the whole list if one engine errored.
- **Hold SSH connections with `ServerAliveInterval=15` / `ServerAliveCountMax=3`.** OpenSSH's own liveness check defaults to *off*, so a black-holed connection left the `ssh` child alive with nothing coming back. 15×3 gives a real exit in ~45s — which closes the pipe, and a closed pipe is what drops the box.

Deliberately **not** a per-call RPC timeout: `projects:clone`, the installer and `tasks:cleanup` legitimately run for minutes. Liveness belongs to the channel, not the call.

## Verification

- `bun test` — 154 pass, including two new regressions: a merge read survives an engine that never answers, and one that errors.
- Live against the Hetzner box through the edited transport: argv carries the keepalive flags, handshake + a real `projects:list` succeed, `onClose` fires on teardown, and `projects:clone` completes in **3.5s**.
- In the dev app: killing one box's relay drops that box and leaves the sibling connection — and the app — untouched.

Docs: `online-ateam.md` now states that a box dropping mid-session shows as disconnected, with the keepalive detection window.