### PR TITLE
Inline editor: VS Code (code-server) on the task's machine, with opt-in install

### DIFF
--- a/apps/desktop/src/main/aggregate.ts
+++ b/apps/desktop/src/main/aggregate.ts
@@ -48,6 +48,7 @@ const ENTITY = new Set<string>([
 	CH.gitDiff,
 	CH.gitFileDiff,
 	CH.gitStatus,
+	CH.editorOpen, // taskId — the editor lives on the task's engine
 	CH.ptySpawnAgent, // {taskId}
 	CH.ptySpawnShell, // {taskId}
 	// Loops live on the engine that runs them — that's what makes a loop local

--- a/apps/desktop/src/main/aggregate.ts
+++ b/apps/desktop/src/main/aggregate.ts
@@ -49,6 +49,7 @@ const ENTITY = new Set<string>([
 	CH.gitFileDiff,
 	CH.gitStatus,
 	CH.editorOpen, // taskId — the editor lives on the task's engine
+	CH.editorInstall, // taskId — installs on that same engine
 	CH.ptySpawnAgent, // {taskId}
 	CH.ptySpawnShell, // {taskId}
 	// Loops live on the engine that runs them — that's what makes a loop local

--- a/apps/desktop/src/main/editor-tunnel.test.ts
+++ b/apps/desktop/src/main/editor-tunnel.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_EDITOR_PORT } from "@ateam/protocol";
+import { editorForwardFlags, editorLocalPort } from "./editor-tunnel";
+
+describe("editor tunnel", () => {
+	test("local port is deterministic and inside the reserved range", () => {
+		const p1 = editorLocalPort("hetzner-devbox");
+		expect(editorLocalPort("hetzner-devbox")).toBe(p1);
+		expect(p1).toBeGreaterThanOrEqual(8391);
+		expect(p1).toBeLessThan(8391 + 500);
+	});
+
+	test("different aliases usually get different ports", () => {
+		expect(editorLocalPort("hetzner-devbox")).not.toBe(editorLocalPort("hetzner-ateam"));
+	});
+
+	test("forward flags target the shared default editor port", () => {
+		const flags = editorForwardFlags("box");
+		expect(flags[0]).toBe("-L");
+		expect(flags[1]).toBe(`${editorLocalPort("box")}:127.0.0.1:${DEFAULT_EDITOR_PORT}`);
+	});
+});

--- a/apps/desktop/src/main/editor-tunnel.ts
+++ b/apps/desktop/src/main/editor-tunnel.ts
@@ -1,0 +1,28 @@
+// The desktop half of reaching an SSH box's in-app editor: a `-L` local forward
+// opened WITH the RPC connection (transport/ssh.ts sshFlags), so the tunnel lives
+// and dies with the connection and no separate process needs managing. The local
+// port must be picked before the box is ever asked, so it's a pure function of
+// the alias.
+import { DEFAULT_EDITOR_PORT } from "@ateam/protocol";
+
+const BASE = 8391;
+const RANGE = 500;
+
+/** Deterministic local forward port for an alias (FNV-1a into BASE..BASE+RANGE). */
+export function editorLocalPort(alias: string): number {
+	let h = 0x811c9dc5;
+	for (let i = 0; i < alias.length; i++) {
+		h ^= alias.charCodeAt(i);
+		h = Math.imul(h, 0x01000193) >>> 0;
+	}
+	return BASE + (h % RANGE);
+}
+
+/**
+ * Extra ssh flags for connect time. shortcut: two aliases can hash to one local
+ * port — ssh then warns and skips the second forward (the connection itself is
+ * unaffected); derive from a persisted per-alias slot if that ever bites.
+ */
+export function editorForwardFlags(alias: string): string[] {
+	return ["-L", `${editorLocalPort(alias)}:127.0.0.1:${DEFAULT_EDITOR_PORT}`];
+}

--- a/apps/desktop/src/main/host.ts
+++ b/apps/desktop/src/main/host.ts
@@ -11,6 +11,8 @@ import {
 	CH,
 	type ClientTransport,
 	createRpcClient,
+	DEFAULT_EDITOR_PORT,
+	type EditorEndpointDTO,
 	PROTOCOL_VERSION,
 	type ProjectDTO,
 	type RpcClient,
@@ -61,6 +63,7 @@ import {
 	type Router,
 	remoteBackend,
 } from "./backend";
+import { editorForwardFlags, editorLocalPort } from "./editor-tunnel";
 import { withTimeout } from "./timeout";
 
 // The one pre-quoted remote command (ssh space-joins remote args, so `bash -lc`
@@ -130,6 +133,9 @@ export interface Host {
 	connected(): Promise<HostStatus[]>;
 	/** id → owning-engine alias (null = local), from the aggregate's learned registry. */
 	origins(): Record<string, string | null>;
+	/** Start the in-app editor on the task's engine and resolve the URL THIS
+	 *  client loads for it (localhost, ssh forward, or tailnet endpoint). */
+	editorUrl(taskId: string): Promise<{ url: string }>;
 	/** Connect the box if needed, then clone+register a repo ON it (from its remote URL). */
 	provision(alias: string, input: { cloneUrl: string }): Promise<ProjectDTO>;
 	/** Install the ateam engine on a reachable SSH box (idempotent), streaming the
@@ -257,7 +263,9 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 				`Unknown connection "${alias}" — add it to ~/.ssh/config, or give a Tailscale endpoint like 100.x.y.z:8787.`,
 			);
 		}
-		return sshClientTransport(alias, [REMOTE_ATTACH]);
+		// The editor forward rides the RPC child (idle forwards cost nothing), so
+		// the tunnel needs no lifecycle of its own — it dies with the connection.
+		return sshClientTransport(alias, [REMOTE_ATTACH], { sshFlags: editorForwardFlags(alias) });
 	}
 
 	async function connect(alias: string | null): Promise<HostStatus> {
@@ -583,6 +591,27 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 		});
 	}
 
+	async function editorUrl(taskId: string): Promise<{ url: string }> {
+		// Ask the OWNING engine to have its editor up before deciding how to reach it.
+		const ep = (await agg.handleFor(taskId, CH.editorOpen, [taskId])) as EditorEndpointDTO;
+		const backend = agg.ownerOf.get(taskId);
+		if (!backend || backend.kind === "local") return { url: `http://127.0.0.1:${ep.port}` };
+		let alias: string | null = null;
+		for (const [a, b] of backends) if (b === backend) alias = a;
+		if (!alias) throw new Error("This task's box is no longer connected.");
+		const ws = endpointUrl(alias);
+		// A ws box is reached over the tailnet — the editor binds that same interface
+		// (editorBindHost), so the alias's own host is the editor's host.
+		if (ws) return { url: `http://${new URL(ws).hostname}:${ep.port}` };
+		// ssh: the forward was opened at connect time against the DEFAULT port; a box
+		// overriding ATEAM_EDITOR_PORT would answer somewhere the tunnel doesn't reach.
+		if (ep.port !== DEFAULT_EDITOR_PORT)
+			throw new Error(
+				`"${alias}" runs its editor on port ${ep.port}, but the ssh forward targets ${DEFAULT_EDITOR_PORT}. Unset ATEAM_EDITOR_PORT on the box.`,
+			);
+		return { url: `http://127.0.0.1:${editorLocalPort(alias)}` };
+	}
+
 	return {
 		router,
 		list: async (): Promise<ConnectionDTO[]> => listConnections(db),
@@ -591,6 +620,7 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 		forget,
 		connected,
 		origins,
+		editorUrl,
 		provision,
 		install,
 		createBox,

--- a/apps/desktop/src/main/host.ts
+++ b/apps/desktop/src/main/host.ts
@@ -13,6 +13,7 @@ import {
 	createRpcClient,
 	DEFAULT_EDITOR_PORT,
 	type EditorEndpointDTO,
+	type EditorOpenResult,
 	PROTOCOL_VERSION,
 	type ProjectDTO,
 	type RpcClient,
@@ -134,8 +135,9 @@ export interface Host {
 	/** id → owning-engine alias (null = local), from the aggregate's learned registry. */
 	origins(): Record<string, string | null>;
 	/** Start the in-app editor on the task's engine and resolve the URL THIS
-	 *  client loads for it (localhost, ssh forward, or tailnet endpoint). */
-	editorUrl(taskId: string): Promise<{ url: string }>;
+	 *  client loads for it (localhost, ssh forward, or tailnet endpoint) — or
+	 *  report that the engine still needs code-server installed. */
+	editorUrl(taskId: string): Promise<{ url: string } | { needsInstall: true }>;
 	/** Connect the box if needed, then clone+register a repo ON it (from its remote URL). */
 	provision(alias: string, input: { cloneUrl: string }): Promise<ProjectDTO>;
 	/** Install the ateam engine on a reachable SSH box (idempotent), streaming the
@@ -591,9 +593,11 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 		});
 	}
 
-	async function editorUrl(taskId: string): Promise<{ url: string }> {
+	async function editorUrl(taskId: string): Promise<{ url: string } | { needsInstall: true }> {
 		// Ask the OWNING engine to have its editor up before deciding how to reach it.
-		const ep = (await agg.handleFor(taskId, CH.editorOpen, [taskId])) as EditorEndpointDTO;
+		const res = (await agg.handleFor(taskId, CH.editorOpen, [taskId])) as EditorOpenResult;
+		if ("needsInstall" in res) return res;
+		const ep: EditorEndpointDTO = res;
 		const backend = agg.ownerOf.get(taskId);
 		if (!backend || backend.kind === "local") return { url: `http://127.0.0.1:${ep.port}` };
 		let alias: string | null = null;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -350,7 +350,7 @@ app
 		// the engine's events to every window is the host's job now (see createHost);
 		// window management (detaching a project) is desktop-native, passed to registerIpc.
 		const host = createHost({ localEngine: engine, broadcast });
-		registerIpc(host.router, { openProjectWindow });
+		registerIpc(host.router, { openProjectWindow, editorUrl: host.editorUrl });
 		registerHostIpc(host);
 
 		if (SMOKE) {

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -64,6 +64,9 @@ const SEND_CHANNELS = new Set<string>([CH.ptyWrite, CH.ptyResize]);
 export interface NativeHandlers {
 	/** Detach a project into its own window (or focus its existing one). */
 	openProjectWindow: (projectId: string) => void;
+	/** Resolve the in-app editor URL for a task (starts it on the owning engine).
+	 *  Client-native because reaching the port is transport knowledge (host.ts). */
+	editorUrl: (taskId: string) => Promise<{ url: string }>;
 }
 
 /**
@@ -95,6 +98,8 @@ export function registerIpc(router: Router, native: NativeHandlers): void {
 
 	// Detach a project into its own OS window. Not an engine method — it drives
 	// BrowserWindows, which only the desktop host has.
+	ipcMain.handle(CH.editorOpenUrl, (_e, taskId: string) => native.editorUrl(taskId));
+
 	ipcMain.handle(CH.windowOpenProject, async (_e, projectId: string) => {
 		native.openProjectWindow(projectId);
 	});

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -1,6 +1,8 @@
-import { readFileSync } from "node:fs";
-import { extname } from "node:path";
-import { type AttachDelivery, CH } from "@ateam/protocol";
+import { spawn } from "node:child_process";
+import { accessSync, constants, readFileSync } from "node:fs";
+import { extname, join } from "node:path";
+import { type AttachDelivery, CH, type OpenInEditorResult } from "@ateam/protocol";
+import { endpointUrl } from "@ateam/server";
 import { clipboard, dialog, ipcMain, nativeImage } from "electron";
 import type { Router } from "./backend";
 
@@ -16,6 +18,42 @@ function stageImageOnClipboard(path: string | null): boolean {
 	if (img.isEmpty()) return false;
 	clipboard.writeImage(img);
 	return true;
+}
+
+/**
+ * The editors we can hand a folder to, in preference order. First one found wins,
+ * searched by editor rather than by PATH order so the choice is deterministic when
+ * a machine has several.
+ *
+ * shortcut: a fixed list, no preference setting. Add one if users ask for a
+ * different default than "whichever comes first here".
+ */
+const EDITORS = ["code", "cursor", "windsurf", "codium"] as const;
+
+/**
+ * Launched from Finder (rather than a shell) an Electron app inherits a bare PATH
+ * — no /usr/local/bin, no /opt/homebrew/bin — so a PATH-only lookup finds nothing
+ * in the packaged app even when the editor is plainly installed. Search the usual
+ * install dirs too.
+ */
+const EDITOR_DIRS = ["/opt/homebrew/bin", "/usr/local/bin"];
+
+/** Absolute path of the first installed editor, or null if none is on this Mac. */
+function findEditor(): string | null {
+	const dirs = [...(process.env.PATH?.split(":") ?? []), ...EDITOR_DIRS];
+	for (const cmd of EDITORS) {
+		for (const dir of dirs) {
+			if (!dir) continue;
+			const full = join(dir, cmd);
+			try {
+				accessSync(full, constants.X_OK);
+				return full;
+			} catch {
+				/* not here — keep looking */
+			}
+		}
+	}
+	return null;
 }
 
 // Channels the renderer calls with `ipcRenderer.send` (fire-and-forget) rather
@@ -141,4 +179,31 @@ export function registerIpc(router: Router, native: NativeHandlers): void {
 		const path = await router.handleFor(terminalId, CH.utilWriteImageBytes, [base64, "png"]);
 		return { mode: "paths", paths: [path as string] } satisfies AttachDelivery;
 	});
+
+	// Hand a task's worktree to the user's own editor. Client-native on purpose: the
+	// editor is a desktop app on THIS Mac, so this never routes to the engine. For a
+	// task on a box, VS Code's Remote-SSH opens the box-side path over the same
+	// ssh_config alias Ateam already connects with — the box needs no editor
+	// installed, the client pushes a server there on first connect.
+	ipcMain.handle(
+		CH.utilOpenInEditor,
+		async (_e, worktreePath: string, alias: string | null): Promise<OpenInEditorResult> => {
+			const editor = findEditor();
+			if (!editor)
+				return { ok: false, reason: `No editor found (looked for ${EDITORS.join(", ")}).` };
+			// A ws connection is a `host:port` endpoint, not an ssh_config alias, so
+			// Remote-SSH has nothing to resolve. Failing loudly beats the alternative:
+			// opening the path locally would silently show THIS Mac's copy of it.
+			if (alias !== null && endpointUrl(alias))
+				return {
+					ok: false,
+					reason: `"${alias}" is a direct endpoint, not an ssh_config alias. Remote-SSH needs an alias — add one to ~/.ssh/config and connect through it.`,
+				};
+			const args =
+				alias === null ? [worktreePath] : ["--remote", `ssh-remote+${alias}`, worktreePath];
+			// Detached: the editor outlives Ateam, and must not die with it.
+			spawn(editor, args, { detached: true, stdio: "ignore" }).unref();
+			return { ok: true };
+		},
+	);
 }

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -66,7 +66,7 @@ export interface NativeHandlers {
 	openProjectWindow: (projectId: string) => void;
 	/** Resolve the in-app editor URL for a task (starts it on the owning engine).
 	 *  Client-native because reaching the port is transport knowledge (host.ts). */
-	editorUrl: (taskId: string) => Promise<{ url: string }>;
+	editorUrl: (taskId: string) => Promise<{ url: string } | { needsInstall: true }>;
 }
 
 /**

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -89,6 +89,8 @@ const api: AteamApi = {
 		attachClipboardImage: (terminalId) =>
 			ipcRenderer.invoke(CH.utilAttachClipboardImage, terminalId),
 		writeImageBytes: (base64, ext) => ipcRenderer.invoke(CH.utilWriteImageBytes, base64, ext),
+		openInEditor: (worktreePath, alias) =>
+			ipcRenderer.invoke(CH.utilOpenInEditor, worktreePath, alias),
 	},
 	events: {
 		onTaskUpdated: (cb: (task: TaskDTO) => void) => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -46,6 +46,9 @@ const api: AteamApi = {
 	agents: {
 		list: () => ipcRenderer.invoke(CH.agentsList),
 	},
+	editor: {
+		open: (taskId) => ipcRenderer.invoke(CH.editorOpenUrl, taskId),
+	},
 	search: {
 		sessions: (input) => ipcRenderer.invoke(CH.searchSessions, input),
 	},

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -48,6 +48,7 @@ const api: AteamApi = {
 	},
 	editor: {
 		open: (taskId) => ipcRenderer.invoke(CH.editorOpenUrl, taskId),
+		install: (taskId) => ipcRenderer.invoke(CH.editorInstall, taskId),
 	},
 	search: {
 		sessions: (input) => ipcRenderer.invoke(CH.searchSessions, input),

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; script-src 'self'"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; script-src 'self'; frame-src 'self' http:"
     />
     <title>Ateam</title>
   </head>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1561,6 +1561,18 @@ function TaskPanel({
 
 				<span className="spacer" />
 
+				<IconButton
+					icon={ExternalLink}
+					label={alias === null ? "Open worktree in your editor" : `Open worktree in your editor (Remote-SSH: ${alias})`}
+					onClick={() =>
+						run(async () => {
+							// Optional on the API surface (the phone omits it) — the desktop
+							// preload always provides it.
+							const res = await window.ateam.utils.openInEditor?.(task.worktreePath, alias);
+							if (res && !res.ok) throw new Error(res.reason);
+						})
+					}
+				/>
 				<IconButton icon={GitCommitVertical} label="Commit all changes" onClick={commit} />
 				<IconButton
 					icon={ArrowUp}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -22,6 +22,7 @@ import {
 	Columns2,
 	Database,
 	ExternalLink,
+	FileCode,
 	FilePen,
 	FlaskConical,
 	FolderPlus,
@@ -1432,6 +1433,10 @@ function TaskPanel({
 	const [sessionComposerOpen, setSessionComposerOpen] = useState(false);
 	const [diff, setDiff] = useState<DiffResultDTO | null>(null);
 	const [changesOpen, setChangesOpen] = useState(false);
+	// The in-app editor (VS Code on the task's machine). Once loaded, the iframe
+	// stays mounted and is only hidden — unmounting would drop unsaved buffers.
+	const [editorSrc, setEditorSrc] = useState<string | null>(null);
+	const [editorOpen, setEditorOpen] = useState(false);
 	const [viewFile, setViewFile] = useState<string | null>(null);
 	// This task's live PTY sessions — agents and shells alike. They ARE the tabs:
 	// the daemon already owns as many per task as you like, so there is nothing
@@ -1566,6 +1571,7 @@ function TaskPanel({
 		}
 		refreshDiff();
 		setChangesOpen(true);
+		setEditorOpen(false);
 		if (!viewFile && diff?.files[0]) setViewFile(diff.files[0].path);
 	};
 
@@ -1675,6 +1681,27 @@ function TaskPanel({
 				<span className="spacer" />
 
 				<IconButton
+					icon={FileCode}
+					label={editorOpen ? "Back to terminal" : "Edit files (VS Code on the task's machine)"}
+					onClick={() => {
+						if (editorOpen) {
+							setEditorOpen(false);
+							return;
+						}
+						if (editorSrc) {
+							setEditorOpen(true);
+							setChangesOpen(false);
+							return;
+						}
+						void run(async () => {
+							const { url } = await window.ateam.editor.open(task.id);
+							setEditorSrc(`${url}/?folder=${encodeURIComponent(task.worktreePath)}`);
+							setEditorOpen(true);
+							setChangesOpen(false);
+						});
+					}}
+				/>
+				<IconButton
 					icon={ExternalLink}
 					label={alias === null ? "Open worktree in your editor" : `Open worktree in your editor (Remote-SSH: ${alias})`}
 					onClick={() =>
@@ -1767,7 +1794,10 @@ function TaskPanel({
 			<div className="panel-body">
 				{/* Keep the terminal mounted (xterm state survives) while the
 				    changes view is open — just hide it. */}
-				<div className="term-wrap" style={{ display: changesOpen ? "none" : "flex" }}>
+				<div
+					className="term-wrap"
+					style={{ display: changesOpen || editorOpen ? "none" : "flex" }}
+				>
 					{terminalId ? (
 						<TerminalView
 							terminalId={terminalId}
@@ -1796,6 +1826,13 @@ function TaskPanel({
 						onClose={() => setSessionComposerOpen(false)}
 						onCreate={composeSession}
 					/>
+				)}
+
+				{editorSrc && (
+					<div className="editor-wrap" style={{ display: editorOpen ? "flex" : "none" }}>
+						{/* VS Code web (code-server) on the task's engine, scoped to the worktree. */}
+						<iframe className="editor-frame" src={editorSrc} title="Editor" />
+					</div>
 				)}
 
 				{changesOpen && (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1437,6 +1437,7 @@ function TaskPanel({
 	// stays mounted and is only hidden — unmounting would drop unsaved buffers.
 	const [editorSrc, setEditorSrc] = useState<string | null>(null);
 	const [editorOpen, setEditorOpen] = useState(false);
+	const [editorBusy, setEditorBusy] = useState<string | null>(null);
 	const [viewFile, setViewFile] = useState<string | null>(null);
 	// This task's live PTY sessions — agents and shells alike. They ARE the tabs:
 	// the daemon already owns as many per task as you like, so there is nothing
@@ -1694,8 +1695,32 @@ function TaskPanel({
 							return;
 						}
 						void run(async () => {
-							const { url } = await window.ateam.editor.open(task.id);
-							setEditorSrc(`${url}/?folder=${encodeURIComponent(task.worktreePath)}`);
+							let res = await window.ateam.editor.open(task.id);
+							if ("needsInstall" in res) {
+								// Inline coding is optional — nothing is installed without a yes.
+								const where = alias === null ? "this Mac" : `"${alias}"`;
+								const ok = await confirm(
+									"Install the inline editor?",
+									`Inline coding runs VS Code (code-server) on ${where} — a one-time, user-space install (~200 MB, no root). Install it now? It takes about a minute.`,
+								);
+								if (!ok) return;
+								setEditorOpen(true);
+								setChangesOpen(false);
+								setEditorBusy(`Installing the inline editor on ${where}…`);
+								try {
+									await window.ateam.editor.install(task.id);
+									res = await window.ateam.editor.open(task.id);
+									if ("needsInstall" in res)
+										throw new Error("Install finished but the editor is still missing.");
+								} catch (e) {
+									// Back to the terminal — a blank editor pane would hide it.
+									setEditorOpen(false);
+									throw e;
+								} finally {
+									setEditorBusy(null);
+								}
+							}
+							setEditorSrc(`${res.url}/?folder=${encodeURIComponent(task.worktreePath)}`);
 							setEditorOpen(true);
 							setChangesOpen(false);
 						});
@@ -1828,10 +1853,16 @@ function TaskPanel({
 					/>
 				)}
 
-				{editorSrc && (
+				{(editorSrc || editorBusy) && (
 					<div className="editor-wrap" style={{ display: editorOpen ? "flex" : "none" }}>
 						{/* VS Code web (code-server) on the task's engine, scoped to the worktree. */}
-						<iframe className="editor-frame" src={editorSrc} title="Editor" />
+						{editorSrc ? (
+							<iframe className="editor-frame" src={editorSrc} title="Editor" />
+						) : (
+							<div className="muted" style={{ display: "grid", placeItems: "center", flex: 1 }}>
+								{editorBusy}
+							</div>
+						)}
 					</div>
 				)}
 

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -931,6 +931,18 @@ input {
 }
 
 /* changes view: GitHub-Desktop layout — file list left, diff right */
+/* In-app editor (VS Code web in an iframe), filling the panel like the terminal. */
+.editor-wrap {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+}
+.editor-frame {
+	flex: 1;
+	border: 0;
+	background: #1e1e1e;
+}
+
 .changes-view {
 	flex: 1;
 	min-width: 0;

--- a/packages/protocol/src/client-api.ts
+++ b/packages/protocol/src/client-api.ts
@@ -66,7 +66,7 @@ export interface NativeClientApi {
 	/** Resolve the in-app editor URL for a task — how a client REACHES the engine's
 	 *  editor is transport knowledge only the client has. Optional: a client without
 	 *  an editor surface omits it and AteamApi.editor.open rejects with guidance. */
-	editorOpen?(taskId: string): Promise<{ url: string }>;
+	editorOpen?(taskId: string): Promise<{ url: string } | { needsInstall: true }>;
 }
 
 /** Build the full AteamApi over an RpcClient, delegating client-local bits to `native`. */
@@ -110,6 +110,7 @@ export function buildAteamApi(rpc: RpcClient, native: NativeClientApi): AteamApi
 			open:
 				native.editorOpen ??
 				(() => Promise.reject(new Error("This client has no editor surface."))),
+			install: (taskId) => call<void>(CH.editorInstall, [taskId]),
 		},
 		search: {
 			sessions: (input) => call<SessionHitDTO[]>(CH.searchSessions, [input]),

--- a/packages/protocol/src/client-api.ts
+++ b/packages/protocol/src/client-api.ts
@@ -63,6 +63,10 @@ export interface NativeClientApi {
 	// so the window surface is client-native too. A single-window client stubs these.
 	openProject(projectId: string): Promise<void>;
 	boundProjectId(): string | null;
+	/** Resolve the in-app editor URL for a task — how a client REACHES the engine's
+	 *  editor is transport knowledge only the client has. Optional: a client without
+	 *  an editor surface omits it and AteamApi.editor.open rejects with guidance. */
+	editorOpen?(taskId: string): Promise<{ url: string }>;
 }
 
 /** Build the full AteamApi over an RpcClient, delegating client-local bits to `native`. */
@@ -101,6 +105,11 @@ export function buildAteamApi(rpc: RpcClient, native: NativeClientApi): AteamApi
 		},
 		agents: {
 			list: () => call<AgentDTO[]>(CH.agentsList),
+		},
+		editor: {
+			open:
+				native.editorOpen ??
+				(() => Promise.reject(new Error("This client has no editor surface."))),
 		},
 		search: {
 			sessions: (input) => call<SessionHitDTO[]>(CH.searchSessions, [input]),

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -340,6 +340,8 @@ export const CH = {
 	utilAttachClipboardImage: "util:attachClipboardImage",
 	utilWriteImageBytes: "util:writeImageBytes",
 	utilOpenInEditor: "util:openInEditor",
+	editorOpen: "editor:open",
+	editorOpenUrl: "editor:openUrl",
 	ptySpawnAgent: "pty:spawnAgent",
 	ptySpawnShell: "pty:spawnShell",
 	ptyWrite: "pty:write",
@@ -397,6 +399,20 @@ export type AttachDelivery =
  */
 export type OpenInEditorResult = { ok: true } | { ok: false; reason: string };
 
+/**
+ * The in-app editor's default port on the engine's machine (code-server). Shared
+ * between the engine (which binds it) and the desktop's SSH forward (which is
+ * opened at connect time, before the engine is asked) — so both sides must agree.
+ * shortcut: a box overriding ATEAM_EDITOR_PORT breaks the ssh path; carry the
+ * port in system:hello if that override ever matters.
+ */
+export const DEFAULT_EDITOR_PORT = 8390;
+
+/** Where the engine's embedded editor (code-server) answers, on ITS machine. */
+export interface EditorEndpointDTO {
+	port: number;
+}
+
 // ---- the API surface exposed on window.ateam ----
 export interface AteamApi {
 	projects: {
@@ -448,6 +464,15 @@ export interface AteamApi {
 		 * the shortlist and says why each one matched.
 		 */
 		sessions(input: { projectId: string; query: string; ai?: boolean }): Promise<SessionHitDTO[]>;
+	};
+	editor: {
+		/**
+		 * Start (or reuse) the in-app editor for this task's engine and resolve the
+		 * URL THIS client should load — tunneled for an SSH box, direct for a
+		 * Tailscale endpoint, localhost for the local engine. The page is VS Code
+		 * (code-server) on the task's machine; callers append ?folder=<worktree>.
+		 */
+		open(taskId: string): Promise<{ url: string }>;
 	};
 	fs: {
 		/**

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -311,6 +311,7 @@ export const CH = {
 	utilAttachImages: "util:attachImages",
 	utilAttachClipboardImage: "util:attachClipboardImage",
 	utilWriteImageBytes: "util:writeImageBytes",
+	utilOpenInEditor: "util:openInEditor",
 	ptySpawnAgent: "pty:spawnAgent",
 	ptySpawnShell: "pty:spawnShell",
 	ptyWrite: "pty:write",
@@ -360,6 +361,13 @@ export type AttachDelivery =
 	| { mode: "ctrlv" }
 	| { mode: "paths"; paths: string[] }
 	| { mode: "none" };
+
+/**
+ * Outcome of handing a worktree to the user's own editor. `ok: false` carries a
+ * reason to show — the editor isn't installed, or the task's engine is reached by
+ * a `host:port` endpoint that Remote-SSH can't resolve.
+ */
+export type OpenInEditorResult = { ok: true } | { ok: false; reason: string };
 
 // ---- the API surface exposed on window.ateam ----
 export interface AteamApi {
@@ -499,6 +507,15 @@ export interface AteamApi {
 		 * instead of a bitmap on the clipboard. `ext` sets the extension (default "png").
 		 */
 		writeImageBytes(base64: string, ext?: string): Promise<string>;
+		/**
+		 * Open a task's worktree in the user's own editor, on THIS machine. Client-native
+		 * (the editor is a desktop app, not something the engine can launch), so it never
+		 * routes to the engine: a task on a box is opened over VS Code's Remote-SSH using
+		 * the same ssh_config alias Ateam connects with. Optional — a client with no
+		 * desktop editor to hand off to (the phone) simply omits it, and callers hide the
+		 * affordance rather than offering one that can't work.
+		 */
+		openInEditor?(worktreePath: string, alias: string | null): Promise<OpenInEditorResult>;
 	};
 }
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -342,6 +342,7 @@ export const CH = {
 	utilOpenInEditor: "util:openInEditor",
 	editorOpen: "editor:open",
 	editorOpenUrl: "editor:openUrl",
+	editorInstall: "editor:install",
 	ptySpawnAgent: "pty:spawnAgent",
 	ptySpawnShell: "pty:spawnShell",
 	ptyWrite: "pty:write",
@@ -413,6 +414,13 @@ export interface EditorEndpointDTO {
 	port: number;
 }
 
+/**
+ * editor:open's answer: the endpoint, or "code-server isn't installed here" —
+ * a state, not an error, so clients can front the install with a consent dialog
+ * instead of parsing an exception.
+ */
+export type EditorOpenResult = EditorEndpointDTO | { needsInstall: true };
+
 // ---- the API surface exposed on window.ateam ----
 export interface AteamApi {
 	projects: {
@@ -472,7 +480,13 @@ export interface AteamApi {
 		 * Tailscale endpoint, localhost for the local engine. The page is VS Code
 		 * (code-server) on the task's machine; callers append ?folder=<worktree>.
 		 */
-		open(taskId: string): Promise<{ url: string }>;
+		open(taskId: string): Promise<{ url: string } | { needsInstall: true }>;
+		/**
+		 * Install code-server on the task's engine (one-time, user-space, pinned
+		 * version). Call only after the user consented to a needsInstall answer.
+		 * Resolves when installed; a following open() starts it.
+		 */
+		install(taskId: string): Promise<void>;
 	};
 	fs: {
 		/**

--- a/packages/server/src/dispatcher.ts
+++ b/packages/server/src/dispatcher.ts
@@ -35,7 +35,7 @@ import {
 	PROTOCOL_VERSION,
 	type UpdateLoopInput,
 } from "@ateam/protocol";
-import { createEditorHost } from "./editor";
+import { createEditorHost, installCodeServer } from "./editor";
 import type { Engine } from "./engine";
 import { LOOP_TEMPLATES } from "./loops/templates";
 import { type Services, toProjectDTO, toSessionDTO, toTaskDTO } from "./services";
@@ -422,6 +422,13 @@ export function createDispatcher(engine: Engine): Dispatcher {
 		[CH.editorOpen]: async (taskId: string) => {
 			requireTask(services, taskId);
 			return editorHost.ensure();
+		},
+		// Consent-gated: clients call this only after the user said yes to a
+		// needsInstall answer. Long-running (a ~200MB download); RPC calls have no
+		// per-call timeout, so the client just awaits it.
+		[CH.editorInstall]: async (taskId: string) => {
+			requireTask(services, taskId);
+			await installCodeServer();
 		},
 
 		// ---- fs / util: server-side, remote-native (browse + attach on the

--- a/packages/server/src/dispatcher.ts
+++ b/packages/server/src/dispatcher.ts
@@ -35,6 +35,7 @@ import {
 	PROTOCOL_VERSION,
 	type UpdateLoopInput,
 } from "@ateam/protocol";
+import { createEditorHost } from "./editor";
 import type { Engine } from "./engine";
 import { LOOP_TEMPLATES } from "./loops/templates";
 import { type Services, toProjectDTO, toSessionDTO, toTaskDTO } from "./services";
@@ -99,6 +100,8 @@ export interface Dispatcher {
 export function createDispatcher(engine: Engine): Dispatcher {
 	const { services } = engine;
 	const { db, mergeQueue, loopRunner } = services;
+	// Lazy: no code-server process exists until the first editor:open.
+	const editorHost = createEditorHost();
 
 	// ---- cleanup: remove only merged + idle + clean worktrees ----
 	// A task is removable ONLY when it merged, has no live agent session, and its
@@ -411,6 +414,14 @@ export function createDispatcher(engine: Engine): Dispatcher {
 				protocolVersion: PROTOCOL_VERSION,
 				agents: agents.filter((a) => a.available).map((a) => a.id),
 			};
+		},
+
+		// ---- editor: the engine-side half of the in-app editor (code-server on
+		// THIS machine). taskId scopes it to an engine (and routes it there); the
+		// worktree itself is picked client-side via the URL's ?folder= param. ----
+		[CH.editorOpen]: async (taskId: string) => {
+			requireTask(services, taskId);
+			return editorHost.ensure();
 		},
 
 		// ---- fs / util: server-side, remote-native (browse + attach on the

--- a/packages/server/src/editor.ts
+++ b/packages/server/src/editor.ts
@@ -1,0 +1,135 @@
+// The engine's embedded editor: one code-server process per engine, started on
+// demand, serving every task worktree via VS Code web's ?folder= URL. The engine
+// only knows how to RUN it on its own machine; how a client reaches the port
+// (ssh forward, tailnet, localhost) is the client's transport knowledge.
+import { type ChildProcess, spawn } from "node:child_process";
+import { accessSync, constants, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { DEFAULT_EDITOR_PORT, type EditorEndpointDTO } from "@ateam/protocol";
+
+/** Where the standalone install puts the binary (plus the usual system dirs). */
+const BIN_CANDIDATES = [
+	join(homedir(), ".local", "bin", "code-server"),
+	"/usr/local/bin/code-server",
+	"/opt/homebrew/bin/code-server",
+];
+
+export const INSTALL_HINT =
+	"code-server isn't installed on this machine. Install it with: " +
+	"curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=$HOME/.local";
+
+/** Absolute path of the code-server binary, or null. `env` injectable for tests. */
+export function findCodeServer(env: NodeJS.ProcessEnv = process.env): string | null {
+	const candidates = [
+		...(env.ATEAM_CODE_SERVER_BIN ? [env.ATEAM_CODE_SERVER_BIN] : []),
+		...BIN_CANDIDATES,
+		...(env.PATH?.split(":") ?? []).filter(Boolean).map((d) => join(d, "code-server")),
+	];
+	for (const bin of candidates) {
+		try {
+			accessSync(bin, constants.X_OK);
+			return bin;
+		} catch {
+			/* keep looking */
+		}
+	}
+	return null;
+}
+
+/**
+ * The interface the editor binds. Mirrors how the daemon itself is exposed: with
+ * ATEAM_WS_ADDR set the box serves clients over the tailnet, so the editor binds
+ * the same address (same trust boundary); otherwise loopback only, reached over
+ * the client's ssh forward.
+ */
+export function editorBindHost(env: NodeJS.ProcessEnv = process.env): string {
+	const ws = env.ATEAM_WS_ADDR;
+	if (!ws) return "127.0.0.1";
+	const host = ws.replace(/:\d+$/, "");
+	return host.length > 0 ? host : "127.0.0.1";
+}
+
+/**
+ * Seed code-server's user settings ONCE, before its first run: Ateam-dark theme
+ * and workspace trust off (every task is a new worktree — a per-folder trust
+ * prompt would fire on each one). Never touches an existing settings file: after
+ * first run the file is the user's.
+ */
+export function preseedUserSettings(dataDir = join(homedir(), ".local", "share", "code-server")) {
+	const file = join(dataDir, "User", "settings.json");
+	if (existsSync(file)) return;
+	mkdirSync(dirname(file), { recursive: true });
+	writeFileSync(
+		file,
+		`${JSON.stringify(
+			{
+				"workbench.colorTheme": "Default Dark Modern",
+				"security.workspace.trust.enabled": false,
+			},
+			null,
+			2,
+		)}\n`,
+	);
+}
+
+export interface EditorHost {
+	/** Start (or reuse) the editor; resolves when it answers HTTP. */
+	ensure(): Promise<EditorEndpointDTO>;
+}
+
+export function createEditorHost(env: NodeJS.ProcessEnv = process.env): EditorHost {
+	const port = Number(env.ATEAM_EDITOR_PORT) || DEFAULT_EDITOR_PORT;
+	let child: ChildProcess | null = null;
+	let starting: Promise<EditorEndpointDTO> | null = null;
+
+	async function waitReady(host: string): Promise<void> {
+		// code-server exposes /healthz without auth; poll until it answers.
+		for (let i = 0; i < 60; i++) {
+			try {
+				const res = await fetch(`http://${host}:${port}/healthz`, {
+					signal: AbortSignal.timeout(1000),
+				});
+				if (res.ok) return;
+			} catch {
+				/* not up yet */
+			}
+			await new Promise((r) => setTimeout(r, 250));
+		}
+		throw new Error(`The editor didn't answer on port ${port} within 15s.`);
+	}
+
+	function start(): Promise<EditorEndpointDTO> {
+		const bin = findCodeServer(env);
+		if (!bin) return Promise.reject(new Error(INSTALL_HINT));
+		const host = editorBindHost(env);
+		preseedUserSettings();
+		const proc = spawn(
+			bin,
+			["--bind-addr", `${host}:${port}`, "--auth", "none", "--disable-telemetry"],
+			{ stdio: "ignore" },
+		);
+		child = proc;
+		proc.on("exit", () => {
+			if (child === proc) child = null;
+		});
+		// Tie the editor to the engine's life — an orphaned code-server would keep
+		// the port and make the next engine's spawn fail silently.
+		process.on("exit", () => proc.kill());
+		return waitReady(host).then(() => ({ port }));
+	}
+
+	return {
+		ensure() {
+			// Alive child answering = reuse; a died child (crash, external kill)
+			// falls through to a fresh start.
+			if (child && child.exitCode === null) return Promise.resolve({ port });
+			if (!starting) {
+				starting = start().finally(() => {
+					starting = null;
+				});
+			}
+			return starting;
+		},
+	};
+}

--- a/packages/server/src/editor.ts
+++ b/packages/server/src/editor.ts
@@ -2,11 +2,15 @@
 // demand, serving every task worktree via VS Code web's ?folder= URL. The engine
 // only knows how to RUN it on its own machine; how a client reaches the port
 // (ssh forward, tailnet, localhost) is the client's transport knowledge.
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, execFile, spawn } from "node:child_process";
 import { accessSync, constants, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { DEFAULT_EDITOR_PORT, type EditorEndpointDTO } from "@ateam/protocol";
+import {
+	DEFAULT_EDITOR_PORT,
+	type EditorEndpointDTO,
+	type EditorOpenResult,
+} from "@ateam/protocol";
 
 /** Where the standalone install puts the binary (plus the usual system dirs). */
 const BIN_CANDIDATES = [
@@ -15,9 +19,28 @@ const BIN_CANDIDATES = [
 	"/opt/homebrew/bin/code-server",
 ];
 
-export const INSTALL_HINT =
-	"code-server isn't installed on this machine. Install it with: " +
-	"curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=$HOME/.local";
+/** The build the Editor tab was tested against; installs are pinned to it so a
+ *  fleet of boxes doesn't drift. Bumped deliberately, with an Ateam release. */
+export const CODE_SERVER_VERSION = "4.135.0";
+
+/** The official standalone installer: user-space, no root, ~/.local prefix. */
+export const INSTALL_CMD =
+	"curl -fsSL https://code-server.dev/install.sh | " +
+	`sh -s -- --method=standalone --prefix=$HOME/.local --version ${CODE_SERVER_VERSION}`;
+
+/**
+ * Run the installer on THIS machine. Consent lives with the caller — engines
+ * only ever run this after a client relayed the user's yes.
+ */
+export function installCodeServer(env: NodeJS.ProcessEnv = process.env): Promise<void> {
+	return new Promise((resolve, reject) => {
+		execFile("sh", ["-c", INSTALL_CMD], { timeout: 10 * 60_000 }, (err, _out, stderr) => {
+			if (!err && findCodeServer(env)) return resolve();
+			const tail = (stderr ?? "").trim().split("\n").slice(-3).join(" ");
+			reject(new Error(`code-server install failed${tail ? `: ${tail}` : ""}`));
+		});
+	});
+}
 
 /** Absolute path of the code-server binary, or null. `env` injectable for tests. */
 export function findCodeServer(env: NodeJS.ProcessEnv = process.env): string | null {
@@ -74,14 +97,14 @@ export function preseedUserSettings(dataDir = join(homedir(), ".local", "share",
 }
 
 export interface EditorHost {
-	/** Start (or reuse) the editor; resolves when it answers HTTP. */
-	ensure(): Promise<EditorEndpointDTO>;
+	/** Start (or reuse) the editor; `needsInstall` when the binary is absent. */
+	ensure(): Promise<EditorOpenResult>;
 }
 
 export function createEditorHost(env: NodeJS.ProcessEnv = process.env): EditorHost {
 	const port = Number(env.ATEAM_EDITOR_PORT) || DEFAULT_EDITOR_PORT;
 	let child: ChildProcess | null = null;
-	let starting: Promise<EditorEndpointDTO> | null = null;
+	let starting: Promise<EditorOpenResult> | null = null;
 
 	async function waitReady(host: string): Promise<void> {
 		// code-server exposes /healthz without auth; poll until it answers.
@@ -99,9 +122,7 @@ export function createEditorHost(env: NodeJS.ProcessEnv = process.env): EditorHo
 		throw new Error(`The editor didn't answer on port ${port} within 15s.`);
 	}
 
-	function start(): Promise<EditorEndpointDTO> {
-		const bin = findCodeServer(env);
-		if (!bin) return Promise.reject(new Error(INSTALL_HINT));
+	function start(bin: string): Promise<EditorEndpointDTO> {
 		const host = editorBindHost(env);
 		preseedUserSettings();
 		const proc = spawn(
@@ -124,8 +145,10 @@ export function createEditorHost(env: NodeJS.ProcessEnv = process.env): EditorHo
 			// Alive child answering = reuse; a died child (crash, external kill)
 			// falls through to a fresh start.
 			if (child && child.exitCode === null) return Promise.resolve({ port });
+			const bin = findCodeServer(env);
+			if (!bin) return Promise.resolve({ needsInstall: true });
 			if (!starting) {
-				starting = start().finally(() => {
+				starting = start(bin).finally(() => {
 					starting = null;
 				});
 			}

--- a/packages/server/test/editor.test.ts
+++ b/packages/server/test/editor.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { editorBindHost, findCodeServer, preseedUserSettings } from "../src/editor";
+import {
+	CODE_SERVER_VERSION,
+	editorBindHost,
+	findCodeServer,
+	INSTALL_CMD,
+	preseedUserSettings,
+} from "../src/editor";
 
 describe("editor: findCodeServer", () => {
 	test("env override wins when executable", () => {
@@ -50,5 +56,14 @@ describe("editor: preseedUserSettings", () => {
 		mkdirSync(dataDir, { recursive: true });
 		preseedUserSettings(dataDir);
 		expect(existsSync(join(dataDir, "User", "settings.json"))).toBe(true);
+	});
+});
+
+describe("editor: install command", () => {
+	test("official installer, standalone, user prefix, pinned version", () => {
+		expect(INSTALL_CMD).toContain("https://code-server.dev/install.sh");
+		expect(INSTALL_CMD).toContain("--method=standalone");
+		expect(INSTALL_CMD).toContain("--prefix=$HOME/.local");
+		expect(INSTALL_CMD).toContain(`--version ${CODE_SERVER_VERSION}`);
 	});
 });

--- a/packages/server/test/editor.test.ts
+++ b/packages/server/test/editor.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { editorBindHost, findCodeServer, preseedUserSettings } from "../src/editor";
+
+describe("editor: findCodeServer", () => {
+	test("env override wins when executable", () => {
+		const dir = mkdtempSync(join(tmpdir(), "ed-"));
+		const bin = join(dir, "code-server");
+		writeFileSync(bin, "#!/bin/sh\n", { mode: 0o755 });
+		expect(findCodeServer({ ATEAM_CODE_SERVER_BIN: bin, PATH: "" })).toBe(bin);
+	});
+
+	test("null when nothing is installed anywhere on PATH", () => {
+		const empty = mkdtempSync(join(tmpdir(), "ed-empty-"));
+		// Standard locations may exist on a dev machine; PATH-only probe is what
+		// this asserts, via a PATH that can't contain the binary.
+		const found = findCodeServer({ PATH: empty });
+		if (found !== null) expect(found.startsWith(empty)).toBe(false);
+	});
+});
+
+describe("editor: bind interface mirrors the daemon's exposure", () => {
+	test("loopback without ATEAM_WS_ADDR", () => {
+		expect(editorBindHost({})).toBe("127.0.0.1");
+	});
+	test("tailnet host when the daemon serves one", () => {
+		expect(editorBindHost({ ATEAM_WS_ADDR: "100.72.63.61:8787" })).toBe("100.72.63.61");
+	});
+});
+
+describe("editor: preseedUserSettings", () => {
+	test("writes dark theme + trust-off once, never clobbers", () => {
+		const dataDir = mkdtempSync(join(tmpdir(), "ed-seed-"));
+		preseedUserSettings(dataDir);
+		const file = join(dataDir, "User", "settings.json");
+		expect(existsSync(file)).toBe(true);
+		const seeded = JSON.parse(readFileSync(file, "utf8"));
+		expect(seeded["workbench.colorTheme"]).toBe("Default Dark Modern");
+		expect(seeded["security.workspace.trust.enabled"]).toBe(false);
+
+		writeFileSync(file, '{"workbench.colorTheme":"Mine"}');
+		preseedUserSettings(dataDir);
+		expect(JSON.parse(readFileSync(file, "utf8"))["workbench.colorTheme"]).toBe("Mine");
+	});
+
+	test("creates the User dir when missing", () => {
+		const dataDir = join(mkdtempSync(join(tmpdir(), "ed-deep-")), "nested");
+		mkdirSync(dataDir, { recursive: true });
+		preseedUserSettings(dataDir);
+		expect(existsSync(join(dataDir, "User", "settings.json"))).toBe(true);
+	});
+});


### PR DESCRIPTION
Adds an Editor view to the task panel: VS Code web (code-server) running on the task's engine, shown in an iframe, scoped to the task's worktree via ?folder=.

Engine side: editor:open starts one code-server per engine on demand (binds loopback, or the tailnet interface when ATEAM_WS_ADDR serves one) and preseeds dark theme + workspace-trust-off once, never touching existing user settings. When code-server is absent it answers needsInstall instead of erroring; editor:install runs the official standalone installer (user-space, pinned version) only after the user confirms a consent dialog naming the machine and the cost. The panel shows an installing placeholder meanwhile and falls back to the terminal on failure.

Client side: the URL is transport knowledge. Local tasks use localhost; ssh boxes get a connect-time -L forward riding the existing RPC ssh child (deterministic per-alias local port, no tunnel lifecycle); ws boxes are reached directly on their Tailscale host. The iframe stays mounted once loaded so unsaved buffers survive tab switches; CSP gains frame-src for it. Existing box engines simply gate on their next update.