### PR TITLE
Run on picker: remove a box from the list

### DIFF
--- a/apps/desktop/src/main/host.ts
+++ b/apps/desktop/src/main/host.ts
@@ -23,6 +23,7 @@ import {
 	type ConnectionDTO,
 	type Engine,
 	endpointUrl,
+	forgetConnection,
 	hetznerProvider,
 	type HostTransport,
 	listConnections,
@@ -124,6 +125,8 @@ export interface Host {
 	list(): Promise<ConnectionDTO[]>;
 	connect(alias: string | null): Promise<HostStatus>;
 	disconnect(alias: string): void;
+	/** Remove a box from the connections list (disconnecting it first if held). */
+	forget(alias: string): void;
 	connected(): Promise<HostStatus[]>;
 	/** id → owning-engine alias (null = local), from the aggregate's learned registry. */
 	origins(): Record<string, string | null>;
@@ -343,6 +346,14 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 		if (i >= 0) backendList.splice(i, 1);
 		// Rebuild so the learned registry drops the gone engine's ids (no stale routing).
 		agg = createAggregate(backendList, local);
+		broadcastConnections();
+	}
+
+	function forget(alias: string): void {
+		disconnect(alias); // no-op if not held; drops the live engine if it is
+		forgetConnection(db, alias);
+		// disconnect only broadcasts when the box was held — a never-connected row
+		// changes the list too, so always tell the renderer to re-read it.
 		broadcastConnections();
 	}
 
@@ -577,6 +588,7 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 		list: async (): Promise<ConnectionDTO[]> => listConnections(db),
 		connect,
 		disconnect,
+		forget,
 		connected,
 		origins,
 		provision,
@@ -595,6 +607,7 @@ export function registerHostIpc(host: Host): void {
 	ipcMain.handle(HOST_CH.list, () => host.list());
 	ipcMain.handle(HOST_CH.connect, (_e, alias: string | null) => host.connect(alias));
 	ipcMain.handle(HOST_CH.disconnect, (_e, alias: string) => host.disconnect(alias));
+	ipcMain.handle(HOST_CH.forget, (_e, alias: string) => host.forget(alias));
 	ipcMain.handle(HOST_CH.connected, () => host.connected());
 	ipcMain.handle(HOST_CH.origins, () => host.origins());
 	ipcMain.handle(HOST_CH.provision, (_e, alias: string, input: { cloneUrl: string }) =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -121,6 +121,7 @@ const host: AteamHost = {
 	list: () => ipcRenderer.invoke(HOST_CH.list),
 	connect: (alias) => ipcRenderer.invoke(HOST_CH.connect, alias),
 	disconnect: (alias) => ipcRenderer.invoke(HOST_CH.disconnect, alias),
+	forget: (alias) => ipcRenderer.invoke(HOST_CH.forget, alias),
 	connected: () => ipcRenderer.invoke(HOST_CH.connected),
 	origins: () => ipcRenderer.invoke(HOST_CH.origins),
 	provision: (alias, input) => ipcRenderer.invoke(HOST_CH.provision, alias, input),

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -383,6 +383,13 @@ export function App() {
 	const addTailscaleBox = useCallback(async (endpoint: string) => {
 		await window.ateamHost.connect(endpoint);
 	}, []);
+	// Remove a box from the "Run on" list. The main process disconnects it if held
+	// and forgets the saved record (an ssh_config alias is flagged hidden — the
+	// config file itself is never touched); the connections-changed broadcast then
+	// refreshes the list here. Setting the box up again brings it back.
+	const forgetBox = useCallback(async (alias: string) => {
+		await window.ateamHost.forget(alias);
+	}, []);
 	// Set up a fresh box over SSH: install() runs the (idempotent) installer on the
 	// box, streaming its output via onInstallLog, and connects on success. The
 	// onConnectionsChanged reconcile then folds the new box into the environment list.
@@ -1137,6 +1144,7 @@ export function App() {
 					envAgents={envAgents}
 					onAdd={addTailscaleBox}
 					onInstall={installBox}
+					onForget={forgetBox}
 					onInstallAgent={installAgentOnBox}
 					onClose={() => setComposerOpen(false)}
 					onCreate={composeTask}

--- a/apps/desktop/src/renderer/src/components/EnvironmentPicker.tsx
+++ b/apps/desktop/src/renderer/src/components/EnvironmentPicker.tsx
@@ -1,4 +1,4 @@
-import { Check, Cloud, Laptop, Network, Plus, Server } from "lucide-react";
+import { Check, Cloud, Laptop, Network, Plus, Server, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { HostStatus } from "../../../shared/host";
@@ -32,6 +32,7 @@ export function EnvironmentPicker({
 	onChange,
 	onAdd,
 	onInstall,
+	onForget,
 }: {
 	environments: EnvOption[];
 	value: string | null;
@@ -41,6 +42,8 @@ export function EnvironmentPicker({
 	/** Install the engine on a fresh SSH box (`alias` or `user@host`), streaming the
 	 *  installer's output; resolves once the box is set up and connected. */
 	onInstall?: (dest: string, onLog: (chunk: string) => void) => Promise<HostStatus>;
+	/** Remove a box from this list (disconnecting it first if connected). */
+	onForget?: (alias: string) => Promise<void>;
 }) {
 	// The add-a-connection section: "" collapsed → "menu" (the methods) → a chosen
 	// method's inline form → "ready" (the readiness checklist after an SSH set-up).
@@ -192,32 +195,54 @@ export function EnvironmentPicker({
 							<span>Run on</span>
 						</div>
 						{environments.map((env) => (
-							<button
+							<div
 								key={env.label}
-								type="button"
-								className={`conn-row ${env.alias === value ? "active" : ""}`}
-								disabled={env.disabled}
-								onClick={() => pick(env)}
+								className={`conn-row-wrap ${env.alias === value ? "active" : ""}`}
 							>
-								<span className="conn-ico">
-									{env.alias === null ? (
-										<Laptop size={15} strokeWidth={1.75} />
-									) : (
-										<Server size={15} strokeWidth={1.75} />
-									)}
-								</span>
-								<span className="conn-txt">
-									<span className="conn-title">{env.label}</span>
-									{env.disabled && env.alias !== null ? (
-										<span className="conn-sub">repo needs a git remote to run here</span>
-									) : env.needsSetup ? (
-										<span className="conn-sub">not set up — click to install the engine</span>
-									) : env.transport === "ws" ? (
-										<span className="conn-sub">Tailscale</span>
-									) : null}
-								</span>
-								{env.alias === value ? <Check size={15} strokeWidth={2.25} /> : null}
-							</button>
+								<button
+									type="button"
+									className={`conn-row ${env.alias === value ? "active" : ""}`}
+									disabled={env.disabled}
+									onClick={() => pick(env)}
+								>
+									<span className="conn-ico">
+										{env.alias === null ? (
+											<Laptop size={15} strokeWidth={1.75} />
+										) : (
+											<Server size={15} strokeWidth={1.75} />
+										)}
+									</span>
+									<span className="conn-txt">
+										<span className="conn-title">{env.label}</span>
+										{env.disabled && env.alias !== null ? (
+											<span className="conn-sub">repo needs a git remote to run here</span>
+										) : env.needsSetup ? (
+											<span className="conn-sub">not set up — click to install the engine</span>
+										) : env.transport === "ws" ? (
+											<span className="conn-sub">Tailscale</span>
+										) : null}
+									</span>
+									{env.alias === value ? <Check size={15} strokeWidth={2.25} /> : null}
+								</button>
+								{env.alias !== null && onForget && (
+									<button
+										type="button"
+										className="conn-forget"
+										title={`Remove ${env.label} from this list`}
+										aria-label={`Remove ${env.label} from this list`}
+										onClick={() => {
+											const alias = env.alias;
+											if (!alias) return;
+											// Removing the selected box falls back to Local; setting the
+											// box up again is the way to bring it back.
+											if (alias === value) onChange(null);
+											void onForget(alias);
+										}}
+									>
+										<X size={13} strokeWidth={2} />
+									</button>
+								)}
+							</div>
 						))}
 						{(onAdd || onInstall) &&
 							(addMode === "" ? (

--- a/apps/desktop/src/renderer/src/components/PromptComposer.tsx
+++ b/apps/desktop/src/renderer/src/components/PromptComposer.tsx
@@ -47,6 +47,7 @@ export function PromptComposer({
 	envAgents,
 	onAdd,
 	onInstall,
+	onForget,
 	onInstallAgent,
 	onClose,
 	onCreate,
@@ -69,6 +70,8 @@ export function PromptComposer({
 	onAdd?: (endpoint: string) => Promise<void>;
 	/** Set up a fresh box over SSH (install engine + connect) from the picker. */
 	onInstall?: (dest: string, onLog: (chunk: string) => void) => Promise<HostStatus>;
+	/** Remove a box from the picker's list (disconnecting it first if connected). */
+	onForget?: (alias: string) => Promise<void>;
 	/** Install a coding agent's CLI on the selected box, streamed; returns the login step. */
 	onInstallAgent?: (
 		alias: string,
@@ -239,6 +242,7 @@ export function PromptComposer({
 							onChange={setAlias}
 							onAdd={onAdd}
 							onInstall={onInstall}
+							onForget={onForget}
 						/>
 					)}
 					<button

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -1404,6 +1404,48 @@ input {
 .conn-row:disabled {
 	cursor: default;
 }
+/* A picker row + its hover-revealed remove button (can't nest buttons). The wrap
+   owns the hover/active background so the highlight spans both. */
+.conn-row-wrap {
+	display: flex;
+	align-items: center;
+	border-radius: 7px;
+}
+.conn-row-wrap:hover {
+	background: var(--bg-elev-2);
+}
+.conn-row-wrap.active {
+	background: rgba(124, 92, 255, 0.12);
+}
+.conn-row-wrap > .conn-row,
+.conn-row-wrap > .conn-row:hover,
+.conn-row-wrap > .conn-row.active {
+	background: transparent;
+	min-width: 0;
+}
+.conn-forget {
+	flex: none;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	height: 20px;
+	margin-right: 6px;
+	border: none;
+	border-radius: 5px;
+	background: transparent;
+	color: var(--text-dim);
+	cursor: pointer;
+	opacity: 0;
+}
+.conn-row-wrap:hover .conn-forget,
+.conn-forget:focus-visible {
+	opacity: 1;
+}
+.conn-forget:hover {
+	color: var(--text);
+	background: rgba(255, 255, 255, 0.08);
+}
 .conn-add {
 	display: flex;
 	flex-direction: column;

--- a/apps/desktop/src/shared/host.ts
+++ b/apps/desktop/src/shared/host.ts
@@ -10,6 +10,8 @@ export const HOST_CH = {
 	list: "host:list",
 	connect: "host:connect",
 	disconnect: "host:disconnect",
+	/** Remove a box from the connections list (disconnecting it first if held). */
+	forget: "host:forget",
 	/** All currently-held engines (local is always present). */
 	connected: "host:connected",
 	/** projectId/taskId → owning engine alias (null = local), for per-origin badges/routing. */
@@ -115,6 +117,10 @@ export interface AteamHost {
 	connect(alias: string | null): Promise<HostStatus>;
 	/** Drop a connected box (never local). */
 	disconnect(alias: string): Promise<void>;
+	/** Remove a box from the connections list (disconnecting it first if held).
+	 *  Setting it up or connecting to it again brings it back; ~/.ssh/config is
+	 *  never edited. */
+	forget(alias: string): Promise<void>;
 	/** Every engine currently held (local first). */
 	connected(): Promise<HostStatus[]>;
 	/** id → owning-engine alias (null = local) for each entity the engines have surfaced. */

--- a/docs/online-ateam.md
+++ b/docs/online-ateam.md
@@ -175,6 +175,10 @@ Test it:
 ssh my-ateam-box "bash -lc 'ateam'"
 ```
 
+> Don't want a config host offered as a box? Hover its row in the **Run on** picker
+> and click the ✕ — it disappears from the list (your `~/.ssh/config` is never
+> edited), and setting the box up again brings it back.
+
 ## 4. Connect from the desktop app
 
 1. Open Ateam. Top-right of the toolbar is the **connection button** — it shows

--- a/packages/db/src/bootstrap.ts
+++ b/packages/db/src/bootstrap.ts
@@ -134,6 +134,7 @@ export function bootstrap(db: SqliteExecutor): void {
 				server_version TEXT,
 				agents_available TEXT,
 				last_seen INTEGER,
+				hidden INTEGER NOT NULL DEFAULT 0,
 				created_at INTEGER
 			);
 			CREATE INDEX IF NOT EXISTS hosts_last_seen_idx ON hosts (last_seen);
@@ -155,6 +156,7 @@ export function bootstrap(db: SqliteExecutor): void {
 		// Every row that predates this column is an ssh_config alias — the only
 		// kind of connection that existed — so the default backfills correctly.
 		"ALTER TABLE hosts ADD COLUMN transport TEXT NOT NULL DEFAULT 'ssh'",
+		"ALTER TABLE hosts ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0",
 	]) {
 		try {
 			db.exec(sql);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -251,6 +251,10 @@ export const hosts = sqliteTable(
 		serverVersion: text("server_version"),
 		agentsAvailable: text("agents_available", { mode: "json" }).$type<string[]>(),
 		lastSeen: integer("last_seen"),
+		/** User removed it from the connections list. An ssh_config alias can't be
+		 *  deleted (the config would resurface it), so it's flagged instead; a later
+		 *  successful connection clears the flag. */
+		hidden: integer("hidden").notNull().default(0),
 		createdAt: epochMs("created_at"),
 	},
 	(t) => [index("hosts_last_seen_idx").on(t.lastSeen)],

--- a/packages/server/src/connections.ts
+++ b/packages/server/src/connections.ts
@@ -173,11 +173,16 @@ export function listConnections(db: AteamDb, configPath?: string): ConnectionDTO
 		// Metadata is keyed by alias, so a box previously reached under a now-folded
 		// name still has its history — keep the most recently seen of them.
 		let rec: Host | null = null;
+		let hidden = false;
 		for (const sh of group) {
 			absorbed.add(sh.alias);
 			const other = saved.get(sh.alias);
+			if (other?.hidden) hidden = true;
 			if (other && (other.lastSeen ?? 0) >= (rec?.lastSeen ?? 0)) rec = other;
 		}
+		// Removed from the list by the user; every alias stays absorbed so none of
+		// the group's saved rows resurface in the saved-only loop below.
+		if (hidden) continue;
 		byAlias.set(canonical.alias, {
 			alias: canonical.alias,
 			// Everything folded here came out of ssh_config, so it is ssh by
@@ -192,7 +197,7 @@ export function listConnections(db: AteamDb, configPath?: string): ConnectionDTO
 		});
 	}
 	for (const rec of saved.values()) {
-		if (absorbed.has(rec.hostAlias)) continue;
+		if (absorbed.has(rec.hostAlias) || rec.hidden) continue;
 		byAlias.set(rec.hostAlias, {
 			alias: rec.hostAlias,
 			transport: rec.transport as HostTransport,
@@ -220,9 +225,28 @@ export function recordConnection(db: AteamDb, rec: ConnectionRecord): Host {
 	const patch: Partial<Host> & { hostAlias: string } = {
 		hostAlias: rec.hostAlias,
 		lastSeen: Date.now(),
+		// Reaching the box again is the way back in after a forget: setting it up (or
+		// connecting to it) un-hides it, so removal is never a dead end.
+		hidden: 0,
 	};
 	if (rec.transport !== undefined) patch.transport = rec.transport;
 	if (rec.serverVersion !== undefined) patch.serverVersion = rec.serverVersion;
 	if (rec.agentsAvailable !== undefined) patch.agentsAvailable = rec.agentsAvailable;
 	return repo.upsertHost(db, patch);
+}
+
+/**
+ * Remove a connection from the list. A row that exists only in our db (a ws
+ * endpoint, or a user@host set up directly) is deleted outright; an alias still
+ * in ~/.ssh/config would resurface on the next list, so it's flagged hidden
+ * instead — ssh_config stays OpenSSH's file, we never edit it. Either way,
+ * connecting to (or setting up) the box again brings it back: recordConnection
+ * clears the flag.
+ */
+export function forgetConnection(db: AteamDb, alias: string, configPath?: string): void {
+	if (readSshHosts(configPath).some((h) => h.alias === alias)) {
+		repo.upsertHost(db, { hostAlias: alias, hidden: 1 });
+	} else {
+		repo.deleteHost(db, alias);
+	}
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,6 +9,7 @@
 export type { ConnectionDTO, ConnectionRecord, HostTransport, SshHost } from "./connections";
 export {
 	endpointUrl,
+	forgetConnection,
 	listConnections,
 	readSshHosts,
 	recordConnection,

--- a/packages/server/test/connections.test.ts
+++ b/packages/server/test/connections.test.ts
@@ -6,6 +6,7 @@ import { repo } from "@ateam/db";
 import { createTestDb } from "../../db/test/helpers/test-db";
 import {
 	endpointUrl,
+	forgetConnection,
 	listConnections,
 	readSshHosts,
 	recordConnection,
@@ -151,6 +152,52 @@ describe("recordConnection", () => {
 		expect(h?.serverVersion).toBe("1.0.0");
 		expect(h?.agentsAvailable).toEqual(["claude", "codex"]);
 		expect(typeof h?.lastSeen).toBe("number");
+	});
+});
+
+describe("forgetConnection", () => {
+	it("deletes a saved-only host outright", () => {
+		const db = createTestDb();
+		const cfg = writeConfig("Host devbox\n  HostName 10.0.0.1\n");
+		recordConnection(db, { hostAlias: "100.72.63.61:8787", transport: "ws" });
+
+		forgetConnection(db, "100.72.63.61:8787", cfg);
+		expect(repo.getHost(db, "100.72.63.61:8787")).toBeUndefined();
+		expect(listConnections(db, cfg).map((c) => c.alias)).toEqual(["devbox"]);
+	});
+
+	it("hides an ssh_config alias instead of deleting (the config would resurface it)", () => {
+		const db = createTestDb();
+		const cfg = writeConfig("Host devbox\n  HostName 10.0.0.1\nHost other\n  HostName 10.0.0.2\n");
+		recordConnection(db, { hostAlias: "devbox", serverVersion: "1" });
+
+		forgetConnection(db, "devbox", cfg);
+		expect(listConnections(db, cfg).map((c) => c.alias)).toEqual(["other"]);
+		// Also hides a never-connected config alias (no prior saved row).
+		forgetConnection(db, "other", cfg);
+		expect(listConnections(db, cfg)).toEqual([]);
+	});
+
+	it("hides a collapsed group by its canonical alias", () => {
+		const db = createTestDb();
+		const cfg = writeConfig(
+			"Host mybox.boxd mybox.boxd.sh\n  HostName mybox.boxd.sh\n  Port 12836\n  User boxd\n",
+		);
+		// History saved under the folded-away alias must not resurface after forgetting.
+		repo.upsertHost(db, { hostAlias: "mybox.boxd.sh", lastSeen: 42 });
+
+		forgetConnection(db, "mybox.boxd", cfg);
+		expect(listConnections(db, cfg)).toEqual([]);
+	});
+
+	it("reconnecting un-hides a forgotten host", () => {
+		const db = createTestDb();
+		const cfg = writeConfig("Host devbox\n  HostName 10.0.0.1\n");
+		forgetConnection(db, "devbox", cfg);
+		expect(listConnections(db, cfg)).toEqual([]);
+
+		recordConnection(db, { hostAlias: "devbox" });
+		expect(listConnections(db, cfg).map((c) => c.alias)).toEqual(["devbox"]);
 	});
 });
 


### PR DESCRIPTION
A box added to the **Run on** list had no way to be removed: the picker unions every `~/.ssh/config` alias with the hosts table rows saved on each successful connect/install, and nothing ever deleted either (the db layer's `deleteHost` was dead code — and a plain delete wouldn't help anyway, since ssh_config re-populates its aliases on the next read).

Now every remote row reveals a ✕ on hover:

- **Saved-only hosts** (Tailscale endpoints, `user@host` installs) are deleted outright.
- **ssh_config aliases** are flagged `hidden` in the hosts table instead — `~/.ssh/config` is never edited. New `hidden` column with an idempotent migration.
- A **connected** box is disconnected first; a forgotten box also stops auto-reconnecting at launch (rehydration reads the same filtered list).
- **The way back:** `recordConnection` clears the flag, so connecting to or setting the box up again restores it. Removing the selected environment falls back to Local.

Wired through all layers: `forgetConnection` in @ateam/server, `host:forget` IPC + preload, `forget()` in the main-process host controller, and the picker UI (rows became a wrapper so the remove control isn't a nested button; keyboard-reachable). Docs note added to online-ateam.md.

Tests: 4 new cases (delete vs hide, collapsed boxd alias groups, un-hide on reconnect); server suite 113 pass, db suite 8 pass, typecheck clean.