### PR TITLE
Task panels: many terminals per task, as tabs on the toolbar row

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,13 +199,14 @@ bun run --filter @ateam/desktop build      # production bundle
 Working: project registration (with optional `git init` for plain folders),
 worktree-per-task lifecycle, commit/push/update/merge, a GitHub-style changes
 view (aggregate diffstat → file list + side-by-side diffs), prompt-first task
-composer (pick the agent and type the first instruction in one step), agent
-spawning in PTYs (Claude Code, OpenCode, Codex), hook-driven status → kanban
-columns with merged-PR detection, Mission Control grid, collapsible sidebar
-rail, image drag-drop & paste into agent terminals, safe cleanup of merged
-worktrees, and signed/notarized builds with in-app auto-update. The git engine
-and db layer are unit-tested; the Electron main process is boot-verified with
-native modules.
+composer (pick the agent and type the first instruction in one step) reused for
+extra sessions inside an existing task, many terminals per task as tabs (agent
+sessions or plain shells, side by side), agent spawning in PTYs (Claude Code,
+OpenCode, Codex), hook-driven status → kanban columns with merged-PR detection,
+Mission Control grid, collapsible sidebar rail, image drag-drop & paste into
+agent terminals, safe cleanup of merged worktrees, and signed/notarized builds
+with in-app auto-update. The git engine and db layer are unit-tested; the
+Electron main process is boot-verified with native modules.
 
 ## Roadmap
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import type {
 	DiffResultDTO,
 	KanbanColumn,
 	ProjectDTO,
+	SessionDTO,
 	TaskDTO,
 } from "@ateam/protocol";
 import {
@@ -47,7 +48,6 @@ import {
 	Trash2,
 	Wrench,
 	X,
-	Zap,
 } from "lucide-react";
 import { motion, Reorder } from "motion/react";
 import {
@@ -65,9 +65,10 @@ import { FileDiffView } from "./components/FileDiffView";
 import { IconButton } from "./components/IconButton";
 import { LoopsPanel } from "./components/LoopsPanel";
 import { Menu } from "./components/Menu";
-import { NewTaskComposer } from "./components/NewTaskComposer";
+import { PromptComposer } from "./components/PromptComposer";
 import { TerminalView } from "./components/Terminal";
 import { usePrompt } from "./components/usePrompt";
+import { activeTerminal, sessionTabs } from "./session-tabs";
 import { type Alias, aliasLabel, type UnifiedProject, unifyProjects } from "./unify";
 
 const COLUMNS: { key: KanbanColumn; label: string }[] = [
@@ -206,7 +207,10 @@ export function App() {
 	const [taskQuery, setTaskQuery] = useState("");
 	const [error, setError] = useState<string | null>(null);
 	const [info, setInfo] = useState<string | null>(null);
-	const [termByTask, setTermByTask] = useState<Record<string, string>>({});
+	// Which of a task's live sessions is showing in its panel — the active tab.
+	// The sessions themselves live in the PTY daemon; this is only the choice of
+	// which one to look at, and goes null when a task has none left.
+	const [termByTask, setTermByTask] = useState<Record<string, string | null>>({});
 	const { ui: promptUi, ask, confirm } = usePrompt();
 
 	const run = useCallback(async (fn: () => Promise<void>) => {
@@ -1066,6 +1070,9 @@ export function App() {
 								<TaskPanel
 									task={selectedTask}
 									agents={agents}
+									envAgents={envAgents}
+									alias={originOf(selectedTask.projectId)}
+									onInstallAgent={installAgentOnBox}
 									mode={panelMode}
 									onSetMode={setPanelMode}
 									terminalId={termByTask[selectedTask.id] ?? null}
@@ -1085,6 +1092,9 @@ export function App() {
 							<TaskPanel
 								task={selectedTask}
 								agents={agents}
+								envAgents={envAgents}
+								alias={originOf(selectedTask.projectId)}
+								onInstallAgent={installAgentOnBox}
 								mode={panelMode}
 								onSetMode={(m) => (m === "side" ? collapseToMission() : setPanelMode(m))}
 								collapseLabel="Back to Mission Control"
@@ -1121,7 +1131,7 @@ export function App() {
 				/>
 			)}
 			{composerOpen && activeCard && (
-				<NewTaskComposer
+				<PromptComposer
 					agents={agents}
 					environments={composerEnvs}
 					envAgents={envAgents}
@@ -1256,6 +1266,9 @@ function Board({
 function TaskPanel({
 	task,
 	agents,
+	envAgents,
+	alias,
+	onInstallAgent,
 	mode,
 	onSetMode,
 	collapseLabel = "Show beside the board",
@@ -1269,28 +1282,74 @@ function TaskPanel({
 }: {
 	task: TaskDTO;
 	agents: AgentDTO[];
+	/** Agent ids each engine actually has, keyed by alias ("local" for this Mac) —
+	 *  so the session composer only offers what this task's engine can run. */
+	envAgents: Record<string, string[]>;
+	/** The engine this task runs on; null = this Mac. */
+	alias: Alias;
+	/** Install a coding agent's CLI on the box, streamed (the agent picker's flow). */
+	onInstallAgent: (
+		alias: string,
+		agentId: string,
+		onLog: (chunk: string) => void,
+	) => Promise<{ loginCommand?: string }>;
 	mode: "side" | "full";
 	onSetMode: (m: "side" | "full") => void;
 	/** Tooltip for the minimize button — where collapsing takes you. */
 	collapseLabel?: string;
 	terminalId: string | null;
-	setTerminal: (tid: string) => void;
+	setTerminal: (tid: string | null) => void;
 	run: (fn: () => Promise<void>) => Promise<void>;
 	ask: (title: string, initial?: string) => Promise<string | null>;
 	confirm: (title: string, body?: string) => Promise<boolean>;
 	reload: () => void;
 	onClose: (taskId?: string) => void;
 }) {
-	const [agentId, setAgentId] = useState(agents.find((a) => a.available)?.id ?? "claude");
+	// Which agent a relaunch uses when nothing is chosen: the one already on this
+	// task, else the first installed. Picking a different one is the composer's job.
+	const fallbackAgentId = task.agentId ?? agents.find((a) => a.available)?.id ?? "claude";
+	const [sessionComposerOpen, setSessionComposerOpen] = useState(false);
 	const [diff, setDiff] = useState<DiffResultDTO | null>(null);
 	const [changesOpen, setChangesOpen] = useState(false);
 	const [viewFile, setViewFile] = useState<string | null>(null);
+	// This task's live PTY sessions — agents and shells alike. They ARE the tabs:
+	// the daemon already owns as many per task as you like, so there is nothing
+	// extra to persist. Tagged with the task they were read for, because the render
+	// right after you switch tasks still holds the previous task's list — reading
+	// that as this task's would put a foreign terminal in the panel. `null` means
+	// "not read yet", which the tab-fallback effect below must not mistake for
+	// "this task has no sessions".
+	const [loaded, setLoaded] = useState<{ taskId: string; sessions: SessionDTO[] } | null>(null);
+	const sessions = loaded?.taskId === task.id ? loaded.sessions : null;
 
 	// Selecting another task closes the changes view.
 	useEffect(() => {
 		setChangesOpen(false);
 		setViewFile(null);
 	}, [task.id]);
+
+	const refreshSessions = useCallback(async () => {
+		const taskId = task.id;
+		const live = await window.ateam.pty.listForTask(taskId);
+		// The engine hands these back latest-first; reverse so the strip reads
+		// oldest → newest — a new session then appends on the right instead of
+		// shuffling the tabs already open.
+		setLoaded({ taskId, sessions: live.reverse() });
+	}, [task.id]);
+
+	useEffect(() => {
+		void refreshSessions();
+		// A session opened in another window is announced as a task update (see the
+		// engine's spawn handlers), and one ending anywhere arrives as a pty exit.
+		const offUpdated = window.ateam.events.onTaskUpdated((t) => {
+			if (t.id === task.id) void refreshSessions();
+		});
+		const offExit = window.ateam.pty.onExit(() => void refreshSessions());
+		return () => {
+			offUpdated();
+			offExit();
+		};
+	}, [task.id, refreshSessions]);
 
 	const refreshDiff = useCallback(() => {
 		void window.ateam.git.diff(task.id).then(setDiff);
@@ -1302,7 +1361,7 @@ function TaskPanel({
 	}, [refreshDiff]);
 
 	const launch = useCallback(
-		(yolo: boolean, resume = false, agent = agentId) =>
+		(yolo: boolean, resume = false, agent = fallbackAgentId) =>
 			run(async () => {
 				const { terminalId: tid } = await window.ateam.pty.spawnAgent({
 					taskId: task.id,
@@ -1310,43 +1369,62 @@ function TaskPanel({
 					yolo,
 					resume,
 				});
+				await refreshSessions();
 				setTerminal(tid);
 			}),
-		[task.id, agentId, run, setTerminal],
+		[task.id, fallbackAgentId, run, setTerminal, refreshSessions],
 	);
 
-	// Re-attach to a surviving daemon session when (re)opening this task. If the
-	// session has ended while the task was still active work (running or awaiting
-	// input), resume the agent's last conversation automatically so reopening the
-	// task brings it back. Terminal columns (review/merged) are left alone — there
-	// a relaunch is a deliberate act via the Resume button, not a side effect of
-	// opening the task (and spawning would bounce the card back to "running").
+	// Keep the active tab pointed at something real. Covers (re)opening a task
+	// with surviving daemon sessions, and a session ending — its tab disappears
+	// and the newest survivor takes focus. With nothing left, resume the agent's
+	// last conversation if the task is still active work (running or awaiting
+	// input). Terminal columns (review/merged) are left alone — there a relaunch
+	// is a deliberate act via the Resume button, not a side effect of opening the
+	// task (and spawning would bounce the card back to "running").
 	const autoResumedRef = useRef<string | null>(null);
 	useEffect(() => {
-		if (terminalId) return;
-		let cancelled = false;
-		void window.ateam.pty.listForTask(task.id).then((sessions) => {
-			if (cancelled) return;
-			if (sessions[0]) {
-				setTerminal(sessions[0].terminalId);
-			} else if (
-				(task.column === "running" || task.column === "needs_attention") &&
-				autoResumedRef.current !== task.id
-			) {
-				autoResumedRef.current = task.id;
-				void launch(false, true, task.agentId ?? agentId);
-			}
+		if (!sessions) return; // list not read yet — don't judge the task by it
+		const next = activeTerminal(sessions, terminalId);
+		if (next !== terminalId) setTerminal(next);
+		if (next) return;
+		if (
+			(task.column === "running" || task.column === "needs_attention") &&
+			autoResumedRef.current !== task.id
+		) {
+			autoResumedRef.current = task.id;
+			void launch(false, true);
+		}
+	}, [task.id, task.column, sessions, terminalId, setTerminal, launch]);
+
+	// "+ → New agent session…": the task-creation composer minus name/branch/machine.
+	// Launches into THIS task's worktree, so the prompt, attachments, agent and YOLO
+	// all mean the same as they do on a new task — only the branch isn't new.
+	const composeSession = (input: {
+		prompt: string;
+		agentId: string;
+		yolo: boolean;
+		files: string[];
+	}) =>
+		run(async () => {
+			setSessionComposerOpen(false);
+			const { terminalId: tid } = await window.ateam.pty.spawnAgent({
+				taskId: task.id,
+				agentId: input.agentId,
+				yolo: input.yolo,
+				prompt: input.prompt || undefined,
+				files: input.files.length ? input.files : undefined,
+			});
+			await refreshSessions();
+			setTerminal(tid);
 		});
-		return () => {
-			cancelled = true;
-		};
-	}, [task.id, terminalId, task.column, task.agentId, agentId, setTerminal, launch]);
 
 	const shell = () =>
 		run(async () => {
 			const { terminalId: tid } = await window.ateam.pty.spawnShell({
 				taskId: task.id,
 			});
+			await refreshSessions();
 			setTerminal(tid);
 		});
 
@@ -1369,6 +1447,25 @@ function TaskPanel({
 		setChangesOpen(true);
 		if (!viewFile && diff?.files[0]) setViewFile(diff.files[0].path);
 	};
+
+	const tabs = sessionTabs(sessions ?? [], agents);
+
+	// Closing a tab kills its PTY — tabs are exactly the live sessions, so there
+	// is no "closed but still running" state to explain. Confirm first when the
+	// agent is mid-turn or holding a permission prompt, where a stray click would
+	// throw away work in progress.
+	const closeSession = (s: SessionDTO, label: string) =>
+		run(async () => {
+			if (s.status === "running" || s.status === "awaiting_input") {
+				const ok = await confirm(
+					`Close ${label}?`,
+					"This session is still working. Closing kills it, and anything mid-turn is lost.",
+				);
+				if (!ok) return;
+			}
+			await window.ateam.pty.kill(s.terminalId);
+			await refreshSessions();
+		});
 
 	// After toggling side/full, hand focus to the terminal so Enter goes to
 	// the agent — not back into the toggle button.
@@ -1405,32 +1502,56 @@ function TaskPanel({
 			</div>
 
 			<div className="actions">
-				<select
-					className="agent-select"
-					value={agentId}
-					onChange={(e) => setAgentId(e.target.value)}
-				>
-					{agents.map((a) => (
-						<option key={a.id} value={a.id} disabled={!a.available}>
-							{a.label}
-							{a.available ? "" : " (not installed)"}
-						</option>
+				{/* Left: this task's terminals, and the `+` that opens another. What kind
+				    of agent session you get is the composer's question, not a row of
+				    buttons — so the row stays legible however many tabs are open. */}
+				<div className="sess-tabs" role="tablist" aria-label="Sessions">
+					{tabs.map(({ session, label }) => (
+						<div
+							key={session.terminalId}
+							className={`sess-tab ${session.terminalId === terminalId ? "active" : ""}`}
+						>
+							<button
+								type="button"
+								role="tab"
+								aria-selected={session.terminalId === terminalId}
+								className="sess-tab-name"
+								title={label}
+								onClick={() => setTerminal(session.terminalId)}
+							>
+								{label}
+							</button>
+							<button
+								type="button"
+								className="sess-tab-close"
+								aria-label={`Close ${label}`}
+								title={`Close ${label}`}
+								onClick={() => closeSession(session, label)}
+							>
+								<X size={11} />
+							</button>
+						</div>
 					))}
-				</select>
-				<IconButton
-					icon={Play}
-					label="Launch agent (asks before dangerous actions)"
-					onClick={() => launch(false)}
-				/>
-				<IconButton icon={Zap} label="Launch in auto mode" onClick={() => launch(true)} />
-				<IconButton
-					icon={History}
-					label="Resume the last conversation in this worktree"
-					onClick={() => launch(false, true)}
-				/>
-				<IconButton icon={SquareTerminal} label="Open a shell" onClick={shell} />
+					<Menu
+						icon={Plus}
+						label="New tab"
+						items={[
+							{
+								label: "New agent session…",
+								icon: Play,
+								onClick: () => setSessionComposerOpen(true),
+							},
+							{ label: "Terminal", icon: SquareTerminal, onClick: shell },
+							{
+								label: "Resume last conversation",
+								icon: History,
+								onClick: () => launch(false, true),
+							},
+						]}
+					/>
+				</div>
 
-				<span className="tb-divider" />
+				<span className="spacer" />
 
 				<IconButton icon={GitCommitVertical} label="Commit all changes" onClick={commit} />
 				<IconButton
@@ -1499,7 +1620,6 @@ function TaskPanel({
 					]}
 				/>
 
-				<span className="spacer" />
 				<button
 					type="button"
 					className={`diffstat ${changesOpen ? "active" : ""}`}
@@ -1527,10 +1647,23 @@ function TaskPanel({
 						/>
 					) : (
 						<div className="term" style={{ display: "grid", placeItems: "center" }}>
-							<span className="muted">Launch an agent or shell to start a terminal</span>
+							<span className="muted">Open a tab with + to start a terminal</span>
 						</div>
 					)}
 				</div>
+
+				{sessionComposerOpen && (
+					<PromptComposer
+						agents={agents}
+						variant="session"
+						sessionAlias={alias}
+						defaultAgentId={fallbackAgentId}
+						envAgents={envAgents}
+						onInstallAgent={onInstallAgent}
+						onClose={() => setSessionComposerOpen(false)}
+						onCreate={composeSession}
+					/>
+				)}
 
 				{changesOpen && (
 					<div className="changes-view">

--- a/apps/desktop/src/renderer/src/components/PromptComposer.tsx
+++ b/apps/desktop/src/renderer/src/components/PromptComposer.tsx
@@ -25,13 +25,25 @@ function titleFromPrompt(p: string): string {
 }
 
 /**
- * Prompt-first task creation: name is optional (live branch preview shows
- * what you'll get), the prompt is handed to the chosen agent as its first
- * instruction, and YOLO launches it permission-free.
+ * Prompt-first agent launch, in two variants over the same form.
+ *
+ *   "task"    creates a branch + worktree and launches there: name is optional
+ *             (the live branch preview shows what you'll get) and you choose
+ *             which machine runs it.
+ *   "session" opens another agent session inside a task that already exists —
+ *             same prompt, agent, attachments and YOLO, but no name and no
+ *             branch (it reuses the worktree), and no environment to pick
+ *             because the task already lives on one.
+ *
+ * Either way the prompt is handed to the chosen agent as its first instruction,
+ * and YOLO launches it permission-free.
  */
-export function NewTaskComposer({
+export function PromptComposer({
 	agents,
-	environments,
+	variant = "task",
+	sessionAlias,
+	defaultAgentId,
+	environments = [],
 	envAgents,
 	onAdd,
 	onInstall,
@@ -40,9 +52,16 @@ export function NewTaskComposer({
 	onCreate,
 }: {
 	agents: AgentDTO[];
+	/** "task" creates a branch + worktree; "session" launches into one that exists. */
+	variant?: "task" | "session";
+	/** Session variant: the engine the task already runs on — not a choice here. */
+	sessionAlias?: string | null;
+	/** Preselect this agent (a task's existing agent) instead of the first available. */
+	defaultAgentId?: string;
 	/** Where the task can run: this Mac + each ~/.ssh/config box. `alias` null = Local.
-	 *  A box is disabled when the repo can't run there (no GitHub identity to clone). */
-	environments: EnvOption[];
+	 *  A box is disabled when the repo can't run there (no GitHub identity to clone).
+	 *  Unused by the session variant, which has no environment to choose. */
+	environments?: EnvOption[];
 	/** Agent ids each connected engine actually has, keyed by alias ("local" for this
 	 *  Mac). Lets the agent picker offer only what the chosen environment can run. */
 	envAgents: Record<string, string[]>;
@@ -68,7 +87,10 @@ export function NewTaskComposer({
 }) {
 	const [name, setName] = useState("");
 	const [prompt, setPrompt] = useState("");
-	const [agentId, setAgentId] = useState(agents.find((a) => a.available)?.id ?? "claude");
+	const session = variant === "session";
+	const [agentId, setAgentId] = useState(
+		defaultAgentId ?? agents.find((a) => a.available)?.id ?? "claude",
+	);
 	const [yolo, setYolo] = useState(false);
 	const [files, setFiles] = useState<string[]>([]);
 	const [dragging, setDragging] = useState(false);
@@ -76,6 +98,8 @@ export function NewTaskComposer({
 	// re-selected every time; fall back to the first runnable one (Local, unless the repo
 	// isn't here) when nothing valid is saved for this project. "__local__" = the Mac.
 	const [alias, setAliasState] = useState<string | null>(() => {
+		// A session runs where its task already is; only a new task gets a choice.
+		if (session) return sessionAlias ?? null;
 		const saved = localStorage.getItem("ateam.runOn");
 		const savedAlias = saved === "__local__" ? null : saved;
 		const usable =
@@ -104,7 +128,10 @@ export function NewTaskComposer({
 	}, [availOnEnv, agentId, agents]);
 
 	const branch = slugify(name.trim() || titleFromPrompt(prompt));
-	const canSubmit = Boolean(name.trim() || prompt.trim() || files.length);
+	// A session has no name to fall back on — it needs something to say.
+	const canSubmit = Boolean(
+		session ? prompt.trim() || files.length : name.trim() || prompt.trim() || files.length,
+	);
 
 	// De-duped append, preserving order — the picker and drops both feed here.
 	const addFiles = (paths: string[]) =>
@@ -149,17 +176,19 @@ export function NewTaskComposer({
 				onDragLeave={() => setDragging(false)}
 				onDrop={onDrop}
 			>
-				<div className="comp-head">
-					<input
-						className="comp-name"
-						placeholder="Task name (optional)"
-						value={name}
-						onChange={(e) => setName(e.target.value)}
-					/>
-					<span className="branch-preview" title="Branch name">
-						{branch || "branch name"}
-					</span>
-				</div>
+				{!session && (
+					<div className="comp-head">
+						<input
+							className="comp-name"
+							placeholder="Task name (optional)"
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+						/>
+						<span className="branch-preview" title="Branch name">
+							{branch || "branch name"}
+						</span>
+					</div>
+				)}
 				{/* biome-ignore lint/a11y/noAutofocus: composer should focus its prompt */}
 				<textarea
 					autoFocus
@@ -203,13 +232,15 @@ export function NewTaskComposer({
 						alias={alias}
 						onInstallAgent={onInstallAgent}
 					/>
-					<EnvironmentPicker
-						environments={environments}
-						value={alias}
-						onChange={setAlias}
-						onAdd={onAdd}
-						onInstall={onInstall}
-					/>
+					{!session && (
+						<EnvironmentPicker
+							environments={environments}
+							value={alias}
+							onChange={setAlias}
+							onAdd={onAdd}
+							onInstall={onInstall}
+						/>
+					)}
 					<button
 						type="button"
 						className={`iconbtn comp-yolo ${yolo ? "active" : ""}`}
@@ -227,7 +258,11 @@ export function NewTaskComposer({
 						type="button"
 						className="comp-go"
 						disabled={!canSubmit}
-						title="Create task and launch the agent (⌘⏎)"
+						title={
+							session
+								? "Launch another agent session in this task (⌘⏎)"
+								: "Create task and launch the agent (⌘⏎)"
+						}
 						onClick={submit}
 					>
 						<ArrowUp size={15} strokeWidth={2.25} />

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -680,16 +680,10 @@ input {
 }
 .panel .actions {
 	display: flex;
-	flex-wrap: wrap;
 	align-items: center;
 	gap: 2px;
 	padding: 6px 10px;
 	border-bottom: 1px solid var(--border);
-}
-.agent-select {
-	margin-right: 4px;
-	padding: 4px 6px;
-	font-size: 12px;
 }
 .term {
 	flex: 1;
@@ -725,6 +719,72 @@ input {
 	inset: 0;
 	min-height: 0;
 }
+/* Session tabs: one per live PTY on this task, agents and shells alike, plus the
+   `+` that opens another. Shares the actions row with the git shortcuts, so the
+   tabs are the half that shrinks and scrolls — the shortcuts stay put on the
+   right. `min-width: 0` is what lets this flex child shrink below its content. */
+.sess-tabs {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	min-width: 0;
+	overflow-x: auto;
+	/* A horizontal scrollbar must not shove the row taller than the icons. */
+	scrollbar-width: none;
+}
+.sess-tabs::-webkit-scrollbar {
+	display: none;
+}
+/* The `+` never scrolls away with the tabs — it's how you make the next one. */
+.sess-tabs > :last-child {
+	position: sticky;
+	right: 0;
+	flex: none;
+	background: var(--bg);
+}
+.sess-tab {
+	display: flex;
+	align-items: center;
+	flex: none;
+	border-radius: 6px;
+	color: var(--text-dim);
+}
+.sess-tab:hover {
+	background: var(--bg-elev);
+}
+.sess-tab.active {
+	background: var(--bg-elev-2);
+	color: var(--text);
+}
+.sess-tab-name {
+	max-width: 140px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	padding: 3px 2px 3px 8px;
+	border: none;
+	background: transparent;
+	color: inherit;
+	font-size: 12px;
+	cursor: pointer;
+}
+.sess-tab-close {
+	display: grid;
+	place-items: center;
+	padding: 2px;
+	margin-right: 4px;
+	border: none;
+	background: transparent;
+	border-radius: 4px;
+	color: inherit;
+	opacity: 0.5;
+	cursor: pointer;
+}
+.sess-tab-close:hover {
+	opacity: 1;
+	background: var(--bg-elev-2);
+}
+
 /* panel body: terminal, or the changes view (files left · diff right) */
 .panel-body {
 	flex: 1;
@@ -1228,14 +1288,6 @@ input {
 	pointer-events: none;
 	z-index: 300;
 	box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
-}
-
-.tb-divider {
-	width: 1px;
-	height: 18px;
-	background: var(--border);
-	margin: 0 6px;
-	flex: none;
 }
 
 /* ---- overflow menu ---- */

--- a/apps/desktop/src/renderer/src/session-tabs.test.ts
+++ b/apps/desktop/src/renderer/src/session-tabs.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import type { AgentDTO, SessionDTO } from "@ateam/protocol";
+import { activeTerminal, sessionTabs } from "./session-tabs";
+
+const AGENTS: AgentDTO[] = [
+	{ id: "claude", label: "Claude Code", description: "", available: true },
+	{ id: "codex", label: "Codex", description: "", available: true },
+];
+
+function session(terminalId: string, agentId: string): SessionDTO {
+	return {
+		id: `s-${terminalId}`,
+		taskId: "t1",
+		agentId,
+		terminalId,
+		status: "idle",
+		cwd: "/w",
+	};
+}
+
+test("a single session of a kind is labelled by name alone", () => {
+	const tabs = sessionTabs([session("a", "claude"), session("b", "shell")], AGENTS);
+	expect(tabs.map((t) => t.label)).toEqual(["Claude Code", "Shell"]);
+});
+
+test("repeats of the same agent are numbered from the second, oldest keeping its name", () => {
+	const tabs = sessionTabs(
+		[session("a", "claude"), session("b", "shell"), session("c", "claude"), session("d", "shell")],
+		AGENTS,
+	);
+	expect(tabs.map((t) => t.label)).toEqual(["Claude Code", "Shell", "Claude Code 2", "Shell 2"]);
+});
+
+test("an agent the engine no longer reports falls back to its id", () => {
+	expect(sessionTabs([session("a", "gemini")], AGENTS)[0].label).toBe("gemini");
+});
+
+test("a live pick is kept even when it is not the newest", () => {
+	const live = [session("a", "claude"), session("b", "shell")];
+	expect(activeTerminal(live, "a")).toBe("a");
+});
+
+test("a pick whose session ended falls to the newest survivor", () => {
+	expect(activeTerminal([session("a", "claude"), session("b", "shell")], "gone")).toBe("b");
+});
+
+test("opening a task with sessions but no pick lands on the newest", () => {
+	expect(activeTerminal([session("a", "claude"), session("b", "shell")], null)).toBe("b");
+});
+
+test("the last session ending leaves no terminal to show", () => {
+	expect(activeTerminal([], "a")).toBeNull();
+	expect(activeTerminal([], null)).toBeNull();
+});

--- a/apps/desktop/src/renderer/src/session-tabs.ts
+++ b/apps/desktop/src/renderer/src/session-tabs.ts
@@ -1,0 +1,41 @@
+// Tabs for a task's terminals. A task can hold any number of live PTY sessions
+// at once — several agents, a shell or two — and the engine already models that
+// (agent_sessions is keyed by task, pty:listForTask returns every live one). So
+// the tabs are not state of their own: they ARE the session list, and the only
+// thing the panel decides is which one to look at. Pure + unit-tested.
+import type { AgentDTO, SessionDTO } from "@ateam/protocol";
+
+export interface SessionTab {
+	session: SessionDTO;
+	label: string;
+}
+
+/**
+ * Label each session by its agent, numbering only from the second one of a kind
+ * ("Claude", "Claude 2") so the common single-session case reads as a plain name.
+ * `sessions` must be oldest-first, which keeps a tab's number stable for as long
+ * as it lives — numbering the newest would renumber the whole strip on each spawn.
+ */
+export function sessionTabs(sessions: SessionDTO[], agents: AgentDTO[]): SessionTab[] {
+	const seen = new Map<string, number>();
+	return sessions.map((session) => {
+		const base =
+			session.agentId === "shell"
+				? "Shell"
+				: (agents.find((a) => a.id === session.agentId)?.label ?? session.agentId);
+		const n = (seen.get(base) ?? 0) + 1;
+		seen.set(base, n);
+		return { session, label: n > 1 ? `${base} ${n}` : base };
+	});
+}
+
+/**
+ * Which session the panel should be showing, given the live (oldest-first) list
+ * and the tab currently picked. Keeps your pick while it's alive; when it dies —
+ * or when a task is opened with sessions this window has never chosen between —
+ * falls to the newest survivor. `null` means the task has no terminal left.
+ */
+export function activeTerminal(sessions: SessionDTO[], current: string | null): string | null {
+	if (current && sessions.some((s) => s.terminalId === current)) return current;
+	return sessions[sessions.length - 1]?.terminalId ?? null;
+}


### PR DESCRIPTION
A task could already hold any number of live PTY sessions — `agent_sessions` is keyed by task, `pty:listForTask` returns every live one, and Mission Control tiled them all. Only the desktop panel collapsed them to one: `termByTask` held a single `terminalId` per task, so every spawn *replaced* the visible terminal and orphaned the previous session, reachable again only through Mission Control.

So the tabs are not new state — they **are** the live session list. No schema change, no protocol change, nothing extra to persist. The strip rebuilds from the engine on open, on spawn/close, on pty exit, and on task updates (so a session opened in another window shows up).

### The toolbar collapses into one row

Tabs and a `+` on the left, git shortcuts pushed right — replacing the old two rows (agent dropdown / ▷ / ⚡ / 🕒 / shell, with the tab strip underneath).

`+` offers **New agent session…**, **Terminal**, or **Resume last conversation**.

"New agent session" reuses the task composer itself rather than duplicating it — same prompt, attachments, agent picker (with its install-on-box flow) and auto mode — minus what a session cannot have: no name, no branch preview (it reuses the worktree), no environment picker (the task already lives on an engine). Hence `NewTaskComposer` → `PromptComposer` with a `variant`: the old name stopped being true.

### Closing a tab

Kills its PTY, so tabs stay exactly the live sessions with no "closed but still running" state to explain. It confirms first when that session is mid-turn or holding a permission prompt.

### Tests

The two decisions with real branching — how tabs are labelled, and which tab takes over when the active one dies — are pure functions in `session-tabs.ts` with unit tests, following the `unify.ts` pattern.

### Verified in the running app

Driven over CDP against a `todo` task on a box-backed project, using plain shells:

- Row stays one line (41px, all children on one baseline) with tabs, `+` and all five git icons.
- Two `+ → Terminal` → `Shell` / `Shell 2` / `Shell 3`; newest active, earlier ones alive.
- Distinct markers written into each PTY; switching tabs repaints each one's own scrollback from the daemon snapshot.
- Closing a tab kills the PTY and focus falls to the survivor.
- Switching tasks and back shows only that task's sessions.
- Panel squeezed to 300px: tabs scroll, `+` stays pinned, git icons hold the right edge.
- `+ → New agent session…` opens the composer with no name row, branch preview or environment picker.

Not exercised end to end: submitting that composer (it is the same `spawnAgent` call the old ▷/⚡ buttons made, now carrying prompt and files), and the confirm-before-close branch, which needs a real agent mid-turn.

Mobile still picks `live[0]` (`NativeTerminalScreen.tsx:114`) — untouched; a phone needs a different switcher.