### PR TITLE
Desktop: ship image attachments to the box, so a remote agent can actually see them

### DIFF
--- a/apps/desktop/src/main/aggregate.test.ts
+++ b/apps/desktop/src/main/aggregate.test.ts
@@ -132,3 +132,23 @@ test("an entity call with an unknown id falls back rather than throwing", async 
 	await agg.handle(CH.gitStatus, ["unknown-task"]);
 	expect(local.calls).toContain(CH.gitStatus);
 });
+
+// The image-attach fix: util:writeImageBytes carries no routable id in its args
+// (base64, ext), yet the temp file must land on the machine whose agent will read
+// it — so the desktop routes it explicitly by the owning terminal.
+test("handleFor routes an id-less call to the engine that owns the terminal", async () => {
+	const { local, remote, agg } = fixtures();
+	await agg.handle(CH.projectsList, []);
+	await agg.handle(CH.tasksList, ["pB"]);
+	await agg.handle(CH.ptySpawnShell, [{ taskId: "tB" }]); // learns termB→remote
+
+	await agg.handleFor("termB", CH.utilWriteImageBytes, ["aGk=", "png"]);
+	expect(remote.calls).toContain(CH.utilWriteImageBytes);
+	expect(local.calls).not.toContain(CH.utilWriteImageBytes);
+	expect(agg.ownerKindOf("termB")).toBe("remote");
+
+	// Unknown owner → the local fallback, like every other un-routable call.
+	await agg.handleFor("term-unknown", CH.utilWriteImageBytes, ["aGk=", "png"]);
+	expect(local.calls).toContain(CH.utilWriteImageBytes);
+	expect(agg.ownerKindOf("term-unknown")).toBe("local");
+});

--- a/apps/desktop/src/main/aggregate.ts
+++ b/apps/desktop/src/main/aggregate.ts
@@ -107,6 +107,12 @@ function merge(results: unknown[]): unknown[] {
 export interface Aggregate {
 	/** Route/merge one request across the held backends (drop-in for Router.handle). */
 	handle(method: string, args: unknown[]): Promise<unknown>;
+	/** Invoke a method ON the engine that owns `ownerId` (fallback when unknown) —
+	 *  for calls whose own args carry no routable id (e.g. util:writeImageBytes
+	 *  must land on the engine whose agent will read the file). */
+	handleFor(ownerId: string, method: string, args: unknown[]): Promise<unknown>;
+	/** Whether `ownerId` lives on a box or the local engine ("local" when unknown). */
+	ownerKindOf(ownerId: string): "local" | "remote";
 	/** The learned id→backend map (which environment owns each entity). Read-only use. */
 	readonly ownerOf: ReadonlyMap<string, Backend>;
 }
@@ -159,5 +165,14 @@ export function createAggregate(
 		return result;
 	}
 
-	return { handle, ownerOf: reg };
+	async function handleFor(ownerId: string, method: string, args: unknown[]): Promise<unknown> {
+		return (reg.get(ownerId) ?? fallback).handle(method, args);
+	}
+
+	return {
+		handle,
+		handleFor,
+		ownerKindOf: (ownerId) => (reg.get(ownerId) ?? fallback).kind,
+		ownerOf: reg,
+	};
 }

--- a/apps/desktop/src/main/backend.ts
+++ b/apps/desktop/src/main/backend.ts
@@ -29,6 +29,12 @@ export interface Backend {
 export interface Router {
 	readonly methods: readonly string[];
 	handle(method: string, args: unknown[]): unknown | Promise<unknown>;
+	/** Invoke a method ON the engine that owns `ownerId` (local when unknown) — for
+	 *  calls whose own args carry no routable id, like staging an attachment on the
+	 *  machine whose agent will read it. */
+	handleFor(ownerId: string, method: string, args: unknown[]): Promise<unknown>;
+	/** Whether `ownerId` lives on a box or the local engine ("local" when unknown). */
+	ownerKind(ownerId: string): "local" | "remote";
 }
 
 /** The in-process engine: a dispatcher over it, its own events. Never disposed. */

--- a/apps/desktop/src/main/host.ts
+++ b/apps/desktop/src/main/host.ts
@@ -552,6 +552,8 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 	const router: Router = {
 		methods: local.methods,
 		handle: (method, args) => agg.handle(method, args),
+		handleFor: (ownerId, method, args) => agg.handleFor(ownerId, method, args),
+		ownerKind: (ownerId) => agg.ownerKindOf(ownerId),
 	};
 
 	// Rehydrate the board on launch. A box's tasks exist for the aggregate only while

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from "node:fs";
+import { extname } from "node:path";
+import { type AttachDelivery, CH } from "@ateam/protocol";
 import { clipboard, dialog, ipcMain, nativeImage } from "electron";
-import { CH } from "@ateam/protocol";
 import type { Router } from "./backend";
 
 /**
@@ -69,31 +71,74 @@ export function registerIpc(router: Router, native: NativeHandlers): void {
 		return res.canceled ? [] : res.filePaths;
 	});
 
-	// "+ → Attach image": open a picker, then stage the chosen image as a real
-	// bitmap on the clipboard so the renderer's following Ctrl+V hands the agent
-	// pixels, not a path or a file-icon.
+	// Deliver local image files to the terminal's agent, wherever it runs. The
+	// aggregate knows which engine owns each terminal, so this is where the local
+	// clipboard trick and the remote byte-push fork:
+	//   - agent on a box → the Mac's clipboard and files are invisible to it, so
+	//     ship each file's bytes over the engine RPC (util:writeImageBytes writes
+	//     a temp file box-side) and return those paths for the renderer to TYPE —
+	//     the same flow the iOS app proved against remote boxes.
+	//   - local agent, one image → stage a real bitmap on the clipboard for a
+	//     following Ctrl+V (pixels, not a path or a Finder file-icon).
+	//   - local agent, several images (or an undecodable one) → the clipboard
+	//     holds only one bitmap, so hand back the paths to type instead.
+	async function deliverImages(terminalId: string, paths: string[]): Promise<AttachDelivery> {
+		if (paths.length === 0) return { mode: "none" };
+		if (router.ownerKind(terminalId) === "remote") {
+			const remote: string[] = [];
+			for (const p of paths) {
+				try {
+					const base64 = readFileSync(p).toString("base64");
+					const ext = extname(p).slice(1);
+					const method = CH.utilWriteImageBytes;
+					remote.push((await router.handleFor(terminalId, method, [base64, ext])) as string);
+				} catch {
+					/* unreadable file or dropped wire — attach the ones that made it */
+				}
+			}
+			return remote.length ? { mode: "paths", paths: remote } : { mode: "none" };
+		}
+		const [only] = paths;
+		if (paths.length === 1 && only && stageImageOnClipboard(only)) return { mode: "ctrlv" };
+		return { mode: "paths", paths };
+	}
+
+	// Attach image files: explicit `paths` from a renderer drop/paste, or null for
+	// the "+ → Attach images" picker (multi-select, so several attach in one go).
 	//
-	// Always a picker — deliberately never sourced from the clipboard. Staging
-	// writes the image *to* the clipboard, so reading it back here would skip the
-	// picker on the next attach and re-stage the same image (you could never add a
-	// second, different one). Copied screenshots/images are attached via ⌘V paste,
-	// handled separately in the renderer's paste handler.
-	ipcMain.handle(CH.utilStageImage, async () => {
-		const res = await dialog.showOpenDialog({
-			properties: ["openFile"],
-			title: "Attach image",
-			filters: [
-				{
-					name: "Images",
-					extensions: ["png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "heic", "avif"],
-				},
-			],
-		});
-		return stageImageOnClipboard(res.canceled ? null : (res.filePaths[0] ?? null));
+	// Always a picker when null — deliberately never sourced from the clipboard.
+	// Staging writes the image *to* the clipboard, so reading it back here would
+	// skip the picker on the next attach and re-stage the same image (you could
+	// never add a second, different one). Copied screenshots/images are attached
+	// via ⌘V paste, handled separately in the renderer's paste handler.
+	ipcMain.handle(CH.utilAttachImages, async (_e, terminalId: string, paths: string[] | null) => {
+		let files = paths;
+		if (!files) {
+			const res = await dialog.showOpenDialog({
+				properties: ["openFile", "multiSelections"],
+				title: "Attach images",
+				filters: [
+					{
+						name: "Images",
+						extensions: ["png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "heic", "avif"],
+					},
+				],
+			});
+			files = res.canceled ? [] : res.filePaths;
+		}
+		return deliverImages(terminalId, files);
 	});
 
-	// Paste/drop of a copied image *file*: stage its bytes as a real bitmap so the
-	// renderer's following Ctrl+V attaches the pixels. Returns false (renderer
-	// then falls back to typing the path) if the file isn't a decodable image.
-	ipcMain.handle(CH.utilStageImagePath, async (_e, path: string) => stageImageOnClipboard(path));
+	// ⌘V of a raw bitmap (copied screenshot — no backing file). A local agent
+	// reads the Mac clipboard itself off a bare Ctrl+V; a box agent can't, so
+	// encode the clipboard image to PNG and push it like any other attachment.
+	ipcMain.handle(CH.utilAttachClipboardImage, async (_e, terminalId: string) => {
+		if (router.ownerKind(terminalId) !== "remote")
+			return { mode: "ctrlv" } satisfies AttachDelivery;
+		const img = clipboard.readImage();
+		if (img.isEmpty()) return { mode: "none" } satisfies AttachDelivery;
+		const base64 = img.toPNG().toString("base64");
+		const path = await router.handleFor(terminalId, CH.utilWriteImageBytes, [base64, "png"]);
+		return { mode: "paths", paths: [path as string] } satisfies AttachDelivery;
+	});
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -84,8 +84,9 @@ const api: AteamApi = {
 	utils: {
 		pathForFile: (file) => webUtils.getPathForFile(file),
 		pickFiles: () => ipcRenderer.invoke(CH.utilPickFiles),
-		stageClipboardImage: () => ipcRenderer.invoke(CH.utilStageImage),
-		stageImagePath: (path) => ipcRenderer.invoke(CH.utilStageImagePath, path),
+		attachImages: (terminalId, paths) => ipcRenderer.invoke(CH.utilAttachImages, terminalId, paths),
+		attachClipboardImage: (terminalId) =>
+			ipcRenderer.invoke(CH.utilAttachClipboardImage, terminalId),
 		writeImageBytes: (base64, ext) => ipcRenderer.invoke(CH.utilWriteImageBytes, base64, ext),
 	},
 	events: {

--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -1,3 +1,4 @@
+import type { AttachDelivery } from "@ateam/protocol";
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
 import { FileUp, ImageUp, Plus } from "lucide-react";
@@ -12,8 +13,19 @@ import { Menu } from "./Menu";
  */
 const escapePath = (p: string) => p.replace(/([ '"\\!$&*()[\]{};<>?#~`|])/g, "\\$1");
 
-/** Paths we attach as a staged bitmap rather than a typed path. */
+/** Paths we hand to the host's image-attach delivery rather than typing as-is. */
 const IMAGE_RE = /\.(png|jpe?g|gif|webp|bmp|tiff?|heic|heif|avif|ico)$/i;
+
+/**
+ * Act on the host's attach decision: forward a bare Ctrl+V (a bitmap was staged
+ * on the local clipboard), or TYPE the returned paths — box-side temp files when
+ * the agent runs on a box — as escaped keystrokes so path detection fires.
+ */
+const writeDelivery = (terminalId: string, d: AttachDelivery) => {
+	if (d.mode === "ctrlv") window.ateam.pty.write(terminalId, "\x16");
+	else if (d.mode === "paths" && d.paths.length)
+		window.ateam.pty.write(terminalId, `${d.paths.map(escapePath).join(" ")} `);
+};
 
 /**
  * One xterm.js view bound to a main-process PTY by terminalId. Replays the
@@ -81,23 +93,21 @@ export function TerminalView({
 			}
 		};
 
-		// Bring copied/dropped file(s) into the terminal. A single image file is
-		// attached by staging its real bitmap on the clipboard + Ctrl+V — the only
-		// reliable path: a bare Ctrl+V grabs a Finder file's generic icon, and a
-		// typed path only attaches when the agent runs typed-path detection (else it
-		// just leaves a literal path). Anything else (non-image, or multiple files)
-		// types the escaped path(s); so does an image we couldn't decode.
+		// Bring copied/dropped file(s) into the terminal. Image files (one or many)
+		// go through the host's attach delivery, which knows where the agent runs:
+		// a single local image is staged as a real bitmap + Ctrl+V (a bare Ctrl+V
+		// grabs a Finder file's generic icon), several local images come back as
+		// paths to type, and for an agent on a box the bytes are shipped over and
+		// the box-side temp paths come back instead — a typed Mac path would point
+		// at a file the box doesn't have. Non-images (or a mixed drop) type the
+		// escaped local path(s), like a real terminal.
 		const attachFiles = (files: File[]) => {
 			const paths = files.map((f) => window.ateam.utils.pathForFile(f)).filter(Boolean);
-			const [only] = paths;
-			if (paths.length === 1 && only && IMAGE_RE.test(only)) {
-				void window.ateam.utils.stageImagePath(only).then((staged) => {
-					if (staged) {
-						window.ateam.pty.write(terminalId, "\x16");
-						term.focus();
-					} else {
-						typeFilePaths(files);
-					}
+			if (paths.length && paths.every((p) => IMAGE_RE.test(p))) {
+				void window.ateam.utils.attachImages(terminalId, paths).then((d) => {
+					if (d.mode === "none") typeFilePaths(files);
+					else writeDelivery(terminalId, d);
+					term.focus();
 				});
 				return;
 			}
@@ -112,9 +122,10 @@ export function TerminalView({
 		// Plain text pastes normally. A non-text payload splits two ways:
 		//   - a copied file (Finder) has a real path → attachFiles (a single image
 		//     is staged as a bitmap + Ctrl+V; other files type their path).
-		//   - a raw bitmap (screenshot) has no path → forward a bare Ctrl+V and let
-		//     the agent read the bitmap off the clipboard itself, like a raw
-		//     terminal. The agent renders its own "[Image #N]".
+		//   - a raw bitmap (screenshot) has no path → the host decides: a local
+		//     agent gets a bare Ctrl+V and reads the bitmap off the clipboard
+		//     itself, like a raw terminal; an agent on a box (no shared clipboard)
+		//     gets the bitmap shipped over as a box-side temp file to type.
 		const onPaste = (e: ClipboardEvent) => {
 			const dt = e.clipboardData;
 			if (!dt || dt.getData("text/plain")) return; // text → xterm
@@ -125,8 +136,10 @@ export function TerminalView({
 			if (files.every((f) => window.ateam.utils.pathForFile(f))) {
 				attachFiles(files); // copied file(s) on disk
 			} else {
-				window.ateam.pty.write(terminalId, "\x16"); // bitmap → bare ⌃V
-				term.focus();
+				void window.ateam.utils.attachClipboardImage(terminalId).then((d) => {
+					writeDelivery(terminalId, d);
+					term.focus();
+				});
 			}
 		};
 		el.addEventListener("paste", onPaste, true);
@@ -286,15 +299,12 @@ export function TerminalView({
 		termRef.current?.focus();
 	};
 
-	// "+ → Attach image": main opens a picker and stages the chosen image as a
-	// bitmap on the clipboard, then we forward a bare Ctrl+V so the agent reads the
-	// pixels off the clipboard — the one path that attaches reliably, regardless of
-	// typed-path detection. Each click re-opens the picker, so you can add several
-	// different images one after another.
-	const attachImage = async () => {
-		if (await window.ateam.utils.stageClipboardImage()) {
-			window.ateam.pty.write(terminalId, "\x16");
-		}
+	// "+ → Attach images": main opens a multi-select picker and delivers the
+	// chosen images to wherever this terminal's agent runs — one local image is
+	// staged as a bitmap for our Ctrl+V, several (or any on a box) come back as
+	// paths to type. Each click re-opens the picker, so you can keep adding more.
+	const attachImages = async () => {
+		writeDelivery(terminalId, await window.ateam.utils.attachImages(terminalId, null));
 		termRef.current?.focus();
 	};
 
@@ -311,7 +321,7 @@ export function TerminalView({
 					icon={Plus}
 					label="Add to terminal"
 					items={[
-						{ label: "Attach image", icon: ImageUp, onClick: attachImage },
+						{ label: "Attach images", icon: ImageUp, onClick: attachImages },
 						{ label: "Files…", icon: FileUp, onClick: addFiles },
 					]}
 				/>

--- a/apps/mobile/src/connection.ts
+++ b/apps/mobile/src/connection.ts
@@ -21,8 +21,8 @@ export const mobileNative: NativeClientApi = {
 	pathForFile: () => "",
 	pick: async () => null,
 	pickFiles: async () => [],
-	stageClipboardImage: async () => false,
-	stageImagePath: async () => false,
+	attachImages: async () => ({ mode: "none" as const }),
+	attachClipboardImage: async () => ({ mode: "none" as const }),
 	openProject: async () => {},
 	boundProjectId: () => null,
 };

--- a/packages/protocol/src/client-api.ts
+++ b/packages/protocol/src/client-api.ts
@@ -11,6 +11,7 @@
 import type {
 	AgentDTO,
 	AteamApi,
+	AttachDelivery,
 	CleanupCandidate,
 	CleanupReport,
 	CreateLoopInput,
@@ -54,8 +55,8 @@ export interface NativeClientApi {
 	pathForFile(file: File): string;
 	pick(): Promise<string | null>;
 	pickFiles(): Promise<string[]>;
-	stageClipboardImage(): Promise<boolean>;
-	stageImagePath(path: string): Promise<boolean>;
+	attachImages(terminalId: string, paths: string[] | null): Promise<AttachDelivery>;
+	attachClipboardImage(terminalId: string): Promise<AttachDelivery>;
 	// Multi-window is a host-OS concern (an engine can't open the client's windows),
 	// so the window surface is client-native too. A single-window client stubs these.
 	openProject(projectId: string): Promise<void>;
@@ -136,8 +137,8 @@ export function buildAteamApi(rpc: RpcClient, native: NativeClientApi): AteamApi
 		utils: {
 			pathForFile: native.pathForFile,
 			pickFiles: native.pickFiles,
-			stageClipboardImage: native.stageClipboardImage,
-			stageImagePath: native.stageImagePath,
+			attachImages: native.attachImages,
+			attachClipboardImage: native.attachClipboardImage,
 			writeImageBytes: (base64, ext) => call<string>(CH.utilWriteImageBytes, [base64, ext]),
 		},
 	};

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -286,8 +286,8 @@ export const CH = {
 	systemHello: "system:hello",
 	fsListDir: "fs:listDir",
 	utilPickFiles: "util:pickFiles",
-	utilStageImage: "util:stageImage",
-	utilStageImagePath: "util:stageImagePath",
+	utilAttachImages: "util:attachImages",
+	utilAttachClipboardImage: "util:attachClipboardImage",
 	utilWriteImageBytes: "util:writeImageBytes",
 	ptySpawnAgent: "pty:spawnAgent",
 	ptySpawnShell: "pty:spawnShell",
@@ -325,6 +325,19 @@ export interface PtyExitEvent {
 	terminalId: string;
 	exitCode: number;
 }
+
+/**
+ * How the host delivered an image attach (utils.attachImages / attachClipboardImage):
+ * "ctrlv" — a bitmap is staged on the client clipboard; forward a Ctrl+V so the
+ * local agent reads the pixels itself. "paths" — TYPE these paths into the PTY
+ * (escaped keystrokes, not a paste) so the agent's typed-path detection attaches
+ * them; for a remote agent they are box-side temp files. "none" — nothing to do
+ * (cancelled picker, empty clipboard, or no file survived the transfer).
+ */
+export type AttachDelivery =
+	| { mode: "ctrlv" }
+	| { mode: "paths"; paths: string[] }
+	| { mode: "none" };
 
 // ---- the API surface exposed on window.ateam ----
 export interface AteamApi {
@@ -438,20 +451,23 @@ export interface AteamApi {
 		/** Native open dialog; resolves to the chosen paths ([] on cancel). */
 		pickFiles(): Promise<string[]>;
 		/**
-		 * Open an image picker, then put the chosen image on the clipboard as a real
-		 * bitmap so a following Ctrl+V hands the agent pixels, not a Finder file-icon.
-		 * Always a picker (never read from the clipboard, which we just wrote to).
-		 * Resolves true when a bitmap was staged, false if the user cancelled or the
-		 * file wasn't a decodable image.
+		 * Attach image files to the terminal's agent, wherever that agent runs.
+		 * `paths` are client-local image files (from a drop/paste); null opens a
+		 * multi-select image picker instead. The host decides the delivery: for a
+		 * local agent one image is staged on the clipboard as a real bitmap
+		 * ("ctrlv" — the caller forwards a Ctrl+V so the agent reads pixels, not a
+		 * Finder file-icon), while several images — or an agent on a box, which
+		 * can't see this machine's clipboard or files — come back as "paths" for
+		 * the caller to TYPE into the PTY (box-side temp paths when remote).
 		 */
-		stageClipboardImage(): Promise<boolean>;
+		attachImages(terminalId: string, paths: string[] | null): Promise<AttachDelivery>;
 		/**
-		 * Put the image at `path` on the clipboard as a real bitmap (for a following
-		 * Ctrl+V), used when a copied/dropped image *file* is brought into a terminal.
-		 * Resolves false if the file isn't a decodable image, so the caller can fall
-		 * back to typing the path.
+		 * Attach the raw bitmap currently on the client's clipboard (a copied
+		 * screenshot — no backing file). Local agents read the clipboard themselves
+		 * ("ctrlv"); for an agent on a box the bitmap is shipped over and comes
+		 * back as a box-side path to type. "none" when the clipboard has no image.
 		 */
-		stageImagePath(path: string): Promise<boolean>;
+		attachClipboardImage(terminalId: string): Promise<AttachDelivery>;
 		/**
 		 * Write raw image bytes (base64) to a temp file on the *engine's* machine and
 		 * return its absolute path. The remote counterpart of clipboard staging: a

--- a/packages/server/src/connect-cli.ts
+++ b/packages/server/src/connect-cli.ts
@@ -48,8 +48,8 @@ const headlessNative: NativeClientApi = {
 	},
 	pick: async () => null,
 	pickFiles: async () => [],
-	stageClipboardImage: async () => false,
-	stageImagePath: async () => false,
+	attachImages: async () => ({ mode: "none" as const }),
+	attachClipboardImage: async () => ({ mode: "none" as const }),
 	openProject: async () => {},
 	boundProjectId: () => null,
 };

--- a/packages/server/test/client-api.test.ts
+++ b/packages/server/test/client-api.test.ts
@@ -33,8 +33,8 @@ const native: NativeClientApi = {
 	pathForFile: () => "/native/path",
 	pick: async () => "/native/pick",
 	pickFiles: async () => ["/native/a"],
-	stageClipboardImage: async () => true,
-	stageImagePath: async () => false,
+	attachImages: async () => ({ mode: "ctrlv" as const }),
+	attachClipboardImage: async () => ({ mode: "none" as const }),
 };
 
 describe("buildAteamApi over a live serveRpc/dispatcher (the client's view)", () => {
@@ -83,7 +83,7 @@ describe("buildAteamApi over a live serveRpc/dispatcher (the client's view)", ()
 		expect(api.utils.pathForFile(new File([], "x"))).toBe("/native/path");
 		expect(await api.projects.pick()).toBe("/native/pick");
 		expect(await api.utils.pickFiles()).toEqual(["/native/a"]);
-		expect(await api.utils.stageClipboardImage()).toBe(true);
-		expect(await api.utils.stageImagePath("/x")).toBe(false);
+		expect(await api.utils.attachImages("t1", null)).toEqual({ mode: "ctrlv" });
+		expect(await api.utils.attachClipboardImage("t1")).toEqual({ mode: "none" });
 	});
 });

--- a/packages/server/test/dispatcher.test.ts
+++ b/packages/server/test/dispatcher.test.ts
@@ -1,15 +1,15 @@
+import { describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "bun:test";
 import { type AteamDb, repo } from "@ateam/db";
 import { CH } from "@ateam/protocol";
 // Reuse the db package's in-memory bun:sqlite test db (better-sqlite3 can't load
 // under Bun). Cross-package test helper — the DRY source of a test AteamDb.
 import { createTestDb } from "../../db/test/helpers/test-db";
-import type { Engine } from "../src/engine";
 import { createDispatcher } from "../src/dispatcher";
+import type { Engine } from "../src/engine";
 
 // A minimal fake Engine: a real in-memory db for the DB-backed handlers, stubs
 // for the pieces those handlers don't touch, and a spy on taskUpdated so we can
@@ -44,8 +44,8 @@ describe("createDispatcher", () => {
 		expect(d.methods).toContain(CH.ptyWrite);
 		// …and the Electron-only handlers are NOT (they live in the desktop shell).
 		expect(d.methods).not.toContain(CH.projectsPick);
-		expect(d.methods).not.toContain(CH.utilStageImage);
-		expect(d.methods).not.toContain(CH.utilStageImagePath);
+		expect(d.methods).not.toContain(CH.utilAttachImages);
+		expect(d.methods).not.toContain(CH.utilAttachClipboardImage);
 	});
 
 	// Mission Control listens for taskUpdated rather than polling every task's

--- a/packages/server/test/ws.test.ts
+++ b/packages/server/test/ws.test.ts
@@ -39,8 +39,8 @@ const native: NativeClientApi = {
 	pathForFile: () => "",
 	pick: async () => null,
 	pickFiles: async () => [],
-	stageClipboardImage: async () => false,
-	stageImagePath: async () => false,
+	attachImages: async () => ({ mode: "none" as const }),
+	attachClipboardImage: async () => ({ mode: "none" as const }),
 };
 
 describe("buildAteamApi over a real WebSocket (the phone's transport)", () => {


### PR DESCRIPTION
The desktop attached images by staging a bitmap on the Mac's clipboard and forwarding Ctrl+V — which only a local agent can read. An agent on a box got an empty clipboard, or a typed `/Users/...` path the box doesn't have ("Screenshot didn't make it across"). iOS never had the bug: it pushes the bytes over the engine RPC and types the box-side path.

The desktop now does the same, deciding per terminal:

- `aggregate`/`backend`/`host`: new `handleFor(ownerId, …)` + `ownerKind(ownerId)` so an id-less call like `util:writeImageBytes` routes to the engine that owns the terminal (it used to always hit the local engine).
- `ipc`: remote terminal → read each image, push bytes to the owning box (`util:writeImageBytes`, temp dir the engine already prunes), return box-side paths for the renderer to TYPE. Local terminal → unchanged clipboard staging + Ctrl+V. A pasted screenshot (raw bitmap) is encoded to PNG off the clipboard and pushed the same way.
- `Terminal.tsx`: drop, ⌘V, and the toolbar all use the new delivery; the picker is now multi-select ("Attach images") and a drop/paste of several images attaches them all.
- Protocol renames `stageClipboardImage`/`stageImagePath` → `attachImages`/`attachClipboardImage` with mobile/headless stubs updated. No daemon wire change — existing boxes keep working, no protocol version bump.

Known gap left as-is: non-image files dropped into a remote terminal still type their Mac path.

Tests: new aggregate routing test; full suite 156 pass; typecheck + desktop production build green.