### PR TITLE
Mission Control: page tiles instead of scrolling, skip reorders that only permute the visible page

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -32,6 +32,7 @@ import {
 	History,
 	LayoutGrid,
 	Lock,
+	LockOpen,
 	type LucideIcon,
 	Maximize2,
 	Minimize2,
@@ -157,6 +158,15 @@ export function App() {
 	const setMcLayout = (l: McLayout) => {
 		localStorage.setItem("ateam.mcLayout", l);
 		setMcLayoutState(l);
+	};
+	// Mission Control lock: locked freezes tile order for the whole visit (it
+	// re-snapshots the tasks-list order each time you land on Mission Control);
+	// unlocked follows the tasks-list order live, pinning only the tile being
+	// typed in.
+	const [mcLocked, setMcLockedState] = useState(() => localStorage.getItem("ateam.mcLock") === "1");
+	const setMcLocked = (v: boolean) => {
+		localStorage.setItem("ateam.mcLock", v ? "1" : "0");
+		setMcLockedState(v);
 	};
 	const [panelMode, setPanelMode] = useState<"side" | "full">("side");
 	const [projectsCollapsed, setProjectsCollapsed] = useState(false);
@@ -525,6 +535,12 @@ export function App() {
 		}
 		return list;
 	}, [sidebarTasks, taskSort, customOrder]);
+	// Stable identity for Mission Control: a fresh array every render would make
+	// its follow-the-tasks-order effect re-run on every App render.
+	const sidebarOrderIds = useMemo(
+		() => orderedSidebarTasks.map((t) => t.id),
+		[orderedSidebarTasks],
+	);
 
 	// Case-insensitive substring match across the task's name, branch, and
 	// description. Empty query matches all.
@@ -1125,6 +1141,24 @@ export function App() {
 									<Icon size={14} strokeWidth={1.75} />
 								</button>
 							))}
+							<button
+								type="button"
+								className={`navbtn icon ${mcLocked ? "active" : ""}`}
+								title={
+									mcLocked
+										? "Layout locked: tile order is frozen while you watch"
+										: "Lock layout (unlocked: tiles follow the tasks list order; the tile you type in stays put)"
+								}
+								aria-label="Lock layout"
+								aria-pressed={mcLocked}
+								onClick={() => setMcLocked(!mcLocked)}
+							>
+								{mcLocked ? (
+									<Lock size={14} strokeWidth={1.75} />
+								) : (
+									<LockOpen size={14} strokeWidth={1.75} />
+								)}
+							</button>
 						</div>
 					)}
 					<button type="button" className="navbtn" onClick={cleanup} disabled={!activeProjectId}>
@@ -1199,8 +1233,9 @@ export function App() {
 						) : (
 							<MissionControl
 								tasks={activeTasks}
-								order={orderedSidebarTasks.map((t) => t.id)}
+								order={sidebarOrderIds}
 								layout={mcLayout}
+								locked={mcLocked}
 								onExpand={openFromMission}
 							/>
 						)
@@ -1840,23 +1875,82 @@ function MissionControl({
 	tasks,
 	order,
 	layout,
+	locked,
 	onExpand,
 }: {
 	tasks: TaskDTO[];
 	order: string[];
 	layout: McLayout;
+	locked: boolean;
 	onExpand: (task: TaskDTO, terminalId: string) => void;
 }) {
 	const [tiles, setTiles] = useState<{ task: TaskDTO; terminalId: string }[]>([]);
 	const tasksRef = useRef(tasks);
 	tasksRef.current = tasks;
 
-	// Snapshot the sidebar's ordering the moment we land here, so tiles come up
-	// in the same order the tasks list is showing — but freeze it: while you're
-	// watching, terminals must not shuffle under you (e.g. "sort by updated"
-	// would otherwise reorder live as agents emit events). Tasks that gain a
-	// session after we landed (not in the snapshot) sort to the end.
-	const [rank] = useState(() => new Map(order.map((id, i) => [id, i])));
+	// Locked: snapshot the sidebar's ordering the moment we land here (or flip
+	// the lock on) and freeze it, so terminals never shuffle under you while
+	// you watch (e.g. "sort by updated" would otherwise reorder live as agents
+	// emit events). Unlocked: follow the sidebar's live order, except the tile
+	// being typed in keeps its slot (see focusedRef). Tasks not in the active
+	// rank sort to the end.
+	const orderRef = useRef(order);
+	orderRef.current = order;
+	const [frozenRank, setFrozenRank] = useState(() => new Map(order.map((id, i) => [id, i])));
+	useEffect(() => {
+		if (locked) setFrozenRank(new Map(orderRef.current.map((id, i) => [id, i])));
+	}, [locked]);
+	const liveRank = useMemo(() => new Map(order.map((id, i) => [id, i])), [order]);
+	const rank = locked ? frozenRank : liveRank;
+
+	// The tile whose terminal currently has keyboard focus, i.e. the one the
+	// user is typing in. A ref, not state: focus alone must not reorder
+	// anything; it only matters at the moment a re-sort happens.
+	const focusedRef = useRef<string | null>(null);
+	// Latest unsorted session list, kept so a re-sort (order change, lock flip,
+	// blur) doesn't need a fresh round of listForTask calls.
+	const sessionsRef = useRef<{ task: TaskDTO; terminalId: string }[]>([]);
+	const rankRef = useRef(rank);
+	const lockedRef = useRef(locked);
+	lockedRef.current = locked;
+
+	// Sort the collected sessions by the active rank. When unlocked and a tile
+	// is focused, that tile keeps the slot it currently occupies on screen and
+	// everything else re-sorts around it.
+	const resort = useCallback(() => {
+		const r = rankRef.current;
+		const next = [...sessionsRef.current];
+		// Stable sort; V8's stable sort keeps a task's own sessions (and any
+		// equal-rank ties) in encounter order.
+		next.sort(
+			(a, b) =>
+				(r.get(a.task.id) ?? Number.MAX_SAFE_INTEGER) -
+				(r.get(b.task.id) ?? Number.MAX_SAFE_INTEGER),
+		);
+		setTiles((prev) => {
+			const focused = lockedRef.current ? null : focusedRef.current;
+			if (focused) {
+				const cur = prev.findIndex((t) => t.terminalId === focused);
+				const pinned = next.find((t) => t.terminalId === focused);
+				if (cur >= 0 && pinned) {
+					next.splice(next.indexOf(pinned), 1);
+					next.splice(Math.min(cur, next.length), 0, pinned);
+				}
+			}
+			// Keep the previous array when nothing moved so downstream renders
+			// (and their terminals) see a stable identity.
+			if (prev.length === next.length && prev.every((t, i) => t === next[i])) return prev;
+			return next;
+		});
+	}, []);
+
+	// Re-sort when the sidebar order changes (only matters unlocked) or the
+	// lock flips off and the live order takes over again. rankRef is synced
+	// here (not at render time) so the effect legitimately depends on rank.
+	useEffect(() => {
+		rankRef.current = rank;
+		resort();
+	}, [rank, resort]);
 
 	// Sessions announce themselves, so this listens instead of polling. Both spawn
 	// paths broadcast taskUpdated and a dying PTY broadcasts ptyExit — including from
@@ -1878,17 +1972,10 @@ function MissionControl({
 					})),
 				);
 				if (cancelled) return;
-				const collected = perTask.flatMap(({ task, sessions }) =>
+				sessionsRef.current = perTask.flatMap(({ task, sessions }) =>
 					sessions.map((s) => ({ task, terminalId: s.terminalId })),
 				);
-				// Stable sort by the frozen sidebar order; V8's stable sort keeps a
-				// task's own sessions (and any equal-rank ties) in encounter order.
-				collected.sort(
-					(a, b) =>
-						(rank.get(a.task.id) ?? Number.MAX_SAFE_INTEGER) -
-						(rank.get(b.task.id) ?? Number.MAX_SAFE_INTEGER),
-				);
-				setTiles(collected);
+				resort();
 			} finally {
 				inFlight = false;
 			}
@@ -1901,7 +1988,7 @@ function MissionControl({
 			offUpdated();
 			offExit();
 		};
-	}, [rank]);
+	}, [resort]);
 
 	if (tiles.length === 0) {
 		return (
@@ -1918,7 +2005,25 @@ function MissionControl({
 	return (
 		<div className="mc" data-layout={layout}>
 			{tiles.map(({ task, terminalId }) => (
-				<div key={terminalId} className="tile">
+				// biome-ignore lint/a11y/noStaticElementInteractions: focus/blur only observe where focus is; the tile itself isn't interactive
+				<div
+					key={terminalId}
+					className="tile"
+					// React's onFocus/onBlur bubble (focusin/focusout), so these fire
+					// when the xterm textarea inside the tile gains/loses focus.
+					onFocus={() => {
+						focusedRef.current = terminalId;
+					}}
+					onBlur={(e) => {
+						// Ignore focus moving within the same tile (e.g. from the bar's
+						// button to the terminal). Once focus truly leaves, the pin is
+						// released and the tile snaps back to its tasks-list slot.
+						if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+						if (focusedRef.current !== terminalId) return;
+						focusedRef.current = null;
+						resort();
+					}}
+				>
 					<div className="bar">
 						<span>{task.name}</span>
 						<span className="muted">· {task.branch}</span>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -19,6 +19,7 @@ import {
 	Check,
 	ChevronDown,
 	ChevronRight,
+	ChevronUp,
 	Columns2,
 	Database,
 	ExternalLink,
@@ -111,8 +112,12 @@ type TaskSortMode = "status" | "updated" | "custom";
 // ---- mission control layout ----
 // How agent tiles are arranged: "grid" is a 2x2 overview (tiles half the
 // window wide and tall), "split" lays them side-by-side at full window
-// height, "stack" stacks them full-width. Extra tiles scroll downward.
+// height, "stack" stacks them full-width. Extra tiles go to further pages,
+// flipped via the bottom-right pager or Cmd/Ctrl+Alt+Up/Down.
 type McLayout = "grid" | "split" | "stack";
+
+// Tiles per page: how many terminals each layout actually shows at once.
+const MC_PAGE_SIZE: Record<McLayout, number> = { grid: 4, split: 2, stack: 1 };
 
 // Status order: what needs the user's eyes first.
 const STATUS_RANK: Record<KanbanColumn, number> = {
@@ -1711,7 +1716,11 @@ function TaskPanel({
 
 				<IconButton
 					icon={ExternalLink}
-					label={alias === null ? "Open worktree in your editor" : `Open worktree in your editor (Remote-SSH: ${alias})`}
+					label={
+						alias === null
+							? "Open worktree in your editor"
+							: `Open worktree in your editor (Remote-SSH: ${alias})`
+					}
 					onClick={() =>
 						run(async () => {
 							// Optional on the API surface (the phone omits it) — the desktop
@@ -1900,6 +1909,46 @@ function MissionControl({
 	const tasksRef = useRef(tasks);
 	tasksRef.current = tasks;
 
+	// Pages instead of a scroll area: each layout shows a fixed number of tiles
+	// at once, and the rest live on further pages. "In view" is then a crisp
+	// set — exactly what the reorder-skip below needs.
+	const [page, setPage] = useState(0);
+	const pageSize = MC_PAGE_SIZE[layout];
+	const pageCount = Math.max(1, Math.ceil(tiles.length / pageSize));
+	// Clamp in-render (sessions can die, the layout can change page size) so a
+	// stale page never shows an empty grid, then sync the state.
+	const clampedPage = Math.min(page, pageCount - 1);
+	useEffect(() => {
+		if (page !== clampedPage) setPage(clampedPage);
+	}, [page, clampedPage]);
+	const pageRef = useRef(clampedPage);
+	pageRef.current = clampedPage;
+	const pageSizeRef = useRef(pageSize);
+	pageSizeRef.current = pageSize;
+	const pageCountRef = useRef(pageCount);
+	pageCountRef.current = pageCount;
+	// Last flip direction, read by the page transition so it slides the way a
+	// scroll would have gone.
+	const dirRef = useRef(0);
+	const flip = useCallback((d: number) => {
+		dirRef.current = d;
+		setPage((p) => Math.max(0, Math.min(pageCountRef.current - 1, p + d)));
+	}, []);
+	// Cmd/Ctrl+Alt+Up/Down flips pages. Capture phase so it wins over the
+	// focused xterm textarea; the combo is one no shell binding uses.
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			if (!e.altKey || !(e.metaKey || e.ctrlKey)) return;
+			if (e.key === "ArrowDown") flip(1);
+			else if (e.key === "ArrowUp") flip(-1);
+			else return;
+			e.preventDefault();
+			e.stopPropagation();
+		};
+		window.addEventListener("keydown", onKey, true);
+		return () => window.removeEventListener("keydown", onKey, true);
+	}, [flip]);
+
 	// Locked: snapshot the sidebar's ordering the moment we land here (or flip
 	// the lock on) and freeze it, so terminals never shuffle under you while
 	// you watch (e.g. "sort by updated" would otherwise reorder live as agents
@@ -1926,9 +1975,10 @@ function MissionControl({
 	const lockedRef = useRef(locked);
 	lockedRef.current = locked;
 
-	// Sort the collected sessions by the active rank. When unlocked and a tile
-	// is focused, that tile keeps the slot it currently occupies on screen and
-	// everything else re-sorts around it.
+	// Sort the collected sessions by the active rank, with two visibility
+	// courtesies: a new order that only permutes the visible page is skipped
+	// there (see below), and while a tile is being typed in it keeps the slot
+	// it currently occupies on screen.
 	const resort = useCallback(() => {
 		const r = rankRef.current;
 		const next = [...sessionsRef.current];
@@ -1940,13 +1990,33 @@ function MissionControl({
 				(r.get(b.task.id) ?? Number.MAX_SAFE_INTEGER),
 		);
 		setTiles((prev) => {
-			const focused = lockedRef.current ? null : focusedRef.current;
-			if (focused) {
-				const cur = prev.findIndex((t) => t.terminalId === focused);
-				const pinned = next.find((t) => t.terminalId === focused);
-				if (cur >= 0 && pinned) {
-					next.splice(next.indexOf(pinned), 1);
-					next.splice(Math.min(cur, next.length), 0, pinned);
+			// If the new order only permutes tiles already on the visible page,
+			// keep that page's arrangement: swapping terminals the user can
+			// already see gains nothing and yanks the one they're reading. The
+			// page re-orders only when its membership changes (a tile from
+			// another page earns a visible slot, or one of its own dies).
+			// Off-page tiles always take the new order — that move is invisible.
+			const start = pageRef.current * pageSizeRef.current;
+			const prevWin = prev.slice(start, start + pageSizeRef.current);
+			const nextWin = next.slice(start, start + pageSizeRef.current);
+			const sameSet =
+				prevWin.length === nextWin.length &&
+				prevWin.every((p) => nextWin.some((n) => n.terminalId === p.terminalId));
+			if (sameSet && prevWin.length > 0) {
+				// Keep the on-screen arrangement but take next's tile objects,
+				// which carry the freshly fetched task DTOs.
+				const fresh = new Map(nextWin.map((t) => [t.terminalId, t]));
+				const kept = prevWin.map((t) => fresh.get(t.terminalId) ?? t);
+				next.splice(start, kept.length, ...kept);
+			} else {
+				const focused = lockedRef.current ? null : focusedRef.current;
+				if (focused) {
+					const cur = prev.findIndex((t) => t.terminalId === focused);
+					const pinned = next.find((t) => t.terminalId === focused);
+					if (cur >= 0 && pinned) {
+						next.splice(next.indexOf(pinned), 1);
+						next.splice(Math.min(cur, next.length), 0, pinned);
+					}
 				}
 			}
 			// Keep the previous array when nothing moved so downstream renders
@@ -2014,44 +2084,83 @@ function MissionControl({
 		);
 	}
 
+	const visible = tiles.slice(clampedPage * pageSize, clampedPage * pageSize + pageSize);
 	return (
-		<div className="mc" data-layout={layout}>
-			{tiles.map(({ task, terminalId }) => (
-				// biome-ignore lint/a11y/noStaticElementInteractions: focus/blur only observe where focus is; the tile itself isn't interactive
-				<div
-					key={terminalId}
-					className="tile"
-					// React's onFocus/onBlur bubble (focusin/focusout), so these fire
-					// when the xterm textarea inside the tile gains/loses focus.
-					onFocus={() => {
-						focusedRef.current = terminalId;
-					}}
-					onBlur={(e) => {
-						// Ignore focus moving within the same tile (e.g. from the bar's
-						// button to the terminal). Once focus truly leaves, the pin is
-						// released and the tile snaps back to its tasks-list slot.
-						if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
-						if (focusedRef.current !== terminalId) return;
-						focusedRef.current = null;
-						resort();
-					}}
-				>
-					<div className="bar">
-						<span>{task.name}</span>
-						<span className="muted">· {task.branch}</span>
-						<span style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 6 }}>
-							{task.agentStatus && <span className={`tstatus ${task.agentStatus}`} />}
-							<IconButton
-								icon={Maximize2}
-								label="Expand to full width"
-								size={13}
-								onClick={() => onExpand(task, terminalId)}
-							/>
-						</span>
+		<div className="mc-wrap">
+			{/* Keyed by page: flipping remounts the grid, and TerminalView replays
+			    its ring-buffer snapshot on mount, so a page flip is a clean swap.
+			    The slide follows the flip direction — a "perfect scroll" to the
+			    next set of terminals. */}
+			<motion.div
+				key={clampedPage}
+				className="mc"
+				data-layout={layout}
+				initial={dirRef.current === 0 ? false : { y: dirRef.current * 32, opacity: 0.3 }}
+				animate={{ y: 0, opacity: 1 }}
+				transition={springy}
+			>
+				{visible.map(({ task, terminalId }) => (
+					// biome-ignore lint/a11y/noStaticElementInteractions: focus/blur only observe where focus is; the tile itself isn't interactive
+					<div
+						key={terminalId}
+						className="tile"
+						// React's onFocus/onBlur bubble (focusin/focusout), so these fire
+						// when the xterm textarea inside the tile gains/loses focus.
+						onFocus={() => {
+							focusedRef.current = terminalId;
+						}}
+						onBlur={(e) => {
+							// Ignore focus moving within the same tile (e.g. from the bar's
+							// button to the terminal). Once focus truly leaves, the pin is
+							// released: if the pin was holding the tile away from an
+							// off-page slot it now moves there (an in-page permutation
+							// alone is skipped by resort anyway).
+							if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+							if (focusedRef.current !== terminalId) return;
+							focusedRef.current = null;
+							resort();
+						}}
+					>
+						<div className="bar">
+							<span>{task.name}</span>
+							<span className="muted">· {task.branch}</span>
+							<span style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 6 }}>
+								{task.agentStatus && <span className={`tstatus ${task.agentStatus}`} />}
+								<IconButton
+									icon={Maximize2}
+									label="Expand to full width"
+									size={13}
+									onClick={() => onExpand(task, terminalId)}
+								/>
+							</span>
+						</div>
+						<TerminalView terminalId={terminalId} />
 					</div>
-					<TerminalView terminalId={terminalId} />
+				))}
+			</motion.div>
+			{pageCount > 1 && (
+				<div className="mcpager">
+					<IconButton
+						icon={ChevronUp}
+						label="Previous terminals"
+						shortcut="⌘⌥↑"
+						size={14}
+						disabled={clampedPage === 0}
+						onClick={() => flip(-1)}
+					/>
+					<span className="count">
+						{clampedPage + 1}/{pageCount}
+					</span>
+					<IconButton
+						icon={ChevronDown}
+						label="Next terminals"
+						shortcut="⌘⌥↓"
+						size={14}
+						disabled={clampedPage === pageCount - 1}
+						onClick={() => flip(1)}
+					/>
 				</div>
-			))}
+			)}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -1054,13 +1054,20 @@ input {
 }
 
 /* ---- mission control ---- */
+/* Hosts the sliding page grid and the bottom-right pager overlay. */
+.mc-wrap {
+	flex: 1;
+	display: flex;
+	position: relative;
+	min-height: 0;
+}
 .mc {
 	flex: 1;
 	display: grid;
 	gap: 8px;
 	padding: 12px;
-	/* Always scroll vertically once the tiles don't fit — never shrink a
-	   terminal away; extra agents overflow downward into the scroll area. */
+	/* Tiles are paged, not scrolled: each layout renders at most a pageful, so
+	   this only guards pathologically small windows. */
 	overflow-y: auto;
 	overflow-x: hidden;
 	/* Default ("grid"): 2x2 — each tile is half the window wide and half the
@@ -1080,6 +1087,33 @@ input {
 .mc[data-layout="stack"] {
 	grid-template-columns: minmax(0, 1fr);
 	grid-auto-rows: minmax(280px, 1fr);
+}
+
+/* Pager overlay: sits translucent over the bottom-right corner, full opacity
+   on hover. Clicking the chevrons (or Cmd/Ctrl+Alt+Up/Down) flips to the
+   next/previous pageful of terminals. */
+.mcpager {
+	position: absolute;
+	right: 18px;
+	bottom: 18px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding: 3px;
+	background: var(--bg-elev);
+	border: 1px solid var(--border);
+	border-radius: 9px;
+	opacity: 0.4;
+	transition: opacity 120ms ease;
+}
+.mcpager:hover {
+	opacity: 1;
+}
+.mcpager .count {
+	font-size: 10px;
+	color: var(--text-dim);
+	font-variant-numeric: tabular-nums;
+	padding: 2px 0;
 }
 
 /* layout picker (segmented control in the topbar) */


### PR DESCRIPTION
## What

- **Pages, not scroll:** each layout shows a fixed pageful of terminals (grid 4, split 2, stack 1); the rest live on further pages. Navigate with a translucent bottom-right pager (chevrons + `2/3` counter, 40% opacity, full on hover) or `⌘⌥↑` / `⌘⌥↓` (Ctrl+Alt on non-Mac), registered in capture phase so they work while typing in a terminal. Page flips slide in the flip direction.
- **Viewport-aware reordering:** an order change that only permutes tiles already on the visible page is skipped for that page — swapping terminals the user can already see gains nothing. The page re-orders only when its membership changes (a tile from another page earns a visible slot, or a visible session dies). Off-page tiles always take the new order, since that move is invisible. The rule is anchored to the current page, so it follows you as you flip.

## Notes

- Page flips remount the visible `TerminalView`s, which is safe: they replay their ring-buffer snapshot on mount (same as switching Board ↔ Mission Control today).
- Wheel/trackpad paging was deliberately left out: xterm consumes wheel events for its own scrollback, and the pointer is nearly always over a terminal.
- The typing-tile focus pin and the lock toggle from #149 still apply within the membership-change path.

Verified: `tsc` clean, biome clean (no new findings), full `electron-vite build` passes.