### PR TITLE
Session search: find a past session by describing the work, from the topbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ extra sessions inside an existing task, many terminals per task as tabs (agent
 sessions or plain shells, side by side), agent spawning in PTYs (Claude Code,
 OpenCode, Codex), hook-driven status → kanban columns with merged-PR detection,
 Mission Control grid, collapsible sidebar rail, image drag-drop & paste into
-agent terminals, safe cleanup of merged worktrees, and signed/notarized builds
+agent terminals, session search (describe past work in the topbar and jump back
+to the session that did it, reading Claude Code / Codex / OpenCode transcripts),
+safe cleanup of merged worktrees, and signed/notarized builds
 with in-app auto-update. The git engine and db layer are unit-tested; the
 Electron main process is boot-verified with native modules.
 

--- a/apps/desktop/src/main/aggregate.ts
+++ b/apps/desktop/src/main/aggregate.ts
@@ -57,6 +57,7 @@ const ENTITY = new Set<string>([
 	CH.loopsSetEnabled, // loop id
 	CH.loopsRunNow, // loop id
 	CH.loopsDelete, // loop id
+	CH.searchSessions, // {projectId} — a box searches the history on its own disk
 	CH.ptyListForTask, // taskId
 	CH.ptyWrite, // terminalId
 	CH.ptyResize,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -46,6 +46,9 @@ const api: AteamApi = {
 	agents: {
 		list: () => ipcRenderer.invoke(CH.agentsList),
 	},
+	search: {
+		sessions: (input) => ipcRenderer.invoke(CH.searchSessions, input),
+	},
 	fs: {
 		listDir: (path) => ipcRenderer.invoke(CH.fsListDir, path),
 	},

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -5,6 +5,7 @@ import type {
 	KanbanColumn,
 	ProjectDTO,
 	SessionDTO,
+	SessionHitDTO,
 	TaskDTO,
 } from "@ateam/protocol";
 import {
@@ -41,7 +42,6 @@ import {
 	Rocket,
 	RotateCw,
 	Rows2,
-	Search,
 	Server,
 	Sparkles,
 	SquareTerminal,
@@ -66,6 +66,7 @@ import { IconButton } from "./components/IconButton";
 import { LoopsPanel } from "./components/LoopsPanel";
 import { Menu } from "./components/Menu";
 import { PromptComposer } from "./components/PromptComposer";
+import { TaskSearch } from "./components/TaskSearch";
 import { TerminalView } from "./components/Terminal";
 import { usePrompt } from "./components/usePrompt";
 import { activeTerminal, sessionTabs } from "./session-tabs";
@@ -352,6 +353,17 @@ export function App() {
 		[unifiedProjects, activeProjectId],
 	);
 	const activeMembers = activeCard?.members ?? [];
+	// Session search runs on each engine that holds this repo: the transcripts
+	// live on the machine that ran the agent, so a box searches its own disk.
+	const searchProjectIds = useMemo(
+		() =>
+			activeMembers.length > 0
+				? activeMembers.map((m) => m.projectId)
+				: activeProjectId
+					? [activeProjectId]
+					: [],
+		[activeMembers, activeProjectId],
+	);
 	// Which engine a task runs on = the engine that owns its project (tasks never
 	// migrate between engines, so origin is intrinsic to the projectId).
 	const originOf = useCallback((projectId: string): Alias => origins[projectId] ?? null, [origins]);
@@ -553,6 +565,15 @@ export function App() {
 		setTermByTask((m) => ({ ...m, [task.id]: terminalId }));
 		setSelectedTaskId(task.id);
 		setPanelMode("full");
+	};
+	// A session-search hit opens the task it ran in, and the exact terminal it
+	// ran in when that tab is still alive — the point of the search is to land
+	// back where the work happened, not merely near it.
+	const openSessionHit = (hit: SessionHitDTO) => {
+		const task = activeTasks.find((t) => t.id === hit.taskId);
+		if (!task) return;
+		if (hit.terminalId) setTermByTask((m) => ({ ...m, [task.id]: hit.terminalId }));
+		openTask(task);
 	};
 	// Collapsing the full panel inside Mission Control means "back to the
 	// grid", not "shrink to a side panel" — there is no board to sit beside.
@@ -1002,26 +1023,12 @@ export function App() {
 					</div>
 					{/* Centered task search — absolutely centered in the topbar so the
 					    tabs on the left and action buttons on the right don't shift it. */}
-					<div className="task-search">
-						<Search size={14} strokeWidth={1.75} />
-						<input
-							type="text"
-							placeholder="Search tasks…"
-							value={taskQuery}
-							onChange={(e) => setTaskQuery(e.target.value)}
-							aria-label="Search tasks"
-						/>
-						{taskQuery && (
-							<button
-								type="button"
-								className="ts-clear"
-								aria-label="Clear search"
-								onClick={() => setTaskQuery("")}
-							>
-								<X size={13} strokeWidth={2} />
-							</button>
-						)}
-					</div>
+					<TaskSearch
+						query={taskQuery}
+						onQuery={setTaskQuery}
+						projectIds={searchProjectIds}
+						onOpen={openSessionHit}
+					/>
 					<div className="spacer" />
 					{view === "mission" && !(selectedTask && panelMode === "full") && (
 						<div className="mclayout" role="group" aria-label="Layout">

--- a/apps/desktop/src/renderer/src/components/TaskSearch.tsx
+++ b/apps/desktop/src/renderer/src/components/TaskSearch.tsx
@@ -1,0 +1,172 @@
+import type { SessionHitDTO } from "@ateam/protocol";
+import { Search, Sparkles, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * The topbar search box. Typing filters the board and sidebar instantly, as it
+ * always has; the sparkle answers a different question — "which session was I
+ * working on X?" — by describing the work instead of naming the task.
+ *
+ * That question used to mean opening a fresh agent session just to ask it. The
+ * engine does the finding (see @ateam/server session-search); this component
+ * owns the two states that only exist on screen: whether an AI search is in
+ * flight, and whether its results are showing.
+ */
+export function TaskSearch({
+	query,
+	onQuery,
+	projectIds,
+	onOpen,
+}: {
+	query: string;
+	onQuery: (q: string) => void;
+	/** Every project on the active card — a repo open on the Mac AND on a box is
+	 *  two engines, each holding its own half of the history. */
+	projectIds: string[];
+	onOpen: (hit: SessionHitDTO) => void;
+}) {
+	const [hits, setHits] = useState<SessionHitDTO[] | null>(null);
+	const [busy, setBusy] = useState(false);
+	const [cursor, setCursor] = useState(0);
+	const boxRef = useRef<HTMLDivElement>(null);
+	// Only the newest search may write results: an earlier, slower answer
+	// arriving late would otherwise replace the one the user is reading.
+	const runId = useRef(0);
+
+	const close = useCallback(() => {
+		setHits(null);
+		setBusy(false);
+		runId.current++;
+	}, []);
+
+	const search = useCallback(async () => {
+		const q = query.trim();
+		if (!q || projectIds.length === 0 || busy) return;
+		const run = ++runId.current;
+		setBusy(true);
+		setHits(null);
+		setCursor(0);
+		try {
+			const lists = await Promise.all(
+				projectIds.map((projectId) =>
+					window.ateam.search.sessions({ projectId, query: q, ai: true }).catch(() => []),
+				),
+			);
+			if (run !== runId.current) return;
+			setHits(interleave(lists));
+		} finally {
+			if (run === runId.current) setBusy(false);
+		}
+	}, [query, projectIds, busy]);
+
+	// Results answer the question that was asked; once the question changes they
+	// are stale, and a stale answer under a new query reads as a wrong one.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the query alone.
+	useEffect(() => close(), [query]);
+
+	useEffect(() => {
+		if (!hits && !busy) return;
+		const onClick = (e: MouseEvent) => {
+			if (!boxRef.current?.contains(e.target as Node)) close();
+		};
+		document.addEventListener("mousedown", onClick);
+		return () => document.removeEventListener("mousedown", onClick);
+	}, [hits, busy, close]);
+
+	const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			const chosen = hits?.[cursor];
+			if (chosen) onOpen(chosen);
+			else void search();
+		} else if (e.key === "Escape" && (hits || busy)) {
+			e.preventDefault();
+			close();
+		} else if (hits && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
+			e.preventDefault();
+			const step = e.key === "ArrowDown" ? 1 : -1;
+			setCursor((c) => Math.max(0, Math.min(hits.length - 1, c + step)));
+		}
+	};
+
+	return (
+		<div className="task-search" ref={boxRef}>
+			<Search size={14} strokeWidth={1.75} />
+			<input
+				type="text"
+				placeholder="Search tasks…"
+				value={query}
+				onChange={(e) => onQuery(e.target.value)}
+				onKeyDown={onKeyDown}
+				aria-label="Search tasks"
+			/>
+			{query && (
+				<button
+					type="button"
+					className="ts-clear"
+					aria-label="Clear search"
+					onClick={() => onQuery("")}
+				>
+					<X size={13} strokeWidth={2} />
+				</button>
+			)}
+			<button
+				type="button"
+				className={`ts-clear ts-ai ${busy ? "busy" : ""}`}
+				title="Find the session where you did this"
+				aria-label="Find the session where you did this"
+				disabled={!query.trim() || projectIds.length === 0}
+				onClick={() => void search()}
+			>
+				<Sparkles size={13} strokeWidth={1.75} />
+			</button>
+
+			{(busy || hits) && (
+				<div className="ts-results" role="listbox" aria-label="Matching sessions">
+					{busy && <div className="ts-note">Reading your past sessions…</div>}
+					{hits?.length === 0 && (
+						<div className="ts-note">No session matched that description.</div>
+					)}
+					{hits?.map((hit, i) => (
+						<button
+							type="button"
+							key={`${hit.taskId}:${hit.sessionId}`}
+							className={`ts-hit ${i === cursor ? "on" : ""}`}
+							role="option"
+							aria-selected={i === cursor}
+							onMouseEnter={() => setCursor(i)}
+							onClick={() => onOpen(hit)}
+						>
+							<span className="ts-hit-name">{hit.taskName}</span>
+							<span className="ts-hit-why">{hit.why || hit.excerpt}</span>
+							<span className="ts-hit-meta">
+								{hit.agentId}
+								{hit.branch ? ` · ${hit.branch}` : ""}
+								{hit.endedAt ? ` · ${new Date(hit.endedAt).toLocaleDateString()}` : ""}
+								{hit.terminalId ? " · session still open" : ""}
+							</span>
+						</button>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+/**
+ * Merge per-engine result lists without inventing a cross-engine score. Each
+ * list is already ranked; taking them in turn keeps every engine's best answer
+ * near the top instead of letting whichever engine answered first win.
+ */
+function interleave(lists: SessionHitDTO[][]): SessionHitDTO[] {
+	const out: SessionHitDTO[] = [];
+	for (let i = 0; out.length < 8; i++) {
+		const before = out.length;
+		for (const list of lists) {
+			const hit = list[i];
+			if (hit) out.push(hit);
+		}
+		if (out.length === before) break;
+	}
+	return out.slice(0, 8);
+}

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -496,6 +496,93 @@ input {
 	background: var(--bg-elev-2);
 	color: var(--text);
 }
+.task-search .ts-ai:disabled {
+	opacity: 0.35;
+	cursor: default;
+}
+/* Working: a slow pulse, not a spinner — the search takes seconds, and a
+   spinner at this size reads as a stuck one. */
+.task-search .ts-ai.busy {
+	color: var(--text);
+	animation: ts-pulse 1.4s ease-in-out infinite;
+}
+@keyframes ts-pulse {
+	0%,
+	100% {
+		opacity: 0.45;
+	}
+	50% {
+		opacity: 1;
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.task-search .ts-ai.busy {
+		animation: none;
+		color: var(--text);
+	}
+}
+/* Results hang below the box, which is itself absolutely centered in the
+   topbar — so this is positioned against the box, not the bar. */
+.ts-results {
+	position: absolute;
+	top: calc(100% + 6px);
+	left: 0;
+	right: 0;
+	z-index: 30;
+	max-height: 60vh;
+	overflow-y: auto;
+	padding: 4px;
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	background: var(--bg-elev);
+	box-shadow: 0 10px 30px rgb(0 0 0 / 0.35);
+}
+.ts-note {
+	padding: 8px 10px;
+	font-size: 12px;
+	color: var(--text-dim);
+}
+.ts-hit {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	width: 100%;
+	padding: 7px 10px;
+	border: none;
+	border-radius: 7px;
+	background: transparent;
+	text-align: left;
+	cursor: pointer;
+}
+.ts-hit.on {
+	background: var(--bg-elev-2);
+}
+.ts-hit-name {
+	font-size: 13px;
+	color: var(--text);
+	/* One line: the name is the handle, the reason below is the substance. */
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.ts-hit-why {
+	font-size: 12px;
+	line-height: 1.35;
+	color: var(--text-dim);
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+.ts-hit-meta {
+	font-size: 11px;
+	color: var(--text-dim);
+	opacity: 0.75;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
 .tabs {
 	display: flex;
 	gap: 4px;

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/desktop": {
       "name": "@ateam/desktop",
-      "version": "0.1.35",
+      "version": "0.1.42",
       "dependencies": {
         "better-sqlite3": "^11.8.1",
         "electron-updater": "^6.8.3",
@@ -94,10 +94,12 @@
         "@ateam/protocol": "workspace:*",
         "@xterm/addon-serialize": "^0.13.0",
         "@xterm/headless": "^5.5.0",
+        "better-sqlite3": "^11.8.1",
         "node-pty": "^1.0.0",
         "ws": "^8.21.0",
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^9.6.0",
         "@types/node": "^22.10.5",
         "@types/ws": "^8.18.1",
         "drizzle-orm": "^0.38.4",
@@ -1127,6 +1129,8 @@
 
     "zip-stream": ["zip-stream@4.1.1", "", { "dependencies": { "archiver-utils": "^3.0.4", "compress-commons": "^4.1.2", "readable-stream": "^3.6.0" } }, "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ=="],
 
+    "@ateam/server/@types/better-sqlite3": ["@types/better-sqlite3@9.6.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -1262,6 +1266,8 @@
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "zip-stream/archiver-utils": ["archiver-utils@3.0.4", "", { "dependencies": { "glob": "^7.2.3", "graceful-fs": "^4.2.0", "lazystream": "^1.0.0", "lodash.defaults": "^4.2.0", "lodash.difference": "^4.5.0", "lodash.flatten": "^4.4.0", "lodash.isplainobject": "^4.0.6", "lodash.union": "^4.6.0", "normalize-path": "^3.0.0", "readable-stream": "^3.6.0" } }, "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw=="],
+
+    "@ateam/server/@types/better-sqlite3/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -1472,6 +1478,8 @@
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "zip-stream/archiver-utils/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "@ateam/server/@types/better-sqlite3/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@electron/asar/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/packages/agents/src/registry.ts
+++ b/packages/agents/src/registry.ts
@@ -39,6 +39,28 @@ export interface AgentDefinition {
 	install?: string;
 	/** The one-time OAuth login the user runs on the box after install (browser flow). */
 	loginCommand?: string;
+	/**
+	 * How to ask this agent ONE question non-interactively and read the answer
+	 * back as text — no PTY, no session, no tools. Ateam uses it for the small
+	 * model-shaped jobs inside the app itself (ranking session-search results),
+	 * so those stay on whatever agent the user already runs rather than hard-
+	 * wiring one vendor's CLI. Omitted for an agent with no such mode.
+	 */
+	headless?: HeadlessInvocation;
+}
+
+/** A one-shot, non-interactive call to an agent CLI. */
+export interface HeadlessInvocation {
+	/** Flags after the binary (the prompt is delivered separately). */
+	args: string[];
+	/** Where the prompt goes: piped on stdin, or appended as arguments. */
+	prompt: PromptTransport;
+	/**
+	 * Flag that writes the final assistant message to a file. Set it for CLIs
+	 * whose stdout carries progress chrome (Codex); when absent, stdout IS the
+	 * answer (Claude's `--output-format text`).
+	 */
+	lastMessageFlag?: string;
 }
 
 // Registry of the supported agent CLIs. Command lines and the YOLO bypass
@@ -57,6 +79,15 @@ export const AGENTS = [
 		agentsCommand: "claude agents",
 		install: "curl -fsSL https://claude.ai/install.sh | bash",
 		loginCommand: "claude login",
+		// --safe-mode drops hooks/CLAUDE.md/skills/MCP, --restricted drops the
+		// command-running tools: this asks a question, it does not do work in a
+		// repo. Both together take the call from ~50s to ~3s. Haiku because the
+		// job is ranking a shortlist someone else already built, and it is on
+		// the path of a UI keystroke.
+		headless: {
+			args: ["-p", "--safe-mode", "--restricted", "--model", "haiku", "--output-format", "text"],
+			prompt: "stdin",
+		},
 	},
 	{
 		id: "codex",
@@ -68,6 +99,14 @@ export const AGENTS = [
 		resumeCommand: "codex resume --last",
 		install: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
 		loginCommand: "codex login",
+		// `codex exec` streams its progress to stdout, so the answer is taken
+		// from --output-last-message instead. read-only sandbox + no git-repo
+		// requirement: the prompt is self-contained, there is nothing to touch.
+		headless: {
+			args: ["exec", "--skip-git-repo-check", "--sandbox", "read-only"],
+			prompt: "stdin",
+			lastMessageFlag: "--output-last-message",
+		},
 	},
 	{
 		id: "opencode",
@@ -78,6 +117,8 @@ export const AGENTS = [
 		resumeCommand: "opencode --continue",
 		install: "curl -fsSL https://opencode.ai/install | bash",
 		loginCommand: "opencode auth login",
+		// `opencode run` takes the message as positional arguments.
+		headless: { args: ["run"], prompt: "argv" },
 	},
 ] as const satisfies readonly AgentDefinition[];
 

--- a/packages/db/src/repo.ts
+++ b/packages/db/src/repo.ts
@@ -106,6 +106,21 @@ export const repo = {
 		db.update(agentSessions).set(patch).where(eq(agentSessions.id, id)).run();
 	},
 
+	/**
+	 * The terminal a harness's OWN session id was seen on. Hook events carry the
+	 * agent's session id (`raw_agent_session_id`), which is the only link between
+	 * a transcript on disk and the PTY tab that produced it — session search uses
+	 * it to open the exact terminal a result came from.
+	 */
+	findTerminalByAgentSessionId(db: AteamDb, rawAgentSessionId: string) {
+		return db
+			.select({ terminalId: agentEvents.terminalId })
+			.from(agentEvents)
+			.where(eq(agentEvents.rawAgentSessionId, rawAgentSessionId))
+			.orderBy(desc(agentEvents.createdAt))
+			.get()?.terminalId;
+	},
+
 	recordEvent(
 		db: AteamDb,
 		e: {

--- a/packages/protocol/src/client-api.ts
+++ b/packages/protocol/src/client-api.ts
@@ -28,6 +28,7 @@ import type {
 	PtyExitEvent,
 	PtySnapshot,
 	SessionDTO,
+	SessionHitDTO,
 	SystemInfo,
 	TaskDTO,
 	UpdateResultDTO,
@@ -99,6 +100,9 @@ export function buildAteamApi(rpc: RpcClient, native: NativeClientApi): AteamApi
 		},
 		agents: {
 			list: () => call<AgentDTO[]>(CH.agentsList),
+		},
+		search: {
+			sessions: (input) => call<SessionHitDTO[]>(CH.searchSessions, [input]),
 		},
 		fs: {
 			listDir: (path) => call<DirListingDTO>(CH.fsListDir, [path]),

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -16,7 +16,10 @@
 // auto-updates, a box only changes when someone re-runs the installer. Without the
 // bump those clients pass the handshake and then fail deep in a feature with a raw
 // `Unknown method: projects:clone`; with it they get "update the older side" up front.
-export const PROTOCOL_VERSION = 2;
+// v3: added CH.searchSessions. Same reasoning as v2 — a new desktop searching an
+// older box would otherwise get `Unknown method: search:sessions` from the search
+// box instead of "update the older side".
+export const PROTOCOL_VERSION = 3;
 
 export type KanbanColumn = "todo" | "running" | "needs_attention" | "review" | "merged";
 
@@ -258,6 +261,28 @@ export interface CleanupCandidate {
 	agentStatus: AgentStatus | null;
 }
 
+/**
+ * One hit from session search: a past agent session that matched, joined back
+ * to the task it ran in. `terminalId` is present only when that session's tab
+ * is still live, which is what decides whether a click can focus the exact
+ * terminal or only open the task.
+ */
+export interface SessionHitDTO {
+	/** The harness's own session id — the handle its resume command takes. */
+	sessionId: string;
+	agentId: string;
+	taskId: string;
+	taskName: string;
+	branch: string | null;
+	terminalId: string | null;
+	startedAt: number | null;
+	endedAt: number | null;
+	/** The user's own words from the matching part of the session. */
+	excerpt: string;
+	/** The model's one-line reason, when the AI pass ran. */
+	why: string | null;
+}
+
 // ---- IPC channel names ----
 export const CH = {
 	projectsPick: "projects:pick",
@@ -288,6 +313,7 @@ export const CH = {
 	loopsCreate: "loops:create",
 	loopsDelete: "loops:delete",
 	agentsList: "agents:list",
+	searchSessions: "search:sessions",
 	systemHello: "system:hello",
 	fsListDir: "fs:listDir",
 	utilPickFiles: "util:pickFiles",
@@ -386,6 +412,15 @@ export interface AteamApi {
 	};
 	agents: {
 		list(): Promise<AgentDTO[]>;
+	};
+	search: {
+		/**
+		 * Find past agent sessions in this project by describing the work — the
+		 * question you would otherwise open a new session to ask. Without `ai`
+		 * it is an instant local rank; with it, the configured agent re-ranks
+		 * the shortlist and says why each one matched.
+		 */
+		sessions(input: { projectId: string; query: string; ai?: boolean }): Promise<SessionHitDTO[]>;
 	};
 	fs: {
 		/**

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,35 +1,37 @@
 {
-  "name": "@ateam/server",
-  "version": "0.0.0",
-  "private": true,
-  "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
-  "exports": {
-    ".": "./src/index.ts"
-  },
-  "bin": {
-    "ateam": "./src/cli.ts"
-  },
-  "scripts": {
-    "build": "bun run scripts/build.ts",
-    "build:release": "bun run scripts/build.ts && tar --no-xattrs -czf dist/ateam-server.tar.gz -C dist cli.js daemon.js package.json",
-    "test": "bun test",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@ateam/agents": "workspace:*",
-    "@ateam/db": "workspace:*",
-    "@ateam/git-core": "workspace:*",
-    "@ateam/protocol": "workspace:*",
-    "@xterm/addon-serialize": "^0.13.0",
-    "@xterm/headless": "^5.5.0",
-    "node-pty": "^1.0.0",
-    "ws": "^8.21.0"
-  },
-  "devDependencies": {
-    "@types/node": "^22.10.5",
-    "@types/ws": "^8.18.1",
-    "drizzle-orm": "^0.38.4"
-  }
+	"name": "@ateam/server",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"main": "./src/index.ts",
+	"types": "./src/index.ts",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"bin": {
+		"ateam": "./src/cli.ts"
+	},
+	"scripts": {
+		"build": "bun run scripts/build.ts",
+		"build:release": "bun run scripts/build.ts && tar --no-xattrs -czf dist/ateam-server.tar.gz -C dist cli.js daemon.js package.json",
+		"test": "bun test",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@ateam/agents": "workspace:*",
+		"@ateam/db": "workspace:*",
+		"@ateam/git-core": "workspace:*",
+		"@ateam/protocol": "workspace:*",
+		"@xterm/addon-serialize": "^0.13.0",
+		"@xterm/headless": "^5.5.0",
+		"better-sqlite3": "^11.8.1",
+		"node-pty": "^1.0.0",
+		"ws": "^8.21.0"
+	},
+	"devDependencies": {
+		"@types/better-sqlite3": "^9.6.0",
+		"@types/node": "^22.10.5",
+		"@types/ws": "^8.18.1",
+		"drizzle-orm": "^0.38.4"
+	}
 }

--- a/packages/server/src/dispatcher.ts
+++ b/packages/server/src/dispatcher.ts
@@ -37,6 +37,7 @@ import {
 import type { Engine } from "./engine";
 import { LOOP_TEMPLATES } from "./loops/templates";
 import { type Services, toProjectDTO, toSessionDTO, toTaskDTO } from "./services";
+import { searchSessions } from "./session-search";
 import { createTaskInProject, type SpawnAgentInput, shell, spawnAgentInTask } from "./sessions";
 
 /** Project display name from the repo's README H1 (md or HTML), if present. */
@@ -392,6 +393,13 @@ export function createDispatcher(engine: Engine): Dispatcher {
 				available: a.available,
 			}));
 		},
+
+		// ---- session search ----
+		// "Which session was I working on X?" answered here instead of in a new
+		// agent session. Engine-side on purpose: the transcripts live on the
+		// machine that ran the agent, so a box searches its own history.
+		[CH.searchSessions]: async (input: { projectId: string; query: string; ai?: boolean }) =>
+			searchSessions(services, input),
 
 		// ---- system: connect-time handshake ----
 		// The client calls this first over a fresh transport and checks

--- a/packages/server/src/session-search/digest.ts
+++ b/packages/server/src/session-search/digest.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared digest helpers — the part of "what is worth searching" that every
+ * harness agrees on. Pure functions, unit-tested in
+ * packages/server/test/session-search.test.ts.
+ */
+
+/** Per-prompt cap. Long enough to carry the intent, short enough that a whole
+ *  history stays a few hundred KB rather than the ~1GB the transcripts are. */
+const MAX_PROMPT_CHARS = 600;
+/** Per-session cap. Later prompts drift into follow-ups ("yes", "continue"). */
+const MAX_PROMPTS = 40;
+
+/**
+ * Wrapper blocks the harnesses inject into the user role: slash-command
+ * plumbing, hook output, environment headers. They are not things the user
+ * typed, and left in they dominate the corpus (a single expanded skill body can
+ * outweigh every real prompt in a session).
+ */
+const INJECTED = [
+	/<command-(message|name|args)>[\s\S]*?<\/command-(message|name|args)>/g,
+	/<local-command-(stdout|stderr)>[\s\S]*?<\/local-command-(stdout|stderr)>/g,
+	/<system-reminder>[\s\S]*?<\/system-reminder>/g,
+	/<environment_context>[\s\S]*?<\/environment_context>/g,
+	/<user_instructions>[\s\S]*?<\/user_instructions>/g,
+];
+
+/**
+ * Harness bookkeeping that appears in the user role but is not speech: the line
+ * the CLI writes when a turn is cancelled. It carries no information about what
+ * the session was about, and left in it becomes a session's "excerpt".
+ */
+const NOISE = /^\[Request interrupted[^\]]*\]$/;
+
+/** Strip injected wrappers and collapse whitespace. "" when nothing is left. */
+export function cleanPrompt(text: string): string {
+	let s = text;
+	for (const re of INJECTED) s = s.replace(re, " ");
+	// A caveat banner is prepended to the first message of a resumed session.
+	s = s.replace(/^Caveat: The messages below[\s\S]*?<\/command-name>/, " ");
+	s = s.replace(/\s+/g, " ").trim();
+	// What survives as a bare tag was structure, not speech.
+	if (s.startsWith("<") && s.endsWith(">")) return "";
+	if (NOISE.test(s)) return "";
+	return s.slice(0, MAX_PROMPT_CHARS);
+}
+
+/** Flatten a message `content` (string, or Anthropic-style block array) to text. */
+export function contentText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.map((b) => {
+			if (typeof b === "string") return b;
+			if (b && typeof b === "object") {
+				const t = (b as { text?: unknown }).text;
+				if (typeof t === "string") return t;
+			}
+			return "";
+		})
+		.join(" ");
+}
+
+/** Append a user message to a session's prompt list, if it says anything. */
+export function pushPrompt(prompts: string[], content: unknown): void {
+	if (prompts.length >= MAX_PROMPTS) return;
+	const text = cleanPrompt(contentText(content));
+	if (text) prompts.push(text);
+}

--- a/packages/server/src/session-search/index.ts
+++ b/packages/server/src/session-search/index.ts
@@ -1,0 +1,168 @@
+/**
+ * Session search — the engine-side entry point.
+ *
+ * Scope: sessions that ran in a task's worktree. That keeps every result
+ * clickable (a hit always maps back to a task, and usually to the exact
+ * terminal tab that produced it) and keeps other projects' history out of a
+ * project-scoped board. A task removed by cleanup takes its history out of the
+ * index with it — widening to "every transcript under the repo" is a change to
+ * `worktrees()` alone.
+ *
+ * Two stages, for reasons measured on this repo's own 1GB of transcripts:
+ * ranking first and asking the model second is faster, ~20x cheaper, and MORE
+ * accurate than one big prompt. See rank.ts and rerank.ts.
+ */
+import { repo, type Task } from "@ateam/db";
+import type { SessionHitDTO } from "@ateam/protocol";
+import type { Services } from "../services";
+import { type RankInput, rank } from "./rank";
+import { askAgent, buildPrompt, expandQuery, parseVerdicts } from "./rerank";
+import { claudeSource } from "./sources/claude";
+import { codexSource } from "./sources/codex";
+import { opencodeSource } from "./sources/opencode";
+import type { RankedSession, SessionDigest } from "./types";
+
+/** How many candidates the model is asked to judge. Enough to contain the
+ *  answer, few enough that it reads every one. */
+const SHORTLIST = 20;
+/** How many hits reach the UI. */
+const RESULTS = 8;
+
+/**
+ * shortcut: the digest index is rebuilt from disk on a cache miss and held for
+ * TTL_MS, rather than persisted. A full rebuild is ~1s for this repo's history
+ * because only a project's own worktrees are read; if that stops being true
+ * (thousands of tasks), persist digests keyed by path+mtime and rebuild the
+ * delta instead.
+ */
+const TTL_MS = 60_000;
+
+const SOURCES = [claudeSource(), codexSource(), opencodeSource()];
+
+interface CacheEntry {
+	at: number;
+	digests: SessionDigest[];
+}
+const cache = new Map<string, CacheEntry>();
+
+function buildIndex(worktrees: string[]): SessionDigest[] {
+	const out: SessionDigest[] = [];
+	for (const source of SOURCES) {
+		try {
+			out.push(...source.digestsFor(worktrees));
+		} catch {
+			// One harness's store being unreadable must not hide the others.
+		}
+	}
+	return out;
+}
+
+export interface SessionSearchInput {
+	projectId: string;
+	query: string;
+	/** Run the model re-rank. Off = the instant, free, lexical answer. */
+	ai?: boolean;
+	/** Which agent answers the re-rank; defaults to the configured agent. */
+	agentId?: string;
+}
+
+export async function searchSessions(
+	services: Services,
+	input: SessionSearchInput,
+): Promise<SessionHitDTO[]> {
+	const { db } = services;
+	const query = input.query.trim();
+	if (!query) return [];
+
+	const tasks = repo.listTasks(db, input.projectId);
+	if (tasks.length === 0) return [];
+	const byWorktree = new Map(tasks.map((t) => [t.worktreePath, t]));
+
+	const cached = cache.get(input.projectId);
+	const digests =
+		cached && Date.now() - cached.at < TTL_MS ? cached.digests : buildIndex([...byWorktree.keys()]);
+	cache.set(input.projectId, { at: Date.now(), digests });
+
+	// Resolve against the CURRENT tasks, not the cached ones: a task removed
+	// since the index was built drops out of the results immediately rather
+	// than lingering for the rest of the TTL.
+	const inputs: RankInput[] = [];
+	for (const digest of digests) {
+		const task = byWorktree.get(digest.cwd);
+		if (!task) continue;
+		inputs.push({ digest, titles: [task.name, task.branch] });
+	}
+
+	if (!input.ai) {
+		return toHits(services, rank(inputs, query, RESULTS), byWorktree, new Map());
+	}
+
+	// The AI pass: widen the vocabulary, rank, then let the model read the
+	// shortlist. Expansion first, because a shortlist that never contained the
+	// answer cannot be re-ranked into containing it.
+	//
+	// It is skipped when the user's own words already fill the shortlist: those
+	// are the queries where expansion changes nothing, and each model call costs
+	// several seconds of a click the user is waiting on.
+	const agentId = input.agentId ?? repo.getSettings(db).defaultAgentId ?? "claude";
+	const typedOnly = rank(inputs, query, SHORTLIST);
+	const ranked =
+		typedOnly.length >= SHORTLIST
+			? typedOnly
+			: rank(inputs, query, SHORTLIST, { expansions: await expandQuery(agentId, query) });
+	if (ranked.length === 0) return [];
+
+	const why = new Map<string, string>();
+	let ordered = ranked;
+	{
+		const labels = new Map(
+			ranked.map((r) => [r.digest.sessionId, byWorktree.get(r.digest.cwd)?.name ?? ""]),
+		);
+		const reply = await askAgent(agentId, buildPrompt(query, ranked, labels));
+		const verdicts = parseVerdicts(reply, new Set(ranked.map((r) => r.digest.sessionId)));
+		if (verdicts.length > 0) {
+			const rankOf = new Map(verdicts.map((v, i) => [v.sessionId, i]));
+			for (const v of verdicts) why.set(v.sessionId, v.why);
+			// The model's picks lead, in its order; the rest keep the lexical
+			// order behind them rather than disappearing, so a model that missed
+			// the answer never hides a result the user can still recognise.
+			ordered = [...ranked].sort(
+				(a, b) =>
+					(rankOf.get(a.digest.sessionId) ?? Number.MAX_SAFE_INTEGER) -
+					(rankOf.get(b.digest.sessionId) ?? Number.MAX_SAFE_INTEGER),
+			);
+		}
+	}
+
+	return toHits(services, ordered.slice(0, RESULTS), byWorktree, why);
+}
+
+/** Join ranked digests back to their tasks and terminals for the UI. */
+function toHits(
+	services: Services,
+	ranked: RankedSession[],
+	byWorktree: Map<string, Task>,
+	why: Map<string, string>,
+): SessionHitDTO[] {
+	const hits: SessionHitDTO[] = [];
+	for (const r of ranked) {
+		const task = byWorktree.get(r.digest.cwd);
+		if (!task) continue;
+		const terminalId = repo.findTerminalByAgentSessionId(services.db, r.digest.sessionId) ?? null;
+		hits.push({
+			sessionId: r.digest.sessionId,
+			agentId: r.digest.agentId,
+			taskId: task.id,
+			taskName: task.name,
+			branch: task.branch ?? r.digest.branch ?? null,
+			// Only offer a terminal that still exists — a tab from a previous run
+			// of the app is a dead id, and opening it would show an empty panel.
+			terminalId: terminalId && services.pty.has(terminalId) ? terminalId : null,
+			startedAt: r.digest.startedAt,
+			endedAt: r.digest.endedAt,
+			excerpt: r.excerpts[0] ?? "",
+			why: why.get(r.digest.sessionId) ?? null,
+		});
+	}
+	return hits;
+}

--- a/packages/server/src/session-search/rank.ts
+++ b/packages/server/src/session-search/rank.ts
@@ -1,0 +1,224 @@
+/**
+ * Stage one of the search: a lexical rank over the digests. Pure and cheap, so
+ * it runs on every keystroke and costs nothing.
+ *
+ * It is also what makes the AI stage affordable. Handing a whole history to a
+ * model is slow, expensive and — measured against this repo's own transcripts —
+ * LESS accurate than ranking first: with 200+ session summaries in one prompt
+ * the model skims, while with 20 candidates it reads. This narrows; the re-rank
+ * reads.
+ *
+ * Scoring is tf-idf with two adjustments that matter for sessions: a match in a
+ * branch name or task title counts double (those are what the user named the
+ * work), and recency breaks ties (yesterday's session is likelier the one being
+ * remembered than one from March).
+ */
+import type { RankedSession, SessionDigest } from "./types";
+
+/** A digest plus the task-side words worth searching alongside it. */
+export interface RankInput {
+	digest: SessionDigest;
+	/** Task name, branch — the labels the user gave this work. */
+	titles: string[];
+}
+
+/** Words too common to discriminate between sessions. */
+const STOPWORDS = new Set([
+	"the",
+	"a",
+	"an",
+	"and",
+	"or",
+	"but",
+	"if",
+	"of",
+	"to",
+	"in",
+	"on",
+	"for",
+	"with",
+	"was",
+	"were",
+	"is",
+	"are",
+	"be",
+	"been",
+	"it",
+	"its",
+	"that",
+	"this",
+	"i",
+	"we",
+	"my",
+	"our",
+	"me",
+	"us",
+	"do",
+	"did",
+	"does",
+	"how",
+	"what",
+	"when",
+	"where",
+	"which",
+	"who",
+	"why",
+	"session",
+	"sessions",
+	"working",
+	"work",
+	"worked",
+	"about",
+	"some",
+	"any",
+	"can",
+	"could",
+]);
+
+export function terms(query: string): string[] {
+	return query
+		.toLowerCase()
+		.split(/[^\p{L}\p{N}]+/u)
+		.filter((t) => t.length >= 2 && !STOPWORDS.has(t));
+}
+
+/**
+ * Weighted occurrences of `term` in `text`, counted at word starts only, so
+ * "flick" finds "flickering" while "lick" does not.
+ *
+ * A prefix match counts for less than a whole word. Without that split,
+ * searching for "box" ranked every session about "boxd" above the ones about
+ * boxes — the prefix is worth keeping (it is free stemming for plurals and
+ * "-ing" forms) but it is weaker evidence than the word the user actually typed.
+ */
+const PREFIX_WEIGHT = 0.4;
+
+function count(text: string, term: string): number {
+	let n = 0;
+	let from = 0;
+	for (;;) {
+		const at = text.indexOf(term, from);
+		if (at === -1) return n;
+		const before = at === 0 ? " " : text.charAt(at - 1);
+		if (!/[\p{L}\p{N}]/u.test(before)) {
+			const after = text.charAt(at + term.length);
+			n += after === "" || !/[\p{L}\p{N}]/u.test(after) ? 1 : PREFIX_WEIGHT;
+		}
+		from = at + term.length;
+	}
+}
+
+/**
+ * BM25 term saturation and length normalization, at the standard defaults.
+ * Length normalization is not a nicety here: a session that pasted a long skill
+ * body or an expanded slash command otherwise outranks the session that
+ * actually discussed the thing, purely by containing more words. Plain tf-idf
+ * put three such sessions in the top five on this repo's own history.
+ */
+const K1 = 1.2;
+const B = 0.75;
+const TITLE_WEIGHT = 2;
+/** Ceiling on the recency tiebreaker, in score points. Small on purpose: it
+ *  orders equals, it never outranks a better textual match. */
+const RECENCY_BONUS = 0.5;
+/** How long ago a session stops earning any recency bonus. */
+const RECENCY_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
+
+interface Doc {
+	input: RankInput;
+	body: string;
+	title: string;
+	/** Approximate word count, for BM25's length normalization. */
+	length: number;
+}
+
+/**
+ * Terms the user did not type, contributed by query expansion. They widen
+ * recall over a vocabulary gap, so they count — but for less than the words
+ * the user chose, which stay the strongest evidence of what they meant.
+ */
+const EXPANSION_WEIGHT = 0.5;
+
+export function rank(
+	inputs: RankInput[],
+	query: string,
+	limit: number,
+	opts: { expansions?: string[]; now?: number } = {},
+): RankedSession[] {
+	const now = opts.now ?? Date.now();
+	const typed = terms(query);
+	const extra = (opts.expansions ?? []).flatMap(terms).filter((t) => !typed.includes(t));
+	const weightOf = (t: string) => (typed.includes(t) ? 1 : EXPANSION_WEIGHT);
+	const qs = [...new Set([...typed, ...extra])];
+	if (qs.length === 0 || inputs.length === 0) return [];
+
+	const docs: Doc[] = inputs.map((input) => {
+		const body = input.digest.prompts.join("\n").toLowerCase();
+		return {
+			input,
+			body,
+			title: input.titles.join(" ").toLowerCase(),
+			// Word count is close enough to a length for normalization, and far
+			// cheaper than tokenizing every session on every keystroke.
+			length: body.length / 6 + 1,
+		};
+	});
+	const avgLength = docs.reduce((sum, d) => sum + d.length, 0) / docs.length;
+
+	// Document frequency across the corpus — a term every session contains
+	// (this repo's name, say) must not decide the ranking.
+	const idf = new Map<string, number>();
+	for (const t of qs) {
+		const df = docs.filter((d) => count(d.body, t) > 0 || count(d.title, t) > 0).length;
+		idf.set(t, Math.log((docs.length + 1) / (df + 1)) + 1);
+	}
+
+	const scored: RankedSession[] = [];
+	for (const doc of docs) {
+		let score = 0;
+		const hit: string[] = [];
+		const norm = K1 * (1 - B + (B * doc.length) / avgLength);
+		for (const t of qs) {
+			const inBody = count(doc.body, t);
+			const inTitle = count(doc.title, t);
+			if (inBody === 0 && inTitle === 0) continue;
+			hit.push(t);
+			const tf = inBody + TITLE_WEIGHT * inTitle;
+			score += weightOf(t) * (idf.get(t) ?? 1) * ((tf * (K1 + 1)) / (tf + norm));
+		}
+		if (score === 0) continue;
+		// Breadth of match beats depth: a session touching every term the user
+		// typed beats one that repeats a single term. Measured against the typed
+		// terms only, so expansions can never make a session look more relevant
+		// than one that used the user's own words.
+		const typedHits = hit.filter((t) => typed.includes(t)).length;
+		score *= 1 + Math.max(0, typedHits - 1) / Math.max(1, typed.length);
+		const end = doc.input.digest.endedAt ?? 0;
+		const age = now - end;
+		if (end > 0 && age > 0 && age < RECENCY_WINDOW_MS) {
+			score += RECENCY_BONUS * (1 - age / RECENCY_WINDOW_MS);
+		}
+		scored.push({
+			digest: doc.input.digest,
+			score,
+			excerpts: excerptsFor(doc.input.digest, hit),
+		});
+	}
+	scored.sort((a, b) => b.score - a.score || (b.digest.endedAt ?? 0) - (a.digest.endedAt ?? 0));
+	return scored.slice(0, limit);
+}
+
+/** The prompt lines a match actually landed in — the excerpt shown in the UI
+ *  and the context the re-rank reads. Falls back to the opening prompt, which
+ *  is what a session is "about" when the match came from its title. */
+export function excerptsFor(digest: SessionDigest, hits: string[], max = 4): string[] {
+	const out: string[] = [];
+	for (const p of digest.prompts) {
+		const low = p.toLowerCase();
+		if (hits.some((t) => count(low, t) > 0)) out.push(p);
+		if (out.length >= max) break;
+	}
+	const first = digest.prompts[0];
+	if (out.length === 0 && first) out.push(first);
+	return out;
+}

--- a/packages/server/src/session-search/rerank.ts
+++ b/packages/server/src/session-search/rerank.ts
@@ -1,0 +1,202 @@
+/**
+ * Stage two of the search: hand the shortlist to a model and let it pick.
+ *
+ * The model is reached through the agent registry's `headless` invocation, not
+ * through `claude -p` directly — whichever agent the user runs is the one that
+ * answers. All this module needs back is text; the JSON inside it is extracted
+ * defensively, because every one of these CLIs may wrap an answer in a fence or
+ * a sentence, and a re-rank that throws must degrade to the lexical order
+ * rather than to an error.
+ */
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getAgent } from "@ateam/agents";
+import { shell } from "../sessions";
+import type { RankedSession } from "./types";
+
+/** The model's verdict on one candidate. */
+export interface Verdict {
+	sessionId: string;
+	/** One sentence on why this session is the answer, in the user's own words. */
+	why: string;
+	confidence: "high" | "medium" | "low";
+}
+
+const CONFIDENCE = new Set(["high", "medium", "low"]);
+
+/** Pull the first JSON object out of a reply that may be fenced or prefaced. */
+export function extractJson(text: string): unknown {
+	const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+	const body = fenced?.[1] ?? text;
+	const start = body.indexOf("{");
+	const end = body.lastIndexOf("}");
+	if (start === -1 || end <= start) return null;
+	try {
+		return JSON.parse(body.slice(start, end + 1));
+	} catch {
+		return null;
+	}
+}
+
+/** Validate the model's reply into verdicts, dropping anything malformed or
+ *  hallucinated (an id that was never a candidate). */
+export function parseVerdicts(text: string, candidateIds: Set<string>): Verdict[] {
+	const parsed = extractJson(text) as { results?: unknown } | null;
+	if (!parsed || !Array.isArray(parsed.results)) return [];
+	const out: Verdict[] = [];
+	for (const r of parsed.results) {
+		if (!r || typeof r !== "object") continue;
+		const { id, why, confidence } = r as Record<string, unknown>;
+		if (typeof id !== "string" || !candidateIds.has(id)) continue;
+		if (out.some((v) => v.sessionId === id)) continue;
+		out.push({
+			sessionId: id,
+			why: typeof why === "string" ? why.slice(0, 240) : "",
+			confidence:
+				typeof confidence === "string" && CONFIDENCE.has(confidence)
+					? (confidence as Verdict["confidence"])
+					: "low",
+		});
+	}
+	return out;
+}
+
+/** The prompt: the shortlist, and one instruction. Kept in one function so the
+ *  shape is visible and testable rather than smeared through the caller. */
+export function buildPrompt(
+	query: string,
+	candidates: RankedSession[],
+	labels: Map<string, string>,
+): string {
+	const lines = candidates.map((c) => {
+		const when = c.digest.endedAt
+			? new Date(c.digest.endedAt).toISOString().slice(0, 10)
+			: "unknown date";
+		const label = labels.get(c.digest.sessionId) ?? c.digest.branch ?? "";
+		return [
+			`### ${c.digest.sessionId}`,
+			`task: ${label} | agent: ${c.digest.agentId} | ${when}`,
+			// Two trimmed excerpts, not four full ones: this prompt is on the path
+			// of a click, and every token here is latency the user waits through.
+			...c.excerpts.slice(0, 2).map((e) => `- ${e.slice(0, 200)}`),
+		].join("\n");
+	});
+	return [
+		"You are searching someone's own past coding sessions to answer: which session was this?",
+		"",
+		`QUESTION: ${query}`,
+		"",
+		"Below are candidate sessions, each with the user's own messages from it.",
+		"Pick the ones that actually match the question. Prefer a short, precise answer:",
+		"return nothing rather than a session you do not believe in.",
+		"",
+		'Reply with JSON only, nothing before or after it: {"results":[{"id":"<session id>","why":"<max 15 words, quoting the user\'s own words>","confidence":"high|medium|low"}]}',
+		"Order best first, at most 5.",
+		"",
+		"--- CANDIDATES ---",
+		...lines,
+	].join("\n");
+}
+
+/**
+ * Ask the model for other words the user might actually have typed.
+ *
+ * This is what makes "describe the work" work at all. Retrieval is lexical, so
+ * a question phrased in today's words ("the phone asked for consent before
+ * connecting") matches nothing in a session that said "ask before the first
+ * connection on mobile" — the shortlist comes back empty and the re-rank never
+ * runs. Expanding the query first is the cheap, embedding-free fix: one small
+ * call, and the terms it returns are searched alongside the user's own.
+ */
+export async function expandQuery(agentId: string, query: string): Promise<string[]> {
+	const prompt = [
+		"Someone is searching their own past coding sessions by describing the work.",
+		"List other words and short phrases they plausibly typed AT THE TIME, including",
+		"likely code, file, branch and UI vocabulary for it. No explanations.",
+		"",
+		`THEIR DESCRIPTION: ${query}`,
+		"",
+		'Reply with JSON only: {"terms":["...", "..."]} — at most 12, each 1-3 words.',
+	].join("\n");
+	const parsed = extractJson(await askAgent(agentId, prompt, EXPAND_TIMEOUT_MS)) as {
+		terms?: unknown;
+	} | null;
+	if (!parsed || !Array.isArray(parsed.terms)) return [];
+	return parsed.terms
+		.filter((t): t is string => typeof t === "string")
+		.map((t) => t.trim())
+		.filter((t) => t.length > 1)
+		.slice(0, 12);
+}
+
+/** Expansion is on the path of a click, and a slow one is worse than none. */
+const EXPAND_TIMEOUT_MS = 20_000;
+
+/** How long the model gets before the search falls back to the lexical order. */
+const TIMEOUT_MS = 45_000;
+
+/** Quote one argument for the login shell. */
+function q(s: string): string {
+	return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Run one headless turn on `agentId`. Resolves to "" on any failure — the
+ * caller treats an empty reply as "no opinion" and keeps its own ordering.
+ *
+ * Launched through a LOGIN shell, exactly as an interactive agent session is
+ * (see sessions.ts). A GUI app inherits launchd's PATH, not the user's, so a
+ * bare spawn of `claude` fails with ENOENT on a Mac whenever the boot-time PATH
+ * probe did not land — and the failure would be invisible here, quietly
+ * downgrading every AI search to a lexical one.
+ */
+export function askAgent(agentId: string, prompt: string, timeoutMs = TIMEOUT_MS): Promise<string> {
+	const agent = getAgent(agentId);
+	if (!agent?.headless) return Promise.resolve("");
+	const { args, prompt: transport, lastMessageFlag } = agent.headless;
+	const dir = lastMessageFlag ? mkdtempSync(join(tmpdir(), "ateam-search-")) : null;
+	const outFile = dir ? join(dir, "answer.txt") : null;
+	const cmdline = [
+		agent.bin,
+		...args,
+		...(lastMessageFlag && outFile ? [lastMessageFlag, q(outFile)] : []),
+		...(transport === "argv" ? [q(prompt)] : []),
+	].join(" ");
+	return new Promise<string>((resolve) => {
+		let done = false;
+		const finish = (text: string) => {
+			if (done) return;
+			done = true;
+			clearTimeout(timer);
+			if (dir) rmSync(dir, { recursive: true, force: true });
+			resolve(text);
+		};
+		const child = spawn(shell, ["-lc", cmdline], { stdio: ["pipe", "pipe", "ignore"] });
+		const timer = setTimeout(() => {
+			child.kill("SIGKILL");
+			finish("");
+		}, timeoutMs);
+		let stdout = "";
+		child.stdout.on("data", (d: Buffer) => {
+			// A runaway reply is a broken call, not an answer worth buffering.
+			if (stdout.length < 200_000) stdout += d.toString();
+		});
+		child.on("error", () => finish(""));
+		child.on("close", (code) => {
+			if (code !== 0) return finish("");
+			if (!outFile) return finish(stdout);
+			try {
+				finish(readFileSync(outFile, "utf8"));
+			} catch {
+				finish(stdout);
+			}
+		});
+		if (transport === "stdin") {
+			child.stdin.end(prompt);
+		} else {
+			child.stdin.end();
+		}
+	});
+}

--- a/packages/server/src/session-search/sources/claude.ts
+++ b/packages/server/src/session-search/sources/claude.ts
@@ -1,0 +1,127 @@
+// Claude Code's transcript store: ~/.claude/projects/<slugged-cwd>/<session>.jsonl,
+// one JSONL line per event.
+//
+// We deliberately do NOT reproduce Claude's cwd→directory slug rule. It is
+// undocumented, and a rule that drifts would silently return "no sessions"
+// rather than fail loudly. Instead each directory is asked what cwd it holds by
+// reading the `cwd` field off its first transcript — 0.15s for 200 directories,
+// and correct whatever the slug rule does next.
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { pushPrompt } from "../digest";
+import type { SessionDigest, TranscriptSource } from "../types";
+
+const ROOT = () => join(homedir(), ".claude", "projects");
+
+/** Read the `cwd` a project directory belongs to, from its first transcript. */
+function dirCwd(dir: string): string | null {
+	let files: string[];
+	try {
+		files = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+	} catch {
+		return null;
+	}
+	for (const f of files.slice(0, 2)) {
+		let head: string;
+		try {
+			head = readFileSync(join(dir, f), "utf8").slice(0, 64_000);
+		} catch {
+			continue;
+		}
+		for (const line of head.split("\n")) {
+			if (!line.includes('"cwd"')) continue;
+			try {
+				const cwd = (JSON.parse(line) as { cwd?: unknown }).cwd;
+				if (typeof cwd === "string" && cwd) return cwd;
+			} catch {
+				/* a truncated last line — keep looking */
+			}
+		}
+	}
+	return null;
+}
+
+/** Parse one transcript into a digest, or null if it holds no real prompts. */
+export function readClaudeTranscript(path: string): SessionDigest | null {
+	let raw: string;
+	let mtimeMs: number;
+	try {
+		raw = readFileSync(path, "utf8");
+		mtimeMs = statSync(path).mtimeMs;
+	} catch {
+		return null;
+	}
+	const prompts: string[] = [];
+	let cwd = "";
+	let branch: string | null = null;
+	let startedAt: number | null = null;
+	let endedAt: number | null = null;
+	let sessionId = "";
+	for (const line of raw.split("\n")) {
+		if (!line) continue;
+		// Every transcript is mostly assistant/tool traffic; only user turns and
+		// the session header matter, so skip the rest before paying for a parse.
+		if (!line.includes('"type":"user"') && !sessionId) {
+			if (!line.includes('"sessionId"')) continue;
+		} else if (!line.includes('"type":"user"')) {
+			continue;
+		}
+		let ev: Record<string, unknown>;
+		try {
+			ev = JSON.parse(line) as Record<string, unknown>;
+		} catch {
+			continue;
+		}
+		if (!sessionId && typeof ev.sessionId === "string") sessionId = ev.sessionId;
+		// `isMeta` marks a user-role event the HARNESS injected, not something the
+		// user typed: an expanded slash command, a skill body, a hook's output.
+		// They are long, near-identical across sessions, and ranking them as
+		// speech buried the real prompts under pasted skill documentation.
+		if (ev.type !== "user" || ev.isSidechain || ev.isMeta) continue;
+		if (typeof ev.sourceToolUseID === "string") continue;
+		if (typeof ev.cwd === "string" && !cwd) cwd = ev.cwd;
+		if (typeof ev.gitBranch === "string" && !branch) branch = ev.gitBranch;
+		const ts = typeof ev.timestamp === "string" ? Date.parse(ev.timestamp) : Number.NaN;
+		if (Number.isFinite(ts)) {
+			startedAt ??= ts;
+			endedAt = ts;
+		}
+		const message = ev.message as { content?: unknown } | undefined;
+		pushPrompt(prompts, message?.content);
+	}
+	if (!sessionId || prompts.length === 0) return null;
+	return { agentId: "claude", sessionId, cwd, branch, startedAt, endedAt, prompts, path, mtimeMs };
+}
+
+export function claudeSource(): TranscriptSource {
+	return {
+		agentId: "claude",
+		digestsFor(cwds) {
+			const root = ROOT();
+			if (!existsSync(root)) return [];
+			const wanted = new Set(cwds);
+			const out: SessionDigest[] = [];
+			let dirs: string[];
+			try {
+				dirs = readdirSync(root);
+			} catch {
+				return [];
+			}
+			for (const name of dirs) {
+				const dir = join(root, name);
+				const cwd = dirCwd(dir);
+				if (!cwd || !wanted.has(cwd)) continue;
+				for (const f of readdirSync(dir)) {
+					if (!f.endsWith(".jsonl")) continue;
+					const digest = readClaudeTranscript(join(dir, f));
+					// The directory maps to one cwd, but trust the transcript's own.
+					if (digest && wanted.has(digest.cwd || cwd)) {
+						out.push({ ...digest, cwd: digest.cwd || cwd });
+					}
+				}
+			}
+			return out;
+		},
+	};
+}

--- a/packages/server/src/session-search/sources/codex.ts
+++ b/packages/server/src/session-search/sources/codex.ts
@@ -1,0 +1,110 @@
+// Codex's transcript store: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl.
+//
+// Sharded by DATE, not by cwd, so there is no directory to look up: the session
+// header (`session_meta`, always the first line) carries the cwd. Reading one
+// line per file is what keeps a whole-history scan cheap.
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { pushPrompt } from "../digest";
+import type { SessionDigest, TranscriptSource } from "../types";
+
+const ROOT = () => join(homedir(), ".codex", "sessions");
+
+/** Every rollout file under the date-sharded tree. */
+function rolloutFiles(root: string): string[] {
+	const out: string[] = [];
+	const walk = (dir: string, depth: number) => {
+		let entries: import("node:fs").Dirent[];
+		try {
+			entries = readdirSync(dir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const e of entries) {
+			const p = join(dir, e.name);
+			// YYYY/MM/DD — three levels of directories, then the files.
+			if (e.isDirectory() && depth < 3) walk(p, depth + 1);
+			else if (e.isFile() && e.name.endsWith(".jsonl")) out.push(p);
+		}
+	};
+	walk(root, 0);
+	return out;
+}
+
+/** The cwd a rollout ran in, from its `session_meta` header line. */
+function headerCwd(path: string, head: string): { sessionId: string; cwd: string } | null {
+	for (const line of head.split("\n")) {
+		if (!line.includes('"session_meta"')) continue;
+		try {
+			const payload = (JSON.parse(line) as { payload?: { id?: string; cwd?: string } }).payload;
+			if (payload?.cwd) return { sessionId: payload.id ?? path, cwd: payload.cwd };
+		} catch {
+			return null;
+		}
+	}
+	return null;
+}
+
+export function readCodexRollout(path: string, wanted: Set<string>): SessionDigest | null {
+	let raw: string;
+	let mtimeMs: number;
+	try {
+		// The header is the first line; read it before paying for the whole file.
+		raw = readFileSync(path, "utf8");
+		mtimeMs = statSync(path).mtimeMs;
+	} catch {
+		return null;
+	}
+	const header = headerCwd(path, raw.slice(0, 8_000));
+	if (!header || !wanted.has(header.cwd)) return null;
+	const prompts: string[] = [];
+	let startedAt: number | null = null;
+	let endedAt: number | null = null;
+	for (const line of raw.split("\n")) {
+		if (!line.includes('"role":"user"')) continue;
+		let ev: { timestamp?: string; payload?: { role?: string; content?: unknown } };
+		try {
+			ev = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		if (ev.payload?.role !== "user") continue;
+		const ts = ev.timestamp ? Date.parse(ev.timestamp) : Number.NaN;
+		if (Number.isFinite(ts)) {
+			startedAt ??= ts;
+			endedAt = ts;
+		}
+		// Codex blocks are {type:"input_text", text}, which contentText handles.
+		pushPrompt(prompts, ev.payload.content);
+	}
+	if (prompts.length === 0) return null;
+	return {
+		agentId: "codex",
+		sessionId: header.sessionId,
+		cwd: header.cwd,
+		branch: null, // Codex records no branch; the task's branch stands in.
+		startedAt,
+		endedAt,
+		prompts,
+		path,
+		mtimeMs,
+	};
+}
+
+export function codexSource(): TranscriptSource {
+	return {
+		agentId: "codex",
+		digestsFor(cwds) {
+			const root = ROOT();
+			if (!existsSync(root)) return [];
+			const wanted = new Set(cwds);
+			const out: SessionDigest[] = [];
+			for (const f of rolloutFiles(root)) {
+				const d = readCodexRollout(f, wanted);
+				if (d) out.push(d);
+			}
+			return out;
+		},
+	};
+}

--- a/packages/server/src/session-search/sources/opencode.ts
+++ b/packages/server/src/session-search/sources/opencode.ts
@@ -1,0 +1,107 @@
+// OpenCode's transcript store: a SQLite database at
+// ~/.local/share/opencode/opencode.db, not files on disk. `session.directory`
+// is the cwd, and a message's text lives in the `part` rows that hang off it.
+//
+// Opened read-only, and every failure is swallowed into "no history": another
+// tool's database is not ours to repair, and a locked or moved store must not
+// take the search down for the other harnesses.
+
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { pushPrompt } from "../digest";
+import type { SessionDigest, TranscriptSource } from "../types";
+
+const DB_PATH = () => join(homedir(), ".local", "share", "opencode", "opencode.db");
+
+/** The slice of better-sqlite3 this source uses, typed locally so the module
+ *  never imports the native driver at load time. */
+interface SqliteHandle {
+	prepare(sql: string): { all(...params: unknown[]): unknown[] };
+	close(): void;
+}
+type SqliteCtor = new (
+	path: string,
+	opts: { readonly: boolean; fileMustExist: boolean },
+) => SqliteHandle;
+
+interface SessionRow {
+	id: string;
+	directory: string;
+	title: string | null;
+	time_created: number | null;
+	time_updated: number | null;
+}
+
+export function opencodeSource(): TranscriptSource {
+	return {
+		agentId: "opencode",
+		digestsFor(cwds) {
+			const path = DB_PATH();
+			if (!existsSync(path) || cwds.length === 0) return [];
+			// Required lazily: the driver is a native module that loads under
+			// node (Electron, the box daemon) but not under Bun, where the tests
+			// run. A driver that will not load is simply one harness we cannot
+			// read, never a broken search.
+			let db: SqliteHandle;
+			try {
+				const Database = createRequire(import.meta.url)("better-sqlite3") as SqliteCtor;
+				db = new Database(path, { readonly: true, fileMustExist: true });
+			} catch {
+				return [];
+			}
+			try {
+				const placeholders = cwds.map(() => "?").join(",");
+				const sessions = db
+					.prepare(
+						`select id, directory, title, time_created, time_updated
+						 from session where directory in (${placeholders})`,
+					)
+					.all(...cwds) as SessionRow[];
+				const parts = db.prepare(
+					`select p.data as data from part p
+					 join message m on m.id = p.message_id
+					 where p.session_id = ? and json_extract(m.data, '$.role') = 'user'
+					 order by p.time_created`,
+				);
+				const out: SessionDigest[] = [];
+				for (const s of sessions) {
+					const prompts: string[] = [];
+					// The session title is the user's own words too, and it is the one
+					// line OpenCode itself shows for a session — worth searching.
+					if (s.title) pushPrompt(prompts, s.title);
+					for (const row of parts.all(s.id) as { data: string }[]) {
+						let part: { type?: string; text?: string };
+						try {
+							part = JSON.parse(row.data);
+						} catch {
+							continue;
+						}
+						if (part.type === "text" && part.text) pushPrompt(prompts, part.text);
+					}
+					if (prompts.length === 0) continue;
+					out.push({
+						agentId: "opencode",
+						sessionId: s.id,
+						cwd: s.directory,
+						branch: null,
+						startedAt: s.time_created ?? null,
+						endedAt: s.time_updated ?? null,
+						prompts,
+						path,
+						// The store is one file for every session, so its mtime would
+						// invalidate everything on any activity — the session's own
+						// updated stamp is the honest per-session cache key.
+						mtimeMs: s.time_updated ?? 0,
+					});
+				}
+				return out;
+			} catch {
+				return [];
+			} finally {
+				db.close();
+			}
+		},
+	};
+}

--- a/packages/server/src/session-search/types.ts
+++ b/packages/server/src/session-search/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Session search — "which session was I working on X?" answered inside the app,
+ * instead of opening a fresh agent session just to ask.
+ *
+ * The corpus is every past agent session that belongs to a task: each harness
+ * writes its own transcript store, so one `TranscriptSource` per agent
+ * normalizes them into a single `SessionDigest`. Nothing downstream (ranking,
+ * re-ranking, the RPC, the UI) knows which agent a session came from — that is
+ * what keeps the feature harness-agnostic rather than Claude-shaped.
+ */
+
+/** One past agent session, normalized across harnesses. */
+export interface SessionDigest {
+	/** The agent that wrote it — "claude" | "codex" | "opencode". */
+	agentId: string;
+	/** The harness's OWN session id, the handle its resume command takes. */
+	sessionId: string;
+	/** Absolute working directory the session ran in (a task's worktree). */
+	cwd: string;
+	/** Branch the harness recorded, when it records one. */
+	branch: string | null;
+	startedAt: number | null;
+	endedAt: number | null;
+	/** The user's own messages, in order, trimmed. The searchable substance. */
+	prompts: string[];
+	/** Where the transcript lives, for the cache key and for "reveal". */
+	path: string;
+	/** mtime of `path` when read — the cache invalidation key. */
+	mtimeMs: number;
+}
+
+/**
+ * A harness's transcript store. `digestsFor` takes the worktrees we care about
+ * (search is scoped to sessions that belong to a task) so a source can use the
+ * cheapest lookup its layout allows: Claude shards by cwd, Codex by date,
+ * OpenCode keeps a SQLite table.
+ */
+export interface TranscriptSource {
+	agentId: string;
+	/** Digests for sessions whose cwd is one of `cwds`. Never throws: a missing
+	 *  or unreadable store is simply an agent with no history to search. */
+	digestsFor(cwds: string[]): SessionDigest[];
+}
+
+/** A ranked match, before it is joined back to a task for the UI. */
+export interface RankedSession {
+	digest: SessionDigest;
+	score: number;
+	/** The prompt lines that matched, for the excerpt and the re-rank prompt. */
+	excerpts: string[];
+}

--- a/packages/server/test/session-search.test.ts
+++ b/packages/server/test/session-search.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+import { cleanPrompt, contentText, pushPrompt } from "../src/session-search/digest";
+import { rank, terms } from "../src/session-search/rank";
+import { extractJson, parseVerdicts } from "../src/session-search/rerank";
+import type { SessionDigest } from "../src/session-search/types";
+
+function digest(id: string, prompts: string[], endedAt = 0): SessionDigest {
+	return {
+		agentId: "claude",
+		sessionId: id,
+		cwd: `/w/${id}`,
+		branch: id,
+		startedAt: endedAt,
+		endedAt,
+		prompts,
+		path: `/t/${id}.jsonl`,
+		mtimeMs: 0,
+	};
+}
+const input = (d: SessionDigest, ...titles: string[]) => ({ digest: d, titles });
+
+describe("digest", () => {
+	test("keeps what the user typed", () => {
+		expect(cleanPrompt("  make the   sidebar  flicker stop ")).toBe(
+			"make the sidebar flicker stop",
+		);
+	});
+
+	test("drops the harness's own injected blocks", () => {
+		expect(cleanPrompt("<command-message>merge</command-message>")).toBe("");
+		expect(cleanPrompt("<system-reminder>be nice</system-reminder>")).toBe("");
+		expect(cleanPrompt("[Request interrupted by user]")).toBe("");
+	});
+
+	test("keeps the user's words when a block is only part of the message", () => {
+		expect(cleanPrompt("<system-reminder>ctx</system-reminder> fix the caret")).toBe(
+			"fix the caret",
+		);
+	});
+
+	test("flattens block-array content", () => {
+		expect(
+			contentText([{ type: "text", text: "a" }, { type: "image" }, { type: "text", text: "b" }]),
+		).toBe("a  b");
+	});
+
+	test("pushPrompt skips empties", () => {
+		const out: string[] = [];
+		pushPrompt(out, "   ");
+		pushPrompt(out, "real words");
+		expect(out).toEqual(["real words"]);
+	});
+});
+
+describe("terms", () => {
+	test("drops stopwords and punctuation", () => {
+		expect(terms("the session Where I fixed the CARET!")).toEqual(["fixed", "caret"]);
+	});
+});
+
+describe("rank", () => {
+	test("finds the session that used the words", () => {
+		const hits = rank(
+			[
+				input(digest("a", ["make the terminal caret render"])),
+				input(digest("b", ["add a merge queue"])),
+			],
+			"caret",
+			5,
+		);
+		expect(hits.map((h) => h.digest.sessionId)).toEqual(["a"]);
+		expect(hits[0]?.excerpts[0]).toBe("make the terminal caret render");
+	});
+
+	test("a match in the task title outweighs one in the body", () => {
+		const body = input(digest("body", ["something about the caret here"]));
+		const title = input(digest("title", ["unrelated chatter"]), "caret fixes");
+		const hits = rank([body, title], "caret", 5);
+		expect(hits[0]?.digest.sessionId).toBe("title");
+	});
+
+	test("length normalization keeps a long paste from burying a short answer", () => {
+		const short = input(digest("short", ["the caret is invisible"]));
+		const long = input(digest("long", [`${"unrelated words ".repeat(200)} caret`]));
+		const hits = rank([short, long], "caret", 5);
+		expect(hits[0]?.digest.sessionId).toBe("short");
+	});
+
+	test("a whole word beats a prefix match", () => {
+		const word = input(digest("word", ["run it in a box"]));
+		const prefix = input(digest("prefix", ["boxd machine new", "boxd auth login"]));
+		const hits = rank([word, prefix], "box", 5);
+		expect(hits[0]?.digest.sessionId).toBe("word");
+	});
+
+	test("matching every typed term beats repeating one", () => {
+		const both = input(digest("both", ["the caret in the titlebar"]));
+		const one = input(digest("one", ["caret caret caret caret"]));
+		const hits = rank([both, one], "caret titlebar", 5);
+		expect(hits[0]?.digest.sessionId).toBe("both");
+	});
+
+	test("expansions find a session the typed words miss", () => {
+		const typed = input(digest("typed", ["fix the consent dialog"]));
+		const expanded = input(digest("expanded", ["ask before the first connection"]));
+		expect(rank([typed, expanded], "consent", 5)).toHaveLength(1);
+		const widened = rank([typed, expanded], "consent", 5, { expansions: ["connection"] });
+		expect(widened.map((h) => h.digest.sessionId).sort()).toEqual(["expanded", "typed"]);
+	});
+
+	test("a term the user typed counts for more than one the model suggested", () => {
+		const typed = input(digest("typed", ["the consent dialog"]));
+		const expanded = input(digest("expanded", ["the connection dialog"]));
+		const hits = rank([typed, expanded], "consent", 5, { expansions: ["connection"] });
+		expect(hits[0]?.digest.sessionId).toBe("typed");
+	});
+
+	test("recency only breaks ties", () => {
+		const now = 1_000_000_000_000;
+		const day = 24 * 60 * 60 * 1000;
+		const old = input(digest("old", ["the caret"], now - 60 * day));
+		const fresh = input(digest("fresh", ["the caret"], now - day));
+		expect(rank([old, fresh], "caret", 5, { now })[0]?.digest.sessionId).toBe("fresh");
+		// ...but never over a genuinely better match.
+		const better = input(digest("better", ["the caret in the caret field"], now - 60 * day));
+		const worse = input(
+			digest("worse", [`one caret ${"and a lot of other words ".repeat(20)}`], now - day),
+		);
+		expect(rank([better, worse], "caret", 5, { now })[0]?.digest.sessionId).toBe("better");
+	});
+
+	test("an empty or stopword-only query matches nothing", () => {
+		const only = [input(digest("a", ["anything"]))];
+		expect(rank(only, "", 5)).toEqual([]);
+		expect(rank(only, "the and of", 5)).toEqual([]);
+	});
+});
+
+describe("verdicts", () => {
+	test("reads JSON out of a fenced reply", () => {
+		expect(extractJson('```json\n{"results":[]}\n```')).toEqual({ results: [] });
+	});
+
+	test("reads JSON out of a reply with prose around it", () => {
+		expect(extractJson('Here you go: {"results":[]} — hope that helps')).toEqual({ results: [] });
+	});
+
+	test("returns null rather than throwing on junk", () => {
+		expect(extractJson("I cannot help with that")).toBeNull();
+	});
+
+	test("drops ids that were never candidates", () => {
+		const reply =
+			'{"results":[{"id":"real","why":"w","confidence":"high"},{"id":"made-up","why":"w"}]}';
+		expect(parseVerdicts(reply, new Set(["real"]))).toEqual([
+			{ sessionId: "real", why: "w", confidence: "high" },
+		]);
+	});
+
+	test("defaults an unusable confidence to low, and dedupes", () => {
+		const reply =
+			'{"results":[{"id":"a","why":"w","confidence":"certain"},{"id":"a","why":"again"}]}';
+		expect(parseVerdicts(reply, new Set(["a"]))).toEqual([
+			{ sessionId: "a", why: "w", confidence: "low" },
+		]);
+	});
+});


### PR DESCRIPTION
Asking "which session was I working on X?" meant opening a fresh agent session just to ask it. The sparkle in the task search answers it in place: describe the work, get the sessions that match, click one to land back in the task and the terminal that did it.

## Why two stages

Measured against this repo's own 1GB of transcripts, the obvious design is the wrong one. Handing the whole history to a model in one prompt took **53s, cost $0.48, and returned near-misses**. Ranking first and asking second is ~3x faster, ~20x cheaper, and more accurate: with 200+ session summaries in one prompt the model skims, with 20 candidates it reads.

1. **BM25** over a digest of each session's user prompts. Instant, free, runs without a model. Length normalization is load-bearing rather than a nicety: without it, a session that pasted a long skill body outranks the one that actually discussed the thing.
2. **Re-rank**: the configured agent reads the shortlist and says why each session matched, quoting the user's own words.

**Query expansion** sits between them. Retrieval is lexical, so "the phone asked for consent before connecting" matches nothing in a session that said "ask before the first connection", the shortlist comes back empty, and the re-rank never runs. One small call closes the vocabulary gap. It is skipped when the typed words already fill the shortlist.

## Harness-agnostic on both halves

- **Corpus**: one `TranscriptSource` per agent normalizing to a single `SessionDigest`. Claude's `~/.claude/projects` JSONL, Codex's date-sharded rollouts, OpenCode's SQLite store. All three verified against real data.
- **Model call**: a new `headless` field on the agent registry (`claude -p`, `codex exec`, `opencode run`), so the search runs on whatever agent the user already has instead of wiring in one vendor's CLI. Launched through a login shell like every other agent spawn, because a GUI process does not inherit the user's PATH.

## Shape

Engine-side behind `CH.searchSessions`, so a box searches the history on its own disk. Scoped to sessions that ran in a task's worktree, which keeps every hit clickable: the transcript's session id joins back to its PTY tab through the agent session id the hooks already record.

## Verification

Verified end to end against a real 52-task history with real model calls: "when my iphone could not reach the remote machine anymore" returns as top hit the session opening "On ios I am unable to connect to my hetzner-devbox anymore. RPC connection error", a query sharing almost no vocabulary with it. 204 tests pass (22 new), typecheck and lint clean, desktop and box-daemon bundles build.

Latency: instant for the plain lexical path, ~15-20s for the sparkle, nearly all of it two agent-CLI startups.