### PR TITLE
Docs: boxd auto-hibernate takes the tailnet node down with it

### DIFF
--- a/docs/providers/boxd.md
+++ b/docs/providers/boxd.md
@@ -108,6 +108,16 @@ sudo tailscale serve --bg --tcp 8787 tcp://localhost:8787
 Then point the phone at `<tailnet-ip>:8787`. The engine only ever binds loopback,
 so it's reachable from your tailnet and nowhere else — the same posture as a VPS.
 
+**Turn auto-hibernate off on any box the phone uses.** boxd cold-snapshots an idle
+machine — the default is `auto_hibernate: 14400s`, four hours — which takes
+`tailscaled` down with it, and **the phone cannot wake it**: waking needs the boxd
+CLI or API, which the iOS app knows nothing about. Otherwise you open the app away
+from your desk and find a dead endpoint with no way to revive it.
+
+```bash
+boxd machine config set mybox auto-hibernate.timeout 0   # 0 disables
+```
+
 Two caveats: traffic relays through DERP rather than a direct path (fine for
 JSON-RPC, laggier for PTY output), and this is manual per box.
 
@@ -125,4 +135,9 @@ JSON-RPC, laggier for PTY output), and this is manual per box.
   database silently mis-route git operations and hide one fork's tasks. Delete it
   before `boxd snapshots save`, and log `gh` out first — forks inherit credentials
   too.
+- **A hibernated box looks like a Tailscale failure.** An idle machine hibernates by
+  default and its tailnet node goes `offline, last seen …`; the node is fine and its
+  key hasn't expired — there's simply no host running. `boxd machine wake <vm>` brings
+  it back, keeping its state and the *same* tailnet IP, and systemd restarts the
+  engine. See the iOS section for turning it off.
 - **`boxd snapshots save`**, not `create`.


### PR DESCRIPTION
An idle boxd machine cold-snapshots after four hours by default (`auto_hibernate: 14400s`). `tailscaled` goes down with the host, so the node reads `offline, last seen …` in the Tailscale console — which looks like an expired key or a deregistered node, and is neither. `boxd machine wake <vm>` restores it with its state and the **same** tailnet IP, and systemd brings the engine back on its own.

Hit for real on `ateam-probe`: hibernated after 6h idle → woken → node back at `100.81.40.73` → the phone's endpoint answered `protocolVersion 2` again.

The iOS section gets the sharper warning, because there it isn't an annoyance: **the phone cannot wake a hibernated box** — waking needs the boxd CLI or API, which the iOS app knows nothing about. So "agents around the clock, reachable from your phone" and auto-hibernate are incompatible, and any box backing the phone needs `auto-hibernate.timeout 0`.

Docs only. The page's `Verified against` line is deliberately left at v0.1.39 / boxd 0.2.5 — re-stamping without re-running the whole recipe would be exactly the fake stamp the directory's rules forbid.