### PR TITLE
Task toolbar: open the worktree in your own editor (local + Remote-SSH)

### DIFF
--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,6 +1,8 @@
-import { readFileSync } from "node:fs";
-import { extname } from "node:path";
-import { type AttachDelivery, CH } from "@ateam/protocol";
+import { spawn } from "node:child_process";
+import { accessSync, constants, readFileSync } from "node:fs";
+import { extname, join } from "node:path";
+import { type AttachDelivery, CH, type OpenInEditorResult } from "@ateam/protocol";
+import { endpointUrl } from "@ateam/server";
 import { clipboard, dialog, ipcMain, nativeImage } from "electron";
 import type { Router } from "./backend";
 
@@ -16,6 +18,42 @@ function stageImageOnClipboard(path: string | null): boolean {
 	if (img.isEmpty()) return false;
 	clipboard.writeImage(img);
 	return true;
+}
+
+/**
+ * The editors we can hand a folder to, in preference order. First one found wins,
+ * searched by editor rather than by PATH order so the choice is deterministic when
+ * a machine has several.
+ *
+ * shortcut: a fixed list, no preference setting. Add one if users ask for a
+ * different default than "whichever comes first here".
+ */
+const EDITORS = ["code", "cursor", "windsurf", "codium"] as const;
+
+/**
+ * Launched from Finder (rather than a shell) an Electron app inherits a bare PATH
+ * — no /usr/local/bin, no /opt/homebrew/bin — so a PATH-only lookup finds nothing
+ * in the packaged app even when the editor is plainly installed. Search the usual
+ * install dirs too.
+ */
+const EDITOR_DIRS = ["/opt/homebrew/bin", "/usr/local/bin"];
+
+/** Absolute path of the first installed editor, or null if none is on this Mac. */
+function findEditor(): string | null {
+	const dirs = [...(process.env.PATH?.split(":") ?? []), ...EDITOR_DIRS];
+	for (const cmd of EDITORS) {
+		for (const dir of dirs) {
+			if (!dir) continue;
+			const full = join(dir, cmd);
+			try {
+				accessSync(full, constants.X_OK);
+				return full;
+			} catch {
+				/* not here — keep looking */
+			}
+		}
+	}
+	return null;
 }
 
 // Channels the renderer calls with `ipcRenderer.send` (fire-and-forget) rather
@@ -141,4 +179,31 @@ export function registerIpc(router: Router, native: NativeHandlers): void {
 		const path = await router.handleFor(terminalId, CH.utilWriteImageBytes, [base64, "png"]);
 		return { mode: "paths", paths: [path as string] } satisfies AttachDelivery;
 	});
+
+	// Hand a task's worktree to the user's own editor. Client-native on purpose: the
+	// editor is a desktop app on THIS Mac, so this never routes to the engine. For a
+	// task on a box, VS Code's Remote-SSH opens the box-side path over the same
+	// ssh_config alias Ateam already connects with — the box needs no editor
+	// installed, the client pushes a server there on first connect.
+	ipcMain.handle(
+		CH.utilOpenInEditor,
+		async (_e, worktreePath: string, alias: string | null): Promise<OpenInEditorResult> => {
+			const editor = findEditor();
+			if (!editor)
+				return { ok: false, reason: `No editor found (looked for ${EDITORS.join(", ")}).` };
+			// A ws connection is a `host:port` endpoint, not an ssh_config alias, so
+			// Remote-SSH has nothing to resolve. Failing loudly beats the alternative:
+			// opening the path locally would silently show THIS Mac's copy of it.
+			if (alias !== null && endpointUrl(alias))
+				return {
+					ok: false,
+					reason: `"${alias}" is a direct endpoint, not an ssh_config alias. Remote-SSH needs an alias — add one to ~/.ssh/config and connect through it.`,
+				};
+			const args =
+				alias === null ? [worktreePath] : ["--remote", `ssh-remote+${alias}`, worktreePath];
+			// Detached: the editor outlives Ateam, and must not die with it.
+			spawn(editor, args, { detached: true, stdio: "ignore" }).unref();
+			return { ok: true };
+		},
+	);
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -89,6 +89,8 @@ const api: AteamApi = {
 		attachClipboardImage: (terminalId) =>
 			ipcRenderer.invoke(CH.utilAttachClipboardImage, terminalId),
 		writeImageBytes: (base64, ext) => ipcRenderer.invoke(CH.utilWriteImageBytes, base64, ext),
+		openInEditor: (worktreePath, alias) =>
+			ipcRenderer.invoke(CH.utilOpenInEditor, worktreePath, alias),
 	},
 	events: {
 		onTaskUpdated: (cb: (task: TaskDTO) => void) => {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1561,6 +1561,18 @@ function TaskPanel({
 
 				<span className="spacer" />
 
+				<IconButton
+					icon={ExternalLink}
+					label={alias === null ? "Open worktree in your editor" : `Open worktree in your editor (Remote-SSH: ${alias})`}
+					onClick={() =>
+						run(async () => {
+							// Optional on the API surface (the phone omits it) — the desktop
+							// preload always provides it.
+							const res = await window.ateam.utils.openInEditor?.(task.worktreePath, alias);
+							if (res && !res.ok) throw new Error(res.reason);
+						})
+					}
+				/>
 				<IconButton icon={GitCommitVertical} label="Commit all changes" onClick={commit} />
 				<IconButton
 					icon={ArrowUp}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -311,6 +311,7 @@ export const CH = {
 	utilAttachImages: "util:attachImages",
 	utilAttachClipboardImage: "util:attachClipboardImage",
 	utilWriteImageBytes: "util:writeImageBytes",
+	utilOpenInEditor: "util:openInEditor",
 	ptySpawnAgent: "pty:spawnAgent",
 	ptySpawnShell: "pty:spawnShell",
 	ptyWrite: "pty:write",
@@ -360,6 +361,13 @@ export type AttachDelivery =
 	| { mode: "ctrlv" }
 	| { mode: "paths"; paths: string[] }
 	| { mode: "none" };
+
+/**
+ * Outcome of handing a worktree to the user's own editor. `ok: false` carries a
+ * reason to show — the editor isn't installed, or the task's engine is reached by
+ * a `host:port` endpoint that Remote-SSH can't resolve.
+ */
+export type OpenInEditorResult = { ok: true } | { ok: false; reason: string };
 
 // ---- the API surface exposed on window.ateam ----
 export interface AteamApi {
@@ -499,6 +507,15 @@ export interface AteamApi {
 		 * instead of a bitmap on the clipboard. `ext` sets the extension (default "png").
 		 */
 		writeImageBytes(base64: string, ext?: string): Promise<string>;
+		/**
+		 * Open a task's worktree in the user's own editor, on THIS machine. Client-native
+		 * (the editor is a desktop app, not something the engine can launch), so it never
+		 * routes to the engine: a task on a box is opened over VS Code's Remote-SSH using
+		 * the same ssh_config alias Ateam connects with. Optional — a client with no
+		 * desktop editor to hand off to (the phone) simply omits it, and callers hide the
+		 * affordance rather than offering one that can't work.
+		 */
+		openInEditor?(worktreePath: string, alias: string | null): Promise<OpenInEditorResult>;
 	};
 }
 


### PR DESCRIPTION
Adds an open-in-editor button to the task toolbar. A local task opens its worktree in the first editor found (code/cursor/windsurf/codium, with Finder-safe PATH lookup); a task on a box opens over VS Code Remote-SSH using the same ssh_config alias the connection uses, so the box needs no editor installed. Tasks on ws-endpoint boxes get a clear error instead of silently opening this Mac's path. The API method is optional so the phone client compiles without it.