### PR TITLE
Provision: fall back to plain git clone when gh is unauthenticated

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "private": true,
   "main": "./out/main/bootstrap.js",
   "scripts": {

--- a/docs/providers/boxd.md
+++ b/docs/providers/boxd.md
@@ -8,7 +8,7 @@ running processes. The images already ship `git`, `gh`, `node`, `docker` and
 `claude`, so there's no user, firewall or Tailscale setup to do. Unlike a VPS, the
 box is reached over boxd's own authenticated SSH proxy rather than your tailnet.
 
-**Verified against** Ateam v0.1.39 · boxd CLI 0.2.5 · 2026-08-12
+**Verified against** Ateam v0.1.39 · boxd CLI 0.2.10 · 2026-08-25
 
 ## Create a box
 
@@ -80,14 +80,50 @@ plus a shared `boxd.sh` defaults entry). Ateam collapses aliases that reach the
 same engine, so you should see one entry — but if you're on an older build you'll
 see all three, and `boxd.sh` is not a machine.
 
+## Tailscale integration (org-level, shipped)
+
+boxd's proxy-based Tailscale integration has shipped
+([guide](https://docs.boxd.sh/guides/tailscale.md)). It works at the **edge**, not
+per VM: boxd's edge servers enrol as `boxd-proxy-*` devices in *your* tailnet, and
+every `*.boxd.sh` hostname you own — HTTPS, subdomain proxies, SSH aliases, raw
+port forwards — resolves only to tailnet addresses and routes through those nodes.
+Same hostnames, same TLS, nothing to install inside any VM. A personal Tailscale
+account works fine; "org" means your boxd org.
+
+Onboarding is not self-service:
+
+1. Email `contact@boxd.sh` with your boxd org name and a Tailscale auth key
+   (reusable, non-ephemeral, no tags) from your own admin console.
+2. Approve the `boxd-proxy-*` devices that appear in your tailnet and disable key
+   expiry on each (they otherwise expire after 180 days).
+3. Use machines as before: `curl https://myapp.boxd.sh`, `ssh myapp.boxd`.
+
+Caveats:
+
+- **All-or-nothing for the boxd org.** Every machine's hostnames become reachable
+  only from inside your tailnet — anything you shared publicly via a `*.boxd.sh`
+  URL stops resolving for outsiders. The boxd API/CLI stays reachable from
+  anywhere.
+- Org wildcard domains follow onto the tailnet; per-machine apex domains can't
+  (A-record conflict).
+- The auth key you hand over expires (90 days max); an expired key blocks boxd
+  from enrolling *new* edge capacity.
+- Corporate DNS with rebinding protection may strip the `100.64.0.0/10` answers —
+  use Tailscale's resolver.
+- Because traffic now enters through boxd's edge — the same path that wakes a
+  machine on inbound SSH/HTTPS — auto-hibernate should no longer strand the phone
+  the way the in-VM setup below does. *Unverified: this org isn't enrolled yet;
+  test wake-from-phone before relying on it.*
+
 ## iOS
 
-The phone reaches a box over a WebSocket on your tailnet, and a boxd VM **can't run
-`tailscaled` normally**: the kernel is monolithic with no TUN device (`/lib/modules`
-is empty and loading `tun` fails). boxd is building a proxy-based Tailscale
-integration — proxy nodes join *your* tailnet and route to your VMs — which will
-make this automatic. Until that ships, it works via Tailscale's
-**userspace-networking** mode, which needs no TUN:
+The phone reaches a box over a WebSocket on your tailnet. With the edge
+integration above enabled there is nothing to do per box — the engine's port is
+already tailnet-reachable through boxd's proxy. Without it, note that a boxd VM
+**can't run `tailscaled` normally**: the kernel is monolithic with no TUN device
+(`/lib/modules` is empty and loading `tun` fails). The fallback — and what runs on
+this org's boxes today — is Tailscale's **userspace-networking** mode, which needs
+no TUN:
 
 ```bash
 # on the box

--- a/docs/providers/boxd.md
+++ b/docs/providers/boxd.md
@@ -56,7 +56,11 @@ git config --global --unset-all credential.https://github.com.helper
 ```
 
 Still run `gh auth login`: Ateam's PR and merge-queue operations go through the
-`gh` API rather than git.
+`gh` API rather than git. Provisioning a project onto the box no longer requires
+it (since v0.1.42): the engine's clone falls back from `gh` to plain `git clone`,
+which rides boxd's credential helper — a bare box with only the GitHub
+integration connected can clone, because `GH_TOKEN` is injected into login
+shells only and the engine daemon never sees it.
 
 ## Install the engine
 

--- a/packages/git-core/src/project.ts
+++ b/packages/git-core/src/project.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { GitCoreError } from "./errors";
@@ -203,7 +203,16 @@ export async function cloneRepo(cloneUrl: string, dest: string): Promise<void> {
 	const gh = cloneUrl.match(/github\.com[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?\/?$/i);
 	try {
 		if (gh) {
-			await pexec("gh", ["repo", "clone", `${gh[1]}/${gh[2]}`, dest]);
+			try {
+				await pexec("gh", ["repo", "clone", `${gh[1]}/${gh[2]}`, dest]);
+			} catch {
+				// `gh` may be unauthenticated in this process even when git can
+				// clone: hosts like boxd inject GH_TOKEN into login shells only,
+				// while wiring a system-scope git credential helper that works
+				// from any process. Fall back to plain `git clone`.
+				await rm(dest, { recursive: true, force: true });
+				await pexec("git", ["clone", cloneUrl, dest]);
+			}
 		} else {
 			await pexec("git", ["clone", cloneUrl, dest]);
 		}

--- a/packages/git-core/test/git-core.test.ts
+++ b/packages/git-core/test/git-core.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import simpleGit from "simple-git";
 import {
+	cloneRepo,
 	commit,
 	createTask,
 	detectDefaultBranch,
@@ -403,5 +404,50 @@ describe("path safety", () => {
 	it("slugify neutralizes traversal characters", () => {
 		expect(slugify("../../evil")).toBe("evil");
 		expect(slugify("Add Auth!!")).toBe("add-auth");
+	});
+});
+
+describe("cloneRepo — gh fallback (no GitHub needed)", () => {
+	const GH_URL = "https://github.com/acme/demo.git";
+	let savedEnv: Record<string, string | undefined>;
+
+	// A fake `gh` that always fails (an unauthenticated gh, e.g. an engine
+	// process on a boxd box, where GH_TOKEN only exists in login shells), plus a
+	// git URL rewrite so the fallback `git clone` resolves to the local bare
+	// origin instead of the network.
+	beforeEach(async () => {
+		const bin = join(repo.dir, "fake-bin");
+		await mkdir(bin);
+		await writeFile(join(bin, "gh"), "#!/bin/sh\nexit 1\n");
+		await chmod(join(bin, "gh"), 0o755);
+		savedEnv = {
+			PATH: process.env.PATH,
+			GIT_CONFIG_COUNT: process.env.GIT_CONFIG_COUNT,
+			GIT_CONFIG_KEY_0: process.env.GIT_CONFIG_KEY_0,
+			GIT_CONFIG_VALUE_0: process.env.GIT_CONFIG_VALUE_0,
+		};
+		process.env.PATH = `${bin}:${process.env.PATH}`;
+		process.env.GIT_CONFIG_COUNT = "1";
+		process.env.GIT_CONFIG_KEY_0 = `url.${repo.origin}.insteadOf`;
+		process.env.GIT_CONFIG_VALUE_0 = GH_URL;
+	});
+	afterEach(() => {
+		for (const [key, value] of Object.entries(savedEnv)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+
+	it("falls back to plain git clone when gh fails", async () => {
+		const dest = join(repo.dir, "cloned");
+		await cloneRepo(GH_URL, dest);
+		expect(existsSync(join(dest, "README.md"))).toBe(true);
+	});
+
+	it("throws GH_FAILED when git fails too", async () => {
+		process.env.GIT_CONFIG_KEY_0 = `url.${join(repo.dir, "nowhere.git")}.insteadOf`;
+		await expect(
+			cloneRepo(GH_URL, join(repo.dir, "cloned")),
+		).rejects.toMatchObject({ code: "GH_FAILED" });
 	});
 });


### PR DESCRIPTION
Fixes the boxd onboarding failure where `host:provision` dies with "Could not clone ... (is git/gh installed and authenticated on that machine?)" on a box whose terminal clones the same repo fine.

Root cause: `cloneRepo` uses `gh repo clone` for GitHub URLs, but on a boxd box gh's auth comes from `GH_TOKEN` injected into **login shells only** — the engine daemon never sees it, so gh is unauthenticated in exactly the process doing the provisioning. Meanwhile boxd wires a system-scope git credential helper that works from any process, so plain `git clone` succeeds.

- `cloneRepo` now falls back from `gh` to plain `git clone` (cleaning any partial dest) before raising `GH_FAILED`
- Two hermetic tests: failing `gh` shim + `insteadOf` rewrite to a local bare origin proves the fallback; both-fail still raises `GH_FAILED`
- boxd provider doc: provisioning no longer requires `gh auth login` (PR/merge-queue ops still do)