### PR TITLE
Mission Control follows the tasks-list order, with a lock toggle

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -32,6 +32,7 @@ import {
 	History,
 	LayoutGrid,
 	Lock,
+	LockOpen,
 	type LucideIcon,
 	Maximize2,
 	Minimize2,
@@ -157,6 +158,15 @@ export function App() {
 	const setMcLayout = (l: McLayout) => {
 		localStorage.setItem("ateam.mcLayout", l);
 		setMcLayoutState(l);
+	};
+	// Mission Control lock: locked freezes tile order for the whole visit (it
+	// re-snapshots the tasks-list order each time you land on Mission Control);
+	// unlocked follows the tasks-list order live, pinning only the tile being
+	// typed in.
+	const [mcLocked, setMcLockedState] = useState(() => localStorage.getItem("ateam.mcLock") === "1");
+	const setMcLocked = (v: boolean) => {
+		localStorage.setItem("ateam.mcLock", v ? "1" : "0");
+		setMcLockedState(v);
 	};
 	const [panelMode, setPanelMode] = useState<"side" | "full">("side");
 	const [projectsCollapsed, setProjectsCollapsed] = useState(false);
@@ -525,6 +535,12 @@ export function App() {
 		}
 		return list;
 	}, [sidebarTasks, taskSort, customOrder]);
+	// Stable identity for Mission Control: a fresh array every render would make
+	// its follow-the-tasks-order effect re-run on every App render.
+	const sidebarOrderIds = useMemo(
+		() => orderedSidebarTasks.map((t) => t.id),
+		[orderedSidebarTasks],
+	);
 
 	// Case-insensitive substring match across the task's name, branch, and
 	// description. Empty query matches all.
@@ -1125,6 +1141,24 @@ export function App() {
 									<Icon size={14} strokeWidth={1.75} />
 								</button>
 							))}
+							<button
+								type="button"
+								className={`navbtn icon ${mcLocked ? "active" : ""}`}
+								title={
+									mcLocked
+										? "Layout locked: tile order is frozen while you watch"
+										: "Lock layout (unlocked: tiles follow the tasks list order; the tile you type in stays put)"
+								}
+								aria-label="Lock layout"
+								aria-pressed={mcLocked}
+								onClick={() => setMcLocked(!mcLocked)}
+							>
+								{mcLocked ? (
+									<Lock size={14} strokeWidth={1.75} />
+								) : (
+									<LockOpen size={14} strokeWidth={1.75} />
+								)}
+							</button>
 						</div>
 					)}
 					<button type="button" className="navbtn" onClick={cleanup} disabled={!activeProjectId}>
@@ -1199,8 +1233,9 @@ export function App() {
 						) : (
 							<MissionControl
 								tasks={activeTasks}
-								order={orderedSidebarTasks.map((t) => t.id)}
+								order={sidebarOrderIds}
 								layout={mcLayout}
+								locked={mcLocked}
 								onExpand={openFromMission}
 							/>
 						)
@@ -1840,23 +1875,82 @@ function MissionControl({
 	tasks,
 	order,
 	layout,
+	locked,
 	onExpand,
 }: {
 	tasks: TaskDTO[];
 	order: string[];
 	layout: McLayout;
+	locked: boolean;
 	onExpand: (task: TaskDTO, terminalId: string) => void;
 }) {
 	const [tiles, setTiles] = useState<{ task: TaskDTO; terminalId: string }[]>([]);
 	const tasksRef = useRef(tasks);
 	tasksRef.current = tasks;
 
-	// Snapshot the sidebar's ordering the moment we land here, so tiles come up
-	// in the same order the tasks list is showing — but freeze it: while you're
-	// watching, terminals must not shuffle under you (e.g. "sort by updated"
-	// would otherwise reorder live as agents emit events). Tasks that gain a
-	// session after we landed (not in the snapshot) sort to the end.
-	const [rank] = useState(() => new Map(order.map((id, i) => [id, i])));
+	// Locked: snapshot the sidebar's ordering the moment we land here (or flip
+	// the lock on) and freeze it, so terminals never shuffle under you while
+	// you watch (e.g. "sort by updated" would otherwise reorder live as agents
+	// emit events). Unlocked: follow the sidebar's live order, except the tile
+	// being typed in keeps its slot (see focusedRef). Tasks not in the active
+	// rank sort to the end.
+	const orderRef = useRef(order);
+	orderRef.current = order;
+	const [frozenRank, setFrozenRank] = useState(() => new Map(order.map((id, i) => [id, i])));
+	useEffect(() => {
+		if (locked) setFrozenRank(new Map(orderRef.current.map((id, i) => [id, i])));
+	}, [locked]);
+	const liveRank = useMemo(() => new Map(order.map((id, i) => [id, i])), [order]);
+	const rank = locked ? frozenRank : liveRank;
+
+	// The tile whose terminal currently has keyboard focus, i.e. the one the
+	// user is typing in. A ref, not state: focus alone must not reorder
+	// anything; it only matters at the moment a re-sort happens.
+	const focusedRef = useRef<string | null>(null);
+	// Latest unsorted session list, kept so a re-sort (order change, lock flip,
+	// blur) doesn't need a fresh round of listForTask calls.
+	const sessionsRef = useRef<{ task: TaskDTO; terminalId: string }[]>([]);
+	const rankRef = useRef(rank);
+	const lockedRef = useRef(locked);
+	lockedRef.current = locked;
+
+	// Sort the collected sessions by the active rank. When unlocked and a tile
+	// is focused, that tile keeps the slot it currently occupies on screen and
+	// everything else re-sorts around it.
+	const resort = useCallback(() => {
+		const r = rankRef.current;
+		const next = [...sessionsRef.current];
+		// Stable sort; V8's stable sort keeps a task's own sessions (and any
+		// equal-rank ties) in encounter order.
+		next.sort(
+			(a, b) =>
+				(r.get(a.task.id) ?? Number.MAX_SAFE_INTEGER) -
+				(r.get(b.task.id) ?? Number.MAX_SAFE_INTEGER),
+		);
+		setTiles((prev) => {
+			const focused = lockedRef.current ? null : focusedRef.current;
+			if (focused) {
+				const cur = prev.findIndex((t) => t.terminalId === focused);
+				const pinned = next.find((t) => t.terminalId === focused);
+				if (cur >= 0 && pinned) {
+					next.splice(next.indexOf(pinned), 1);
+					next.splice(Math.min(cur, next.length), 0, pinned);
+				}
+			}
+			// Keep the previous array when nothing moved so downstream renders
+			// (and their terminals) see a stable identity.
+			if (prev.length === next.length && prev.every((t, i) => t === next[i])) return prev;
+			return next;
+		});
+	}, []);
+
+	// Re-sort when the sidebar order changes (only matters unlocked) or the
+	// lock flips off and the live order takes over again. rankRef is synced
+	// here (not at render time) so the effect legitimately depends on rank.
+	useEffect(() => {
+		rankRef.current = rank;
+		resort();
+	}, [rank, resort]);
 
 	// Sessions announce themselves, so this listens instead of polling. Both spawn
 	// paths broadcast taskUpdated and a dying PTY broadcasts ptyExit — including from
@@ -1878,17 +1972,10 @@ function MissionControl({
 					})),
 				);
 				if (cancelled) return;
-				const collected = perTask.flatMap(({ task, sessions }) =>
+				sessionsRef.current = perTask.flatMap(({ task, sessions }) =>
 					sessions.map((s) => ({ task, terminalId: s.terminalId })),
 				);
-				// Stable sort by the frozen sidebar order; V8's stable sort keeps a
-				// task's own sessions (and any equal-rank ties) in encounter order.
-				collected.sort(
-					(a, b) =>
-						(rank.get(a.task.id) ?? Number.MAX_SAFE_INTEGER) -
-						(rank.get(b.task.id) ?? Number.MAX_SAFE_INTEGER),
-				);
-				setTiles(collected);
+				resort();
 			} finally {
 				inFlight = false;
 			}
@@ -1901,7 +1988,7 @@ function MissionControl({
 			offUpdated();
 			offExit();
 		};
-	}, [rank]);
+	}, [resort]);
 
 	if (tiles.length === 0) {
 		return (
@@ -1918,7 +2005,25 @@ function MissionControl({
 	return (
 		<div className="mc" data-layout={layout}>
 			{tiles.map(({ task, terminalId }) => (
-				<div key={terminalId} className="tile">
+				// biome-ignore lint/a11y/noStaticElementInteractions: focus/blur only observe where focus is; the tile itself isn't interactive
+				<div
+					key={terminalId}
+					className="tile"
+					// React's onFocus/onBlur bubble (focusin/focusout), so these fire
+					// when the xterm textarea inside the tile gains/loses focus.
+					onFocus={() => {
+						focusedRef.current = terminalId;
+					}}
+					onBlur={(e) => {
+						// Ignore focus moving within the same tile (e.g. from the bar's
+						// button to the terminal). Once focus truly leaves, the pin is
+						// released and the tile snaps back to its tasks-list slot.
+						if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+						if (focusedRef.current !== terminalId) return;
+						focusedRef.current = null;
+						resort();
+					}}
+				>
 					<div className="bar">
 						<span>{task.name}</span>
 						<span className="muted">· {task.branch}</span>


### PR DESCRIPTION
## What

- **Unlocked (default):** Mission Control tiles re-sort live to match the Tasks list order config (status / updated / custom drag order). The one exception is the tile currently being typed in: it keeps its slot on screen while the others reorder around it, and snaps back to its ordered slot once focus leaves it.
- **Locked:** a new lock toggle next to the grid/split/stack layout switcher restores the previous behavior: the tasks-list order is snapshotted when you land on Mission Control (or flip the lock on) and frozen for the visit, so nothing shuffles while you watch. Persisted in localStorage like the layout choice.

## How

- `MissionControl` keeps the raw session list in a ref and re-sorts in place on session events, sidebar-order changes, or focus leaving a pinned tile — order changes reuse already-fetched sessions, so no extra `listForTask` round-trips (which are per-task SSH calls for box-owned tasks).
- Typing detection is passive `onFocus`/`onBlur` on each tile (bubbling from xterm's textarea), stored in a ref so focus alone never re-renders or reorders.
- Sessions not in the active ranking (e.g. appearing after a locked snapshot) still sort to the end, as before.

Verified: `tsc` clean on both configs, biome clean (no new findings), full `electron-vite build` passes.