### PR TITLE
Board: make "running" tell the truth, rank what needs you, and tag tasks with a model

### DIFF
--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -30,6 +30,7 @@ const api: AteamApi = {
 		create: (input) => ipcRenderer.invoke(CH.tasksCreate, input),
 		remove: (input) => ipcRenderer.invoke(CH.tasksRemove, input),
 		setColumn: (id, column: KanbanColumn) => ipcRenderer.invoke(CH.tasksSetColumn, id, column),
+		markRead: (id) => ipcRenderer.invoke(CH.tasksMarkRead, id),
 		cleanupPreview: (projectId) => ipcRenderer.invoke(CH.tasksCleanupPreview, projectId),
 		cleanup: (projectId) => ipcRenderer.invoke(CH.tasksCleanup, projectId),
 		cleanupCandidates: (projectId) => ipcRenderer.invoke(CH.tasksCleanupCandidates, projectId),

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -55,7 +55,7 @@ import { Menu } from "./components/Menu";
 import { NewTaskComposer } from "./components/NewTaskComposer";
 import { TerminalView } from "./components/Terminal";
 import { usePrompt } from "./components/usePrompt";
-import { matchesTagQuery, taskIcon, taskTags } from "./task-tags";
+import { matchesTagQuery, tagsFor, taskIcon } from "./task-tags";
 import { byWhatsNext, relativeAge } from "./triage-order";
 import { type Alias, aliasLabel, type UnifiedProject, unifyProjects } from "./unify";
 
@@ -451,7 +451,7 @@ export function App() {
 	const matchesQuery = useCallback(
 		(t: TaskDTO) => {
 			if (query === "") return true;
-			if (query.startsWith("#")) return matchesTagQuery(query, t.name, t.description);
+			if (query.startsWith("#")) return matchesTagQuery(query, t);
 			return (
 				t.name.toLowerCase().includes(query) ||
 				t.branch.toLowerCase().includes(query) ||
@@ -1208,7 +1208,7 @@ function Board({
 							{col.label} <span className="count">{items.length}</span>
 						</h3>
 						{items.map((t) => {
-							const tags = taskTags(t.name, t.description);
+							const tags = tagsFor(t);
 							return (
 								<motion.div
 									key={t.id}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -10,42 +10,29 @@ import {
 	ArrowDownToLine,
 	ArrowUp,
 	ArrowUpDown,
-	BookOpen,
 	Brush,
-	Bug,
 	Check,
 	ChevronDown,
 	ChevronRight,
 	Columns2,
-	Database,
 	ExternalLink,
-	FilePen,
-	FlaskConical,
 	FolderPlus,
-	Gauge,
-	GitBranch,
 	GitCommitVertical,
 	GitMerge,
 	History,
 	LayoutGrid,
-	Lock,
-	type LucideIcon,
 	Maximize2,
 	Minimize2,
 	Monitor,
-	Palette,
 	PanelLeft,
 	Play,
 	Plus,
-	Rocket,
 	RotateCw,
 	Rows2,
 	Search,
 	Server,
-	Sparkles,
 	SquareTerminal,
 	Trash2,
-	Wrench,
 	X,
 	Zap,
 } from "lucide-react";
@@ -68,6 +55,8 @@ import { Menu } from "./components/Menu";
 import { NewTaskComposer } from "./components/NewTaskComposer";
 import { TerminalView } from "./components/Terminal";
 import { usePrompt } from "./components/usePrompt";
+import { matchesTagQuery, taskIcon, taskTags } from "./task-tags";
+import { byWhatsNext, relativeAge } from "./triage-order";
 import { type Alias, aliasLabel, type UnifiedProject, unifyProjects } from "./unify";
 
 const COLUMNS: { key: KanbanColumn; label: string }[] = [
@@ -78,30 +67,8 @@ const COLUMNS: { key: KanbanColumn; label: string }[] = [
 	{ key: "merged", label: "Done" },
 ];
 
-// Pick an icon from what the task name suggests — like VSCode's file icons,
-// but inferred from intent. First keyword match wins; GitBranch is the default.
-const ICON_RULES: { icon: LucideIcon; re: RegExp }[] = [
-	{ icon: Bug, re: /\b(bug|fix|hotfix|patch|broken|crash|error)\b/i },
-	{ icon: BookOpen, re: /\b(readme|docs?|wiki|guide|changelog)\b/i },
-	{ icon: Lock, re: /\b(auth|login|signin|security|permission|token|oauth)\b/i },
-	{ icon: Palette, re: /\b(ui|ux|style|css|design|theme|button|layout|icon)\b/i },
-	{ icon: FlaskConical, re: /\b(test|spec|e2e|coverage)\b/i },
-	{ icon: Database, re: /\b(db|database|schema|migration|sql|drizzle|query)\b/i },
-	{ icon: Server, re: /\b(api|endpoint|server|backend|route|webhook)\b/i },
-	{ icon: Gauge, re: /\b(perf|performance|optimi|speed|cache|latency)\b/i },
-	{ icon: Wrench, re: /\b(refactor|cleanup|chore|tidy|rename|config|setup)\b/i },
-	{ icon: Rocket, re: /\b(release|deploy|launch|ship|publish)\b/i },
-	{ icon: Sparkles, re: /\b(feat|feature|add|new|implement|create)\b/i },
-	{ icon: FilePen, re: /\b(update|edit|change|tweak|copy|content)\b/i },
-];
-
-function taskIcon(name: string): LucideIcon {
-	for (const rule of ICON_RULES) if (rule.re.test(name)) return rule.icon;
-	return GitBranch;
-}
-
 // ---- sidebar task ordering ----
-type TaskSortMode = "status" | "updated" | "custom";
+type TaskSortMode = "next" | "status" | "updated" | "custom";
 
 // ---- mission control layout ----
 // How agent tiles are arranged: "grid" is a 2x2 overview (tiles half the
@@ -195,7 +162,7 @@ export function App() {
 		document.body.style.userSelect = "none";
 	};
 	const [taskSort, setTaskSortState] = useState<TaskSortMode>(
-		() => (localStorage.getItem("ateam.taskSort") as TaskSortMode) || "status",
+		() => (localStorage.getItem("ateam.taskSort") as TaskSortMode) || "next",
 	);
 	const [customOrder, setCustomOrder] = useState<string[]>([]);
 	const [cleanupOpen, setCleanupOpen] = useState(false);
@@ -460,7 +427,9 @@ export function App() {
 	};
 	const orderedSidebarTasks = useMemo(() => {
 		const list = [...sidebarTasks];
-		if (taskSort === "status") {
+		if (taskSort === "next") {
+			list.sort(byWhatsNext);
+		} else if (taskSort === "status") {
 			list.sort((a, b) => STATUS_RANK[a.column] - STATUS_RANK[b.column]);
 		} else if (taskSort === "updated") {
 			list.sort((a, b) => (b.lastEventAt ?? 0) - (a.lastEventAt ?? 0));
@@ -475,14 +444,20 @@ export function App() {
 	}, [sidebarTasks, taskSort, customOrder]);
 
 	// Case-insensitive substring match across the task's name, branch, and
-	// description. Empty query matches all.
+	// description. Empty query matches all. A leading `#` switches to a tag
+	// filter instead — "#bug" narrows the board to bug-tagged work, which is the
+	// whole point of having a cross-cutting axis.
 	const query = taskQuery.trim().toLowerCase();
 	const matchesQuery = useCallback(
-		(t: TaskDTO) =>
-			query === "" ||
-			t.name.toLowerCase().includes(query) ||
-			t.branch.toLowerCase().includes(query) ||
-			(t.description?.toLowerCase().includes(query) ?? false),
+		(t: TaskDTO) => {
+			if (query === "") return true;
+			if (query.startsWith("#")) return matchesTagQuery(query, t.name, t.description);
+			return (
+				t.name.toLowerCase().includes(query) ||
+				t.branch.toLowerCase().includes(query) ||
+				(t.description?.toLowerCase().includes(query) ?? false)
+			);
+		},
 		[query],
 	);
 	// Sidebar and board both honor the search; Mission Control and the selected
@@ -523,15 +498,29 @@ export function App() {
 		setPanelMode(mem?.mode ?? "side");
 		setView(mem?.view ?? "board");
 	};
+	// Opening a task IS reading it — the hooks set `isUnread` on Stop /
+	// PermissionRequest and nothing ever cleared it. Only explicit user
+	// selection clears it: restoring a remembered selection on a project
+	// switch must not silently mark things read the user never looked at.
+	const markRead = (id: string) => {
+		// Skip the round trip (and its broadcast) for a task already read.
+		const t = Object.values(tasksByProject)
+			.flat()
+			.find((x) => x.id === id);
+		if (!t?.isUnread) return;
+		void window.ateam.tasks.markRead(id).catch(() => {});
+	};
 	// From the sidebar → open full width. From the board → open on the side.
 	const openTask = (t: TaskDTO) => {
 		setActiveProjectId(t.projectId);
 		setSelectedTaskId(t.id);
+		markRead(t.id);
 		setPanelMode("full");
 		setView("board");
 	};
 	const selectFromBoard = (id: string) => {
 		setSelectedTaskId(id);
+		markRead(id);
 		setPanelMode("side");
 	};
 	// Expanding a Mission Control tile opens that exact terminal full-width.
@@ -541,6 +530,7 @@ export function App() {
 	const openFromMission = (task: TaskDTO, terminalId: string) => {
 		setTermByTask((m) => ({ ...m, [task.id]: terminalId }));
 		setSelectedTaskId(task.id);
+		markRead(task.id);
 		setPanelMode("full");
 	};
 	// Collapsing the full panel inside Mission Control means "back to the
@@ -877,6 +867,11 @@ export function App() {
 									label="Order tasks"
 									items={[
 										{
+											label: "What's next",
+											icon: taskSort === "next" ? Check : undefined,
+											onClick: () => setTaskSort("next"),
+										},
+										{
 											label: "By status",
 											icon: taskSort === "status" ? Check : undefined,
 											onClick: () => setTaskSort("status"),
@@ -1172,7 +1167,7 @@ function TaskRow({
 				) : (
 					<Icon className="ticon" size={14} strokeWidth={1.75} />
 				)}
-				<span className="tname">{t.name}</span>
+				<span className={`tname ${t.isUnread ? "unread-row" : ""}`}>{t.name}</span>
 			</button>
 			<span className="task-trail">
 				{t.agentStatus && <span className={`tstatus ${t.agentStatus}`} />}
@@ -1212,40 +1207,75 @@ function Board({
 						<h3>
 							{col.label} <span className="count">{items.length}</span>
 						</h3>
-						{items.map((t) => (
-							<motion.div
-								key={t.id}
-								layout
-								transition={springy}
-								className={`card ${t.id === selectedId ? "selected" : ""}`}
-								onClick={(e) => {
-									e.stopPropagation();
-									onSelect(t.id);
-								}}
-							>
-								{t.agentStatus && <span className={`ring ${t.agentStatus}`} />}
-								<div className="name">{t.name}</div>
-								{originLabel(t) && (
-									<span className="card-env muted" style={{ fontSize: 10 }}>
-										{originLabel(t)}
-									</span>
-								)}
-								<div className="branch">{t.branch}</div>
-								<div className="meta">
-									{t.gitStatus && (
-										<span>
-											↑{t.gitStatus.ahead} ↓{t.gitStatus.behind} · {t.gitStatus.dirty} changed
+						{items.map((t) => {
+							const tags = taskTags(t.name, t.description);
+							return (
+								<motion.div
+									key={t.id}
+									layout
+									transition={springy}
+									className={`card ${t.id === selectedId ? "selected" : ""}`}
+									onClick={(e) => {
+										e.stopPropagation();
+										onSelect(t.id);
+									}}
+								>
+									{/* A stalled agent must not wear the live "running" ring — the card
+								    would contradict its own caption. */}
+									{t.agentStatus && (
+										<span
+											className={`ring ${t.triage.bucket === "stalled" ? "stalled" : t.agentStatus}`}
+										/>
+									)}
+									<div className="name">
+										{t.isUnread && <span className="unread" title="New since you last looked" />}
+										{t.name}
+									</div>
+									{originLabel(t) && (
+										<span className="card-env muted" style={{ fontSize: 10 }}>
+											{originLabel(t)}
 										</span>
 									)}
-									{t.prNumber && <span>PR #{t.prNumber}</span>}
-								</div>
-								{t.agentId && (
-									<span className="card-agent">
-										<AgentIcon agentId={t.agentId} size={15} />
-									</span>
-								)}
-							</motion.div>
-						))}
+									{/* Tags live in the branch's slot and appear only on hover (the
+								    branch is the most redundant line on the card, being a slug of the
+								    name). Sharing one fixed-height row means hovering never reflows
+								    the board. */}
+									<div className={`branch-slot ${tags.length ? "has-tags" : ""}`}>
+										<div className="branch">{t.branch}</div>
+										{tags.length > 0 && (
+											<div className="tags">
+												{tags.map((tag) => (
+													<span className="tag" key={tag}>
+														{tag}
+													</span>
+												))}
+											</div>
+										)}
+									</div>
+									{/* Why this card is where it is — the triage verdict that until now
+								    was computed on every refresh and shown only to the MCP tool. */}
+									<div className="triage" title={t.triage.reason}>
+										{t.triage.reason}
+									</div>
+									<div className="meta">
+										{t.gitStatus && (
+											<span>
+												↑{t.gitStatus.ahead} ↓{t.gitStatus.behind} · {t.gitStatus.dirty} changed
+											</span>
+										)}
+										{t.prNumber && <span>PR #{t.prNumber}</span>}
+										{relativeAge(t.lastEventAt, Date.now()) && (
+											<span className="age">{relativeAge(t.lastEventAt, Date.now())}</span>
+										)}
+									</div>
+									{t.agentId && (
+										<span className="card-agent">
+											<AgentIcon agentId={t.agentId} size={15} />
+										</span>
+									)}
+								</motion.div>
+							);
+						})}
 					</div>
 				);
 			})}
@@ -1290,7 +1320,7 @@ function TaskPanel({
 	useEffect(() => {
 		setChangesOpen(false);
 		setViewFile(null);
-	}, [task.id]);
+	}, []);
 
 	const refreshDiff = useCallback(() => {
 		void window.ateam.git.diff(task.id).then(setDiff);

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -590,12 +590,74 @@ input {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+/* Tags share the branch's row and only surface on hover, so the board never
+   reflows and a resting card stays quiet. Same shared-slot swap the sidebar
+   already uses for its status dot / delete button (.task-trail). */
+.card .branch-slot {
+	position: relative;
+}
+.card .tags {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 120ms ease;
+}
+.card:hover .branch-slot.has-tags .branch {
+	opacity: 0;
+}
+.card:hover .branch-slot.has-tags .tags {
+	opacity: 1;
+}
+.card .tag {
+	font-size: 9.5px;
+	line-height: 1;
+	letter-spacing: 0.02em;
+	padding: 3px 6px;
+	border-radius: 999px;
+	border: 1px solid var(--border);
+	background: var(--bg-elev-2);
+	color: var(--text-dim);
+	white-space: nowrap;
+}
 .card .meta {
 	display: flex;
 	gap: 8px;
 	margin-top: 8px;
 	font-size: 11px;
 	color: var(--text-dim);
+}
+/* Why this card sits where it does (the triage reason). Sits between the
+   branch and the git counts, dimmer than both so it reads as a caption. */
+.card .triage {
+	margin-top: 6px;
+	font-size: 10.5px;
+	color: var(--text-dim);
+	opacity: 0.85;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.card .meta .age {
+	margin-left: auto;
+}
+/* "Something happened here while you were away." White, not the purple accent,
+   to match the selected-card border. */
+.unread {
+	display: inline-block;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--text);
+	margin-right: 6px;
+	vertical-align: middle;
+}
+.tname.unread-row {
+	color: var(--text);
+	font-weight: 600;
 }
 .ring {
 	position: absolute;
@@ -616,6 +678,12 @@ input {
 }
 .ring.idle {
 	background: var(--green);
+}
+/* Claims to be running but stopped advancing: hollow, not pulsing, so it reads
+   as "no longer live" rather than "working". */
+.ring.stalled {
+	background: transparent;
+	border: 1.5px solid var(--text-dim);
 }
 .card-agent {
 	position: absolute;

--- a/apps/desktop/src/renderer/src/task-tags.test.ts
+++ b/apps/desktop/src/renderer/src/task-tags.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { Bug, GitBranch, Rocket } from "lucide-react";
-import { MAX_TAGS, matchesTagQuery, TAG_RULES, taskIcon, taskTags } from "./task-tags";
+import { MAX_TAGS, matchesTagQuery, TAG_RULES, tagsFor, taskIcon, taskTags } from "./task-tags";
 
 test("a task carries every category its text matches, not just the first", () => {
 	expect(taskTags("fix the auth api")).toEqual(["bug", "auth", "api"]);
@@ -43,19 +43,40 @@ test("the icon is exactly the first tag's icon — one rule set, two readings", 
 });
 
 test("#tag search narrows as you type and matches any of a task's tags", () => {
-	const name = "fix the auth api";
-	expect(matchesTagQuery("#bug", name)).toBe(true);
-	expect(matchesTagQuery("#a", name)).toBe(true); // prefix: auth + api
-	expect(matchesTagQuery("#auth", name)).toBe(true);
-	expect(matchesTagQuery("#release", name)).toBe(false);
+	const t = { name: "fix the auth api" };
+	expect(matchesTagQuery("#bug", t)).toBe(true);
+	expect(matchesTagQuery("#a", t)).toBe(true); // prefix: auth + api
+	expect(matchesTagQuery("#auth", t)).toBe(true);
+	expect(matchesTagQuery("#release", t)).toBe(false);
 });
 
 test("a bare # matches everything, so typing it does not blank the board", () => {
-	expect(matchesTagQuery("#", "anything at all")).toBe(true);
+	expect(matchesTagQuery("#", { name: "anything at all" })).toBe(true);
 });
 
 test("#tag search reads the description too", () => {
-	expect(matchesTagQuery("#release", "users have to multitask", "we should deploy this")).toBe(
-		true,
-	);
+	expect(
+		matchesTagQuery("#release", {
+			name: "users have to multitask",
+			description: "we should deploy this",
+		}),
+	).toBe(true);
+});
+
+test("model tags win over the keyword reading of the same task", () => {
+	// Keywords would say "bug" here; the model looked at intent and said "perf".
+	const t = { name: "fix the slow board", tags: ["perf"] };
+	expect(tagsFor(t)).toEqual(["perf"]);
+	expect(matchesTagQuery("#perf", t)).toBe(true);
+	expect(matchesTagQuery("#bug", t)).toBe(false);
+});
+
+test("keywords carry a task the model never tagged", () => {
+	expect(tagsFor({ name: "fix the auth api", tags: null })).toEqual(["bug", "auth", "api"]);
+	expect(tagsFor({ name: "fix the auth api", tags: [] })).toEqual(["bug", "auth", "api"]);
+});
+
+test("model tags are capped like keyword ones", () => {
+	const t = { name: "whatever", tags: ["a", "b", "c", "d", "e"] };
+	expect(tagsFor(t).length).toBe(MAX_TAGS);
 });

--- a/apps/desktop/src/renderer/src/task-tags.test.ts
+++ b/apps/desktop/src/renderer/src/task-tags.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+import { Bug, GitBranch, Rocket } from "lucide-react";
+import { MAX_TAGS, matchesTagQuery, TAG_RULES, taskIcon, taskTags } from "./task-tags";
+
+test("a task carries every category its text matches, not just the first", () => {
+	expect(taskTags("fix the auth api")).toEqual(["bug", "auth", "api"]);
+});
+
+test("an untagged task gets no chips rather than a fallback tag", () => {
+	expect(taskTags("thinking about next quarter")).toEqual([]);
+});
+
+test("tags are capped so chips stay a glance", () => {
+	// bug + docs + auth + ui + test would be five without the cap.
+	const t = taskTags("fix the docs for auth ui tests");
+	expect(t.length).toBe(MAX_TAGS);
+	expect(t).toEqual(["bug", "docs", "auth"]);
+});
+
+test("the description contributes, since the name is often a truncated prompt", () => {
+	expect(taskTags("users have to multitask")).toEqual([]);
+	expect(taskTags("users have to multitask", "we should deploy this")).toEqual(["release"]);
+});
+
+test("matching is word-bounded, so 'apirate' is not an api task", () => {
+	expect(taskTags("apirate behaviour")).toEqual([]);
+	expect(taskTags("the api rate limit")).toContain("api");
+});
+
+test("the icon still comes from the first match, unchanged", () => {
+	expect(taskIcon("fix the auth api")).toBe(Bug);
+	expect(taskIcon("ship the release")).toBe(Rocket);
+	expect(taskIcon("thinking about next quarter")).toBe(GitBranch);
+});
+
+test("the icon is exactly the first tag's icon — one rule set, two readings", () => {
+	for (const name of ["deploy the new database schema", "fix the auth api", "update the readme"]) {
+		const first = taskTags(name)[0];
+		const rule = TAG_RULES.find((r) => r.tag === first);
+		expect(rule).toBeDefined();
+		expect(taskIcon(name)).toBe(rule!.icon);
+	}
+});
+
+test("#tag search narrows as you type and matches any of a task's tags", () => {
+	const name = "fix the auth api";
+	expect(matchesTagQuery("#bug", name)).toBe(true);
+	expect(matchesTagQuery("#a", name)).toBe(true); // prefix: auth + api
+	expect(matchesTagQuery("#auth", name)).toBe(true);
+	expect(matchesTagQuery("#release", name)).toBe(false);
+});
+
+test("a bare # matches everything, so typing it does not blank the board", () => {
+	expect(matchesTagQuery("#", "anything at all")).toBe(true);
+});
+
+test("#tag search reads the description too", () => {
+	expect(matchesTagQuery("#release", "users have to multitask", "we should deploy this")).toBe(
+		true,
+	);
+});

--- a/apps/desktop/src/renderer/src/task-tags.ts
+++ b/apps/desktop/src/renderer/src/task-tags.ts
@@ -82,11 +82,29 @@ export function taskTags(name: string, description?: string | null): string[] {
 }
 
 /**
+ * The tags to show for a task: the model's, when it produced any, otherwise the
+ * keyword reading of its text. Model tags win because keywords miss roughly
+ * three quarters of real tasks; the fallback still covers every card created
+ * before tagging existed, and any card whose tagging call failed.
+ */
+export function tagsFor(task: {
+	name: string;
+	description?: string | null;
+	tags?: string[] | null;
+}): string[] {
+	if (task.tags?.length) return task.tags.slice(0, MAX_TAGS);
+	return taskTags(task.name, task.description);
+}
+
+/**
  * Does this task match a `#tag` search term? `#a` matches the `api` and `auth`
  * chips, so typing narrows as you go rather than only hitting on a full word.
  */
-export function matchesTagQuery(term: string, name: string, description?: string | null): boolean {
+export function matchesTagQuery(
+	term: string,
+	task: { name: string; description?: string | null; tags?: string[] | null },
+): boolean {
 	const wanted = term.replace(/^#/, "").toLowerCase();
 	if (!wanted) return true;
-	return taskTags(name, description).some((t) => t.startsWith(wanted));
+	return tagsFor(task).some((t) => t.startsWith(wanted));
 }

--- a/apps/desktop/src/renderer/src/task-tags.ts
+++ b/apps/desktop/src/renderer/src/task-tags.ts
@@ -1,0 +1,92 @@
+// Task tags — the cross-cutting "what KIND of work is this" axis, alongside
+// project (where) and column (how far along).
+//
+// The vocabulary is NOT new. These rules already existed in App.tsx to pick a
+// card icon from the task name; they are a tuned, closed set of twelve
+// categories, which is exactly what a tag taxonomy needs. Reusing them means
+// tagging is automatic from the moment a task is created, and it can never
+// drift into `frontend` / `front-end` / `ui` synonyms the way a free-form or
+// LLM-generated vocabulary does. The icon and the tags are now two readings of
+// one rule set rather than two things to keep in sync.
+//
+// Deliberately DERIVED, not stored: a tag is a function of the task's own text,
+// so there is no column to migrate, nothing to backfill across the hundreds of
+// existing cards, and no way for a tag to go stale when a task is renamed.
+// Hand-written tags would need a real column; nobody has asked for those yet.
+//
+// Pure + unit-tested (see task-tags.test.ts).
+import {
+	BookOpen,
+	Bug,
+	Database,
+	FilePen,
+	FlaskConical,
+	Gauge,
+	GitBranch,
+	Lock,
+	type LucideIcon,
+	Palette,
+	Rocket,
+	Server,
+	Sparkles,
+	Wrench,
+} from "lucide-react";
+
+/** One category: its chip label, its card icon, and what it matches. */
+export interface TagRule {
+	tag: string;
+	icon: LucideIcon;
+	re: RegExp;
+}
+
+// Order matters for the ICON (first match wins, as it always has); tags use
+// every match, so a "fix the auth api" task carries bug + auth + api.
+export const TAG_RULES: TagRule[] = [
+	{ tag: "bug", icon: Bug, re: /\b(bug|fix|hotfix|patch|broken|crash|error)\b/i },
+	{ tag: "docs", icon: BookOpen, re: /\b(readme|docs?|wiki|guide|changelog)\b/i },
+	{ tag: "auth", icon: Lock, re: /\b(auth|login|signin|security|permission|token|oauth)\b/i },
+	{ tag: "ui", icon: Palette, re: /\b(ui|ux|style|css|design|theme|button|layout|icon)\b/i },
+	{ tag: "test", icon: FlaskConical, re: /\b(test|spec|e2e|coverage)\b/i },
+	{ tag: "db", icon: Database, re: /\b(db|database|schema|migration|sql|drizzle|query)\b/i },
+	{ tag: "api", icon: Server, re: /\b(api|endpoint|server|backend|route|webhook)\b/i },
+	{ tag: "perf", icon: Gauge, re: /\b(perf|performance|optimi|speed|cache|latency)\b/i },
+	{ tag: "refactor", icon: Wrench, re: /\b(refactor|cleanup|chore|tidy|rename|config|setup)\b/i },
+	{ tag: "release", icon: Rocket, re: /\b(release|deploy|launch|ship|publish)\b/i },
+	{ tag: "feat", icon: Sparkles, re: /\b(feat|feature|add|new|implement|create)\b/i },
+	{ tag: "content", icon: FilePen, re: /\b(update|edit|change|tweak|copy|content)\b/i },
+];
+
+/** Cap per card. Beyond three, chips stop being a glance and become a wall. */
+export const MAX_TAGS = 3;
+
+/** Pick an icon from what the task name suggests. First match wins; GitBranch
+ *  is the default. Unchanged behaviour, now sharing one rule set with tags. */
+export function taskIcon(name: string): LucideIcon {
+	for (const rule of TAG_RULES) if (rule.re.test(name)) return rule.icon;
+	return GitBranch;
+}
+
+/**
+ * Every category the task's text matches, in rule order, capped at MAX_TAGS.
+ * Reads the name and the description: the name is often a truncated first line
+ * of the prompt, so the description carries signal the title lost.
+ */
+export function taskTags(name: string, description?: string | null): string[] {
+	const text = description ? `${name} ${description}` : name;
+	const hits: string[] = [];
+	for (const rule of TAG_RULES) {
+		if (rule.re.test(text)) hits.push(rule.tag);
+		if (hits.length === MAX_TAGS) break;
+	}
+	return hits;
+}
+
+/**
+ * Does this task match a `#tag` search term? `#a` matches the `api` and `auth`
+ * chips, so typing narrows as you go rather than only hitting on a full word.
+ */
+export function matchesTagQuery(term: string, name: string, description?: string | null): boolean {
+	const wanted = term.replace(/^#/, "").toLowerCase();
+	if (!wanted) return true;
+	return taskTags(name, description).some((t) => t.startsWith(wanted));
+}

--- a/apps/desktop/src/renderer/src/triage-order.test.ts
+++ b/apps/desktop/src/renderer/src/triage-order.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test";
+import type { TaskDTO, TriageBucket } from "@ateam/protocol";
+import { byWhatsNext, nextRank, relativeAge } from "./triage-order";
+
+const NOW = 1_700_000_000_000;
+
+function task(
+	id: string,
+	over: Partial<TaskDTO> = {},
+	bucket: TriageBucket = "not_started",
+): TaskDTO {
+	return {
+		id,
+		projectId: "p1",
+		name: id,
+		description: null,
+		slug: id,
+		branch: id,
+		baseBranch: "main",
+		worktreePath: `/wt/${id}`,
+		column: "todo",
+		agentStatus: null,
+		agentId: null,
+		mergeStatus: null,
+		prNumber: null,
+		prUrl: null,
+		gitStatus: null,
+		lastEventAt: NOW,
+		isUnread: false,
+		triage: { bucket, done: false, reason: "test" },
+		...over,
+	};
+}
+
+test("an agent blocked on you outranks everything, including an open PR", () => {
+	const blocked = task("blocked", { agentStatus: "awaiting_input" }, "active");
+	const pr = task("pr", {}, "open_pr");
+	expect(nextRank(blocked)).toBeLessThan(nextRank(pr));
+});
+
+test("a card in needs_attention counts as blocked even with no agent status", () => {
+	expect(nextRank(task("x", { column: "needs_attention" }))).toBe(0);
+});
+
+test("news you have not seen outranks any triage bucket", () => {
+	const unread = task("unread", { isUnread: true }, "merged_done");
+	const pr = task("pr", {}, "open_pr");
+	expect(nextRank(unread)).toBeLessThan(nextRank(pr));
+});
+
+test("a running agent sinks below work that wants a human", () => {
+	const running = task("running", { agentStatus: "running" }, "active");
+	expect(nextRank(task("pr", {}, "open_pr"))).toBeLessThan(nextRank(running));
+	expect(nextRank(task("dirty", {}, "uncommitted"))).toBeLessThan(nextRank(running));
+});
+
+test("finished work sorts last", () => {
+	const done = task("done", {}, "merged_done");
+	for (const b of ["open_pr", "uncommitted", "unmerged_no_pr", "active"] as TriageBucket[]) {
+		expect(nextRank(task("x", {}, b))).toBeLessThan(nextRank(done));
+	}
+});
+
+test("within a band the longest-ignored card surfaces first", () => {
+	const fresh = task("fresh", { lastEventAt: NOW }, "open_pr");
+	const stale = task("stale", { lastEventAt: NOW - 5 * 86_400_000 }, "open_pr");
+	expect([fresh, stale].sort(byWhatsNext).map((t) => t.id)).toEqual(["stale", "fresh"]);
+});
+
+test("full ordering: blocked, then unread, then urgency, then age", () => {
+	const list = [
+		task("done", {}, "merged_done"),
+		task("openPr", {}, "open_pr"),
+		task("blocked", { agentStatus: "awaiting_input" }, "active"),
+		task("unread", { isUnread: true }, "not_started"),
+	];
+	expect(list.sort(byWhatsNext).map((t) => t.id)).toEqual(["blocked", "unread", "openPr", "done"]);
+});
+
+test("a stalled agent rides in the top band — only a restart from you revives it", () => {
+	const stalled = task("stalled", { agentStatus: "running" }, "stalled");
+	expect(nextRank(stalled)).toBe(0);
+	expect(nextRank(stalled)).toBeLessThan(nextRank(task("unread", { isUnread: true })));
+	expect(nextRank(stalled)).toBeLessThan(nextRank(task("pr", {}, "open_pr")));
+});
+
+test("a healthy running agent still sinks below a stalled one", () => {
+	const running = task("running", { agentStatus: "running" }, "active");
+	const stalled = task("stalled", { agentStatus: "running" }, "stalled");
+	expect([running, stalled].sort(byWhatsNext).map((t) => t.id)).toEqual(["stalled", "running"]);
+});
+
+test("relativeAge is compact and handles a missing timestamp", () => {
+	expect(relativeAge(null, NOW)).toBeNull();
+	expect(relativeAge(NOW - 5_000, NOW)).toBe("just now");
+	expect(relativeAge(NOW - 5 * 60_000, NOW)).toBe("5m");
+	expect(relativeAge(NOW - 3 * 3_600_000, NOW)).toBe("3h");
+	expect(relativeAge(NOW - 6 * 86_400_000, NOW)).toBe("6d");
+});

--- a/apps/desktop/src/renderer/src/triage-order.ts
+++ b/apps/desktop/src/renderer/src/triage-order.ts
@@ -1,0 +1,72 @@
+// "What's next" ordering for the task list.
+//
+// The board's columns say where work sits and the triage verdict says whether
+// it is really finished, but neither alone answers the question you actually
+// have after a day away: what do I pick up first? This layers the two.
+//
+// Triage on its own gets one case badly wrong: an agent blocked on a question
+// is `active` (a live agent is never "done"), yet it is the single most urgent
+// card on the board. So blocked-on-you wins outright, then anything that
+// happened while you were away, then the triage buckets in the order a human
+// cares about, and finally oldest-first so stale work rises instead of sinking.
+//
+// Pure + unit-tested (see triage-order.test.ts).
+import type { TaskDTO, TriageBucket } from "@ateam/protocol";
+
+/** How much each triage bucket wants a human, lower first. */
+const BUCKET_RANK: Record<TriageBucket, number> = {
+	stalled: 0, // an agent that stopped advancing; only you can restart it
+	open_pr: 1, // a PR sitting there waiting on you
+	uncommitted: 2, // real work not yet saved
+	unmerged_no_pr: 3, // commits with nowhere to go yet
+	merged_unfinished: 4, // merged, but the conversation kept going
+	orphan: 5, // a worktree git no longer tracks
+	not_started: 6, // hasn't begun — backlog, not urgency
+	active: 7, // an agent has it; nothing for you to do
+	merged_done: 8, // finished
+};
+
+/**
+ * Blocked waiting on the user — the agent literally cannot continue. A stalled
+ * agent belongs here too: it is dead work masquerading as running, and only a
+ * restart from you revives it.
+ */
+function isBlockedOnYou(t: TaskDTO): boolean {
+	return (
+		t.agentStatus === "awaiting_input" ||
+		t.column === "needs_attention" ||
+		t.triage.bucket === "stalled"
+	);
+}
+
+/** Priority band for one task. Lower sorts first. */
+export function nextRank(t: TaskDTO): number {
+	if (isBlockedOnYou(t)) return 0;
+	if (t.isUnread) return 100;
+	return 200 + BUCKET_RANK[t.triage.bucket];
+}
+
+/**
+ * Comparator for the "what's next" order: band first, then oldest activity
+ * first, so the thing you have been ignoring longest surfaces within its band.
+ */
+export function byWhatsNext(a: TaskDTO, b: TaskDTO): number {
+	const d = nextRank(a) - nextRank(b);
+	if (d !== 0) return d;
+	return (a.lastEventAt ?? 0) - (b.lastEventAt ?? 0);
+}
+
+/**
+ * Compact age label ("just now", "5m", "3h", "6d") for a card. Deliberately
+ * short: it sits inline in the card's meta row next to the git counts.
+ */
+export function relativeAge(at: number | null, now: number): string | null {
+	if (at == null) return null;
+	const s = Math.max(0, Math.round((now - at) / 1000));
+	if (s < 60) return "just now";
+	const m = Math.round(s / 60);
+	if (m < 60) return `${m}m`;
+	const h = Math.round(m / 60);
+	if (h < 24) return `${h}h`;
+	return `${Math.round(h / 24)}d`;
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1,3 +1,9 @@
+export type {
+	AgentDefinition,
+	AgentId,
+	AvailableAgent,
+	PromptTransport,
+} from "./registry";
 export {
 	AGENTS,
 	agentCommand,
@@ -5,9 +11,11 @@ export {
 	isAgentAvailable,
 	listAgents,
 } from "./registry";
-export type {
-	AgentDefinition,
-	AgentId,
-	AvailableAgent,
-	PromptTransport,
-} from "./registry";
+export type { TagOptions } from "./tagging";
+export {
+	generateTaskTags,
+	MAX_TAGS,
+	parseTagReply,
+	sanitizeTags,
+	TAG_VOCABULARY,
+} from "./tagging";

--- a/packages/agents/src/tagging.ts
+++ b/packages/agents/src/tagging.ts
@@ -1,0 +1,150 @@
+/**
+ * Model-assisted task tagging: the app's first headless LLM call.
+ *
+ * Keyword tagging over Ateam's task text was measured on a real 400-task board
+ * and reached only 24% coverage, because a task's name is six slugified words
+ * of conversational English ("I am not a fan of") while the keyword vocabulary
+ * is dev jargon. Even fed whole prompts it managed ~50%, with false positives.
+ * A model reads intent instead of matching words, which is the difference
+ * between a decorative feature and a usable axis.
+ *
+ * Three deliberate constraints:
+ *
+ *  • CLOSED VOCABULARY. The model picks from a fixed list plus whatever tags
+ *    the project already uses. Free-form tagging drifts into `frontend` /
+ *    `front-end` / `ui` across three tasks and the axis stops grouping anything.
+ *  • NEVER BLOCKING. This runs after the agent is already launched, so a slow
+ *    or missing `claude` delays nothing the user is waiting on. Tags simply
+ *    appear a few seconds later.
+ *  • ALWAYS RECOVERABLE. Every failure path (no CLI, timeout, unparseable
+ *    output, junk tags) returns null, and the caller keeps the keyword
+ *    fallback. Tagging must never be able to break task creation.
+ *
+ * Invocation contract verified against claude 2.1.251: the prompt goes on
+ * STDIN, `--strict-mcp-config` skips the user's MCP servers, and cwd is a temp
+ * dir so the target repo's CLAUDE.md and hooks are not loaded. Measured ~4.2s.
+ * Counter-intuitively `--model haiku` is SLOWER here (startup-bound, not
+ * inference-bound), so sonnet is the fast choice.
+ */
+
+import { execFile } from "node:child_process";
+import { tmpdir } from "node:os";
+
+/** The house vocabulary: the same categories the card icons already use. */
+export const TAG_VOCABULARY = [
+	"bug",
+	"docs",
+	"auth",
+	"ui",
+	"test",
+	"db",
+	"api",
+	"perf",
+	"refactor",
+	"release",
+	"feat",
+	"content",
+] as const;
+
+/** Hard cap, matching what a card can show without becoming a wall of chips. */
+export const MAX_TAGS = 3;
+/** Generous next to a measured ~4.2s; this is a hang guard, not a deadline. */
+const TIMEOUT_MS = 30_000;
+/** Truncate long prompts: intent is in the opening, and tokens cost latency. */
+const MAX_PROMPT_CHARS = 2000;
+
+export interface TagOptions {
+	/** Tags already in use on this project, so the model reuses before inventing. */
+	knownTags?: string[];
+	/** Injectable for tests; defaults to the real `claude` CLI. */
+	run?: (input: string) => Promise<string>;
+}
+
+function buildPrompt(taskPrompt: string, knownTags: string[]): string {
+	const vocab = [...new Set([...TAG_VOCABULARY, ...knownTags])].join(" ");
+	return [
+		"You label software tasks with topic tags. Reply with ONLY a JSON array of",
+		`strings, no prose, no code fence. Choose 1 to ${MAX_TAGS} tags that describe what the`,
+		"task is ABOUT. Prefer tags from this list; only invent one if nothing fits,",
+		"and then use a single lowercase word:",
+		vocab,
+		"",
+		"If the text is too vague to label, reply with an empty array [].",
+		"",
+		"Task:",
+		taskPrompt.slice(0, MAX_PROMPT_CHARS),
+	].join("\n");
+}
+
+/** Run the real CLI: prompt on stdin, cwd a temp dir so no repo config loads. */
+function runClaude(input: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const child = execFile(
+			"claude",
+			["-p", "--strict-mcp-config", "--model", "sonnet"],
+			{ cwd: tmpdir(), timeout: TIMEOUT_MS, maxBuffer: 1024 * 1024 },
+			(err, stdout) => (err ? reject(err) : resolve(stdout)),
+		);
+		child.stdin?.end(input);
+	});
+}
+
+/**
+ * Keep only clean, in-vocabulary-shaped tags. A model asked for lowercase words
+ * will occasionally return "UI Polish" or a sentence; this is the boundary that
+ * stops that reaching the database.
+ */
+export function sanitizeTags(raw: unknown, knownTags: string[] = []): string[] {
+	if (!Array.isArray(raw)) return [];
+	const allowed = new Set<string>([...TAG_VOCABULARY, ...knownTags]);
+	const out: string[] = [];
+	for (const item of raw) {
+		if (typeof item !== "string") continue;
+		const tag = item.trim().toLowerCase();
+		// A tag is one short word: anything else is the model narrating.
+		if (!/^[a-z][a-z0-9-]{1,15}$/.test(tag)) continue;
+		if (!allowed.has(tag) && out.length > 0) continue; // at most one newcomer, and only leading
+		if (out.includes(tag)) continue;
+		out.push(tag);
+		if (out.length === MAX_TAGS) break;
+	}
+	return out;
+}
+
+/** Pull the JSON array out of a reply that may carry a stray fence or preamble. */
+export function parseTagReply(stdout: string): unknown {
+	const text = stdout
+		.trim()
+		.replace(/^```(?:json)?/i, "")
+		.replace(/```$/, "");
+	const start = text.indexOf("[");
+	const end = text.lastIndexOf("]");
+	if (start === -1 || end === -1 || end < start) return null;
+	try {
+		return JSON.parse(text.slice(start, end + 1));
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Tags for one task's originating prompt, or null when the model could not be
+ * reached or said nothing usable. Null means "keep the keyword fallback", which
+ * is why every failure collapses to it rather than throwing.
+ */
+export async function generateTaskTags(
+	taskPrompt: string,
+	opts: TagOptions = {},
+): Promise<string[] | null> {
+	const prompt = taskPrompt.trim();
+	if (!prompt) return null;
+	const knownTags = opts.knownTags ?? [];
+	try {
+		const stdout = await (opts.run ?? runClaude)(buildPrompt(prompt, knownTags));
+		const tags = sanitizeTags(parseTagReply(stdout), knownTags);
+		return tags.length > 0 ? tags : null;
+	} catch {
+		// No CLI, not logged in, timeout, crash: all mean "no tags today".
+		return null;
+	}
+}

--- a/packages/agents/test/tagging.test.ts
+++ b/packages/agents/test/tagging.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+import { generateTaskTags, MAX_TAGS, parseTagReply, sanitizeTags } from "../src/tagging";
+
+/** A stubbed CLI: whatever the model "replied". */
+const replying = (out: string) => () => Promise.resolve(out);
+
+describe("parseTagReply", () => {
+	it("reads a bare array", () => {
+		expect(parseTagReply('["bug","api"]')).toEqual(["bug", "api"]);
+	});
+
+	it("survives a code fence, which models add unprompted", () => {
+		expect(parseTagReply('```json\n["bug"]\n```')).toEqual(["bug"]);
+	});
+
+	it("survives a preamble sentence", () => {
+		expect(parseTagReply('Here are the tags: ["ui","perf"]')).toEqual(["ui", "perf"]);
+	});
+
+	it("returns null on prose with no array", () => {
+		expect(parseTagReply("I could not determine any tags.")).toBeNull();
+	});
+
+	it("returns null on malformed JSON rather than throwing", () => {
+		expect(parseTagReply('["bug",')).toBeNull();
+	});
+});
+
+describe("sanitizeTags", () => {
+	it("lowercases and keeps in-vocabulary tags", () => {
+		expect(sanitizeTags(["Bug", "API"])).toEqual(["bug", "api"]);
+	});
+
+	it("drops a sentence the model returned instead of a tag", () => {
+		expect(sanitizeTags(["bug", "this task is about fixing the login flow"])).toEqual(["bug"]);
+	});
+
+	it("drops non-strings and duplicates", () => {
+		expect(sanitizeTags(["bug", 7, "bug", null])).toEqual(["bug"]);
+	});
+
+	it("caps the count", () => {
+		expect(sanitizeTags(["bug", "api", "ui", "db", "perf"]).length).toBe(MAX_TAGS);
+	});
+
+	it("accepts a project's own existing tags as vocabulary", () => {
+		expect(sanitizeTags(["mobile"], ["mobile"])).toEqual(["mobile"]);
+	});
+
+	// Drift control: one newcomer is allowed so a genuinely new topic can appear,
+	// but it cannot arrive alongside known tags and multiply into synonyms.
+	it("allows at most one newcomer, and never trailing known tags", () => {
+		expect(sanitizeTags(["frontend"])).toEqual(["frontend"]);
+		expect(sanitizeTags(["bug", "frontend"])).toEqual(["bug"]);
+	});
+
+	it("returns empty for a non-array", () => {
+		expect(sanitizeTags("bug")).toEqual([]);
+		expect(sanitizeTags(null)).toEqual([]);
+	});
+});
+
+describe("generateTaskTags", () => {
+	it("returns the model's tags on a clean reply", async () => {
+		expect(await generateTaskTags("fix login", { run: replying('["bug","auth"]') })).toEqual([
+			"bug",
+			"auth",
+		]);
+	});
+
+	// Every failure below must collapse to null so the caller keeps its keyword
+	// fallback. Tagging is decoration and may never break task creation.
+	it("returns null when the model declines to label", async () => {
+		expect(await generateTaskTags("hmm", { run: replying("[]") })).toBeNull();
+	});
+
+	it("returns null when the CLI is missing or errors", async () => {
+		const run = () => Promise.reject(new Error("spawn claude ENOENT"));
+		expect(await generateTaskTags("fix login", { run })).toBeNull();
+	});
+
+	it("returns null on unparseable output", async () => {
+		expect(await generateTaskTags("fix login", { run: replying("no idea") })).toBeNull();
+	});
+
+	it("returns null for an empty prompt without calling the model", async () => {
+		let called = false;
+		const run = () => {
+			called = true;
+			return Promise.resolve('["bug"]');
+		};
+		expect(await generateTaskTags("   ", { run })).toBeNull();
+		expect(called).toBe(false);
+	});
+
+	it("offers the project's existing tags to the model", async () => {
+		let seen = "";
+		const run = (input: string) => {
+			seen = input;
+			return Promise.resolve('["mobile"]');
+		};
+		expect(await generateTaskTags("ios build", { knownTags: ["mobile"], run })).toEqual(["mobile"]);
+		expect(seen).toContain("mobile");
+	});
+});

--- a/packages/db/src/bootstrap.ts
+++ b/packages/db/src/bootstrap.ts
@@ -41,6 +41,7 @@ export function bootstrap(db: SqliteExecutor): void {
 			git_status TEXT,
 			last_event_at INTEGER,
 			is_unread INTEGER DEFAULT 0,
+			tags TEXT,
 			created_by TEXT NOT NULL DEFAULT 'ateam',
 			created_at INTEGER,
 			updated_at INTEGER
@@ -145,6 +146,7 @@ export function bootstrap(db: SqliteExecutor): void {
 		"ALTER TABLE tasks ADD COLUMN agent_id TEXT",
 		"ALTER TABLE tasks ADD COLUMN description TEXT",
 		"ALTER TABLE tasks ADD COLUMN merge_status TEXT",
+		"ALTER TABLE tasks ADD COLUMN tags TEXT",
 		"ALTER TABLE loops ADD COLUMN kind TEXT NOT NULL DEFAULT 'builtin'",
 		"ALTER TABLE loops ADD COLUMN template_id TEXT",
 		"ALTER TABLE loops ADD COLUMN name TEXT",

--- a/packages/db/src/repo.ts
+++ b/packages/db/src/repo.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, isNull } from "drizzle-orm";
 import {
 	agentEvents,
 	agentSessions,
@@ -100,6 +100,13 @@ export const repo = {
 			.where(eq(agentSessions.taskId, taskId))
 			.orderBy(desc(agentSessions.startedAt))
 			.all();
+	},
+
+	// Every session the db still believes is running, across all projects. The
+	// engine diffs this against the PTY daemon's live set on connect to find
+	// exits that happened while the app was closed (see pty/stranded.ts).
+	listOpenSessions(db: AteamDb) {
+		return db.select().from(agentSessions).where(isNull(agentSessions.exitedAt)).all();
 	},
 
 	updateSession(db: AteamDb, id: string, patch: Partial<typeof agentSessions.$inferInsert>) {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -80,6 +80,13 @@ export const tasks = sqliteTable(
 		prState: text("pr_state").$type<PrState>(),
 		mergeStatus: text("merge_status").$type<MergeStatus>(),
 		gitStatus: text("git_status", { mode: "json" }).$type<GitStatusSnapshot>(),
+		/**
+		 * Model-assigned topic tags, written once shortly after the agent starts.
+		 * Stored rather than derived because a model's answer cannot be recomputed:
+		 * the keyword fallback in the renderer covers rows that predate this or
+		 * whose tagging call failed.
+		 */
+		tags: text("tags", { mode: "json" }).$type<string[]>(),
 		lastEventAt: integer("last_event_at"),
 		isUnread: integer("is_unread", { mode: "boolean" }).default(false),
 		createdBy: text("created_by")

--- a/packages/db/test/repo.test.ts
+++ b/packages/db/test/repo.test.ts
@@ -121,6 +121,37 @@ describe("agent sessions & events", () => {
 			older.id,
 		]);
 	});
+
+	it("lists open sessions across projects, excluding exited ones", () => {
+		const a = repo.upsertProject(db, { repoPath: "/r/a", name: "A" });
+		const b = repo.upsertProject(db, { repoPath: "/r/b", name: "B" });
+		const mkTask = (projectId: string, slug: string) =>
+			repo.createTask(db, {
+				projectId,
+				name: slug,
+				slug,
+				branch: slug,
+				baseBranch: "main",
+				worktreePath: `/wt/${slug}`,
+			});
+		const ta = mkTask(a!.id, "ta");
+		const tb = mkTask(b!.id, "tb");
+		const open = repo.createSession(db, {
+			taskId: ta.id,
+			agentId: "claude",
+			terminalId: "term-open",
+			cwd: "/wt/ta",
+		});
+		const exited = repo.createSession(db, {
+			taskId: tb.id,
+			agentId: "claude",
+			terminalId: "term-exited",
+			cwd: "/wt/tb",
+		});
+		repo.updateSession(db, exited.id, { exitedAt: Date.now() });
+
+		expect(repo.listOpenSessions(db).map((s) => s.id)).toEqual([open.id]);
+	});
 });
 
 describe("settings", () => {

--- a/packages/protocol/src/client-api.ts
+++ b/packages/protocol/src/client-api.ts
@@ -82,6 +82,7 @@ export function buildAteamApi(rpc: RpcClient, native: NativeClientApi): AteamApi
 			create: (input) => call<TaskDTO>(CH.tasksCreate, [input]),
 			remove: (input) => call<void>(CH.tasksRemove, [input]),
 			setColumn: (id, column: KanbanColumn) => call<TaskDTO>(CH.tasksSetColumn, [id, column]),
+			markRead: (id) => call<TaskDTO>(CH.tasksMarkRead, [id]),
 			cleanupPreview: (projectId) => call<CleanupReport>(CH.tasksCleanupPreview, [projectId]),
 			cleanupCandidates: (projectId) =>
 				call<CleanupCandidate[]>(CH.tasksCleanupCandidates, [projectId]),

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -16,11 +16,41 @@
 // auto-updates, a box only changes when someone re-runs the installer. Without the
 // bump those clients pass the handshake and then fail deep in a feature with a raw
 // `Unknown method: projects:clone`; with it they get "update the older side" up front.
-export const PROTOCOL_VERSION = 2;
+// v3: TaskDTO gained a required `triage` verdict (including the `stalled` bucket),
+// and CH.tasksMarkRead was added.
+// Both break NEW CLIENT → OLD SERVER: an old engine sends cards with no `triage`
+// (the board reads it on every card) and answers markRead with "Unknown method".
+export const PROTOCOL_VERSION = 3;
 
 export type KanbanColumn = "todo" | "running" | "needs_attention" | "review" | "merged";
 
 export type AgentStatus = "idle" | "running" | "awaiting_input" | "stopped";
+
+/**
+ * Why a task is where it is, in urgency order — the done-vs-ongoing judgment
+ * from worktree-triage. Lives here (not in @ateam/server) because it rides on
+ * every TaskDTO: the classifier is server-side, but desktop, mobile, and any
+ * client on the far end of the RPC all render it.
+ */
+export type TriageBucket =
+	| "active"
+	| "stalled"
+	| "uncommitted"
+	| "open_pr"
+	| "unmerged_no_pr"
+	| "merged_unfinished"
+	| "merged_done"
+	| "orphan"
+	| "not_started";
+
+/** One task's triage verdict, computed from its row on every DTO mapping. */
+export interface TaskTriage {
+	bucket: TriageBucket;
+	/** Is this task actually finished? */
+	done: boolean;
+	/** Human-readable justification, shown on the card. */
+	reason: string;
+}
 
 /** Position of a task in the merge queue; null when not queued. */
 export type MergeStatus = "queued" | "updating" | "merging" | "conflict";
@@ -62,6 +92,8 @@ export interface TaskDTO {
 	/** Last agent/lifecycle activity (falls back to row update time). */
 	lastEventAt: number | null;
 	isUnread: boolean;
+	/** Done-vs-ongoing verdict, derived from this row (no git/gh calls). */
+	triage: TaskTriage;
 }
 
 export interface AgentDTO {
@@ -271,6 +303,7 @@ export const CH = {
 	tasksCreate: "tasks:create",
 	tasksRemove: "tasks:remove",
 	tasksSetColumn: "tasks:setColumn",
+	tasksMarkRead: "tasks:markRead",
 	tasksCleanup: "tasks:cleanup",
 	tasksCleanupPreview: "tasks:cleanupPreview",
 	tasksCleanupCandidates: "tasks:cleanupCandidates",
@@ -364,6 +397,8 @@ export interface AteamApi {
 		create(input: { projectId: string; name: string; baseBranch?: string }): Promise<TaskDTO>;
 		remove(input: { id: string; deleteBranch?: boolean; force?: boolean }): Promise<void>;
 		setColumn(id: string, column: KanbanColumn): Promise<TaskDTO>;
+		/** Clear the unread flag once the user has actually looked at the task. */
+		markRead(id: string): Promise<TaskDTO>;
 		/** Preview which tasks a cleanup would remove vs keep (and why). */
 		cleanupPreview(projectId: string): Promise<CleanupReport>;
 		/** Worktrees advised for cleanup (idle/finished), with their terminals. */

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -92,6 +92,9 @@ export interface TaskDTO {
 	/** Last agent/lifecycle activity (falls back to row update time). */
 	lastEventAt: number | null;
 	isUnread: boolean;
+	/** Model-assigned topic tags; null when none were generated (the client
+	 *  falls back to deriving them from the task's text). */
+	tags: string[] | null;
 	/** Done-vs-ongoing verdict, derived from this row (no git/gh calls). */
 	triage: TaskTriage;
 }

--- a/packages/server/src/dispatcher.ts
+++ b/packages/server/src/dispatcher.ts
@@ -242,6 +242,14 @@ export function createDispatcher(engine: Engine): Dispatcher {
 			// Drop the card from every window (not just the caller's).
 			engine.sendTaskRemoved(task.id);
 		},
+		// The user has actually looked at the task, so it is no longer news. Only
+		// the hooks set `isUnread` (on Stop / PermissionRequest); nothing cleared
+		// it before, which is why the flag was never worth rendering.
+		[CH.tasksMarkRead]: async (id: string) => {
+			const row = repo.updateTask(db, id, { isUnread: false });
+			engine.sendTaskUpdated(id);
+			return toTaskDTO(row!);
+		},
 		[CH.tasksSetColumn]: async (id: string, column: KanbanColumn) => {
 			const row = repo.updateTask(db, id, { column });
 			// Broadcast so every view (board, sidebar) reflects the move — e.g. the

--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -24,6 +24,7 @@ import { applySetStatus, buildBoardView } from "./loops/board-signals";
 import { LoopRunner } from "./loops/runner";
 import { MergeQueue } from "./merge-queue";
 import { PtyClient } from "./pty/pty-client";
+import { strandedSessions } from "./pty/stranded";
 import { type Services, toTaskDTO } from "./services";
 import { createTaskInProject, spawnAgentInTask } from "./sessions";
 
@@ -87,6 +88,9 @@ function mapEventToColumn(eventType: string): KanbanColumn {
 export async function createEngine(opts: EngineOptions): Promise<Engine> {
 	const { dataDir, daemonPath, execPath } = opts;
 	const emitter = new EventEmitter();
+	// Captured before any session of this run can exist, so the reconcile below
+	// can tell "stranded by a previous run" from "spawning right now".
+	const engineStartedAt = Date.now();
 
 	// Ensure the data dir exists. Electron's userData always does; a fresh
 	// server's ~/.ateam may not, and better-sqlite3 won't create parent dirs.
@@ -179,33 +183,68 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 		loopRunner,
 	};
 
+	// Record an agent's exit: close the session and file its card. Shared by the
+	// live exit event and the reconcile below so an exit we watched and an exit
+	// we slept through land the card in the same place.
+	//
+	// `markUnread` is the one thing they must NOT share. A live exit is real news
+	// ("your agent just finished"). The reconcile is a BACKFILL of bookkeeping we
+	// missed, possibly weeks ago — flagging all of it unread would drown the
+	// genuine news on a board that has hundreds of stranded cards, and claim the
+	// user hasn't seen work they have. Correcting the column is the value there.
+	const applyAgentExit = (
+		sessionId: string,
+		taskId: string,
+		exitedAt: number,
+		markUnread: boolean,
+	): void => {
+		repo.updateSession(db, sessionId, { status: "stopped", exitedAt });
+		const task = repo.getTask(db, taskId);
+		if (task && task.column === "running") {
+			repo.updateTask(db, task.id, {
+				agentStatus: "stopped",
+				column:
+					task.prNumber != null || (task.gitStatus?.ahead ?? 0) > 0 ? "review" : "needs_attention",
+				...(markUnread ? { isUnread: true } : {}),
+			});
+			sendTaskUpdated(task.id);
+		}
+	};
+
 	// PTY output/exit → emitted for the transport to forward.
 	pty.on("data", (e) => emitter.emit("ptyData", e));
 	pty.on("exit", (e) => {
 		emitter.emit("ptyExit", e);
 		// Record the exit in the DB so a session is never left looking "running"
 		// after its process is gone — the gap that previously stranded cards in
-		// the running column. Exits missed entirely (e.g. while the app was
-		// closed) have NO backstop since the board reconciler was removed; code
-		// that needs liveness must ask the PTY daemon (pty.has), not this status.
+		// the running column. Code that needs liveness must ask the PTY daemon
+		// (pty.has), not this status.
 		const session = repo.getSessionByTerminal(db, e.terminalId);
 		if (!session) return;
-		if (session.exitedAt == null) {
-			repo.updateSession(db, session.id, {
-				status: "stopped",
-				exitedAt: Date.now(),
-			});
+		if (session.exitedAt == null) applyAgentExit(session.id, session.taskId, Date.now(), true);
+	});
+
+	// The backstop for exits nobody watched. The daemon outlives the app, so an
+	// agent that finishes while the app is closed broadcasts to no one and is
+	// then dropped from the daemon's map — leaving its card in `running` for
+	// good. Every connect hands us the daemon's live set, which is exactly the
+	// evidence needed to close those out. See pty/stranded.ts for why this is
+	// scoped to sessions predating this engine.
+	pty.on("attached", (terminals: { terminalId: string }[]) => {
+		const live = new Set(terminals.map((t) => t.terminalId));
+		const open = repo.listOpenSessions(db);
+		const stranded = strandedSessions(open, live, engineStartedAt);
+		for (const s of stranded) {
+			// Best guess at when it died: we only know it was gone by now.
+			applyAgentExit(s.id, s.taskId, Date.now(), false);
 		}
-		const task = repo.getTask(db, session.taskId);
-		if (task && task.column === "running") {
-			repo.updateTask(db, task.id, {
-				agentStatus: "stopped",
-				column:
-					task.prNumber != null || (task.gitStatus?.ahead ?? 0) > 0 ? "review" : "needs_attention",
-				isUnread: true,
-			});
-			sendTaskUpdated(task.id);
-		}
+		// Always log: this is a bulk mutation of the board, so "it did nothing"
+		// has to be as visible as "it closed 700 cards". The desktop passes no
+		// `log`, so fall back to console like LoopRunner does.
+		const log = opts.log ?? ((line: string) => console.log(line));
+		log(
+			`[ateam] pty attach: ${live.size} live, ${open.length} open in db → closed ${stranded.length}`,
+		);
 	});
 
 	// Agent status hooks → update session/task, drive the kanban column.

--- a/packages/server/src/loops/board-signals.ts
+++ b/packages/server/src/loops/board-signals.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { AteamDb, KanbanColumn, Task } from "@ateam/db";
 import { repo } from "@ateam/db";
+import { signalsFromTask } from "../task-triage";
 import { validateSetStatus } from "./board-organizer";
 import { agentAlive } from "./session-liveness";
 import { type TriageResult, triageWorktree, type WorktreeSignals } from "./worktree-triage";
@@ -57,22 +58,17 @@ async function prMergeInfo(
 	}
 }
 
-/** Gather the signals for one task. Cheap fields come from the DB snapshot;
- *  the gh call is made only when a PR could plausibly exist. */
+/** Gather the signals for one task. The row answers most of them (shared with
+ *  the DTO path via signalsFromTask); this path additionally pays for a live pid
+ *  check and a gh call, made only when a PR could plausibly exist. */
 async function gatherSignals(db: AteamDb, task: Task): Promise<WorktreeSignals> {
-	const gs = task.gitStatus;
 	const mightHavePr = task.prNumber != null || task.column === "review" || task.column === "merged";
 	const pr = mightHavePr ? await prMergeInfo(task.worktreePath) : { state: null, mergedAtMs: null };
 
 	return {
+		...signalsFromTask(task),
+		// Ground truth beats the persisted status when we can afford it.
 		agentAlive: agentAlive(db, task.id),
-		createdAtMs: task.createdAt ?? null,
-		// gitStatus.updatedAt tracks the last git refresh; lastEventAt tracks the
-		// last hook activity (our best proxy for conversation activity).
-		indexMtimeMs: gs?.updatedAt ?? null,
-		transcriptMtimeMs: task.lastEventAt ?? null,
-		dirtyRealCount: gs?.dirty ?? 0,
-		commitsAhead: gs?.ahead ?? 0,
 		prState: pr.state,
 		mergedAtMs: pr.mergedAtMs,
 	};

--- a/packages/server/src/loops/worktree-triage.ts
+++ b/packages/server/src/loops/worktree-triage.ts
@@ -36,6 +36,12 @@ export const CONVERSATION_GAP_MS = 4 * 60 * 1000;
 export interface WorktreeSignals {
 	/** Live agent process attached (pid alive)? Overrides everything → active. */
 	agentAlive?: boolean;
+	/**
+	 * The live agent is parked waiting on the USER (a permission prompt, a
+	 * question). Such an agent is legitimately silent for hours and must never be
+	 * called stalled — it is already filed as needs_attention.
+	 */
+	agentAwaitingInput?: boolean;
 	/** Worktree creation time. */
 	createdAtMs?: number | null;
 	/** `.git/worktrees/<n>/index` mtime — moves on git ops/commits. */
@@ -59,6 +65,7 @@ export interface WorktreeSignals {
 /** Buckets, ordered by urgency — the first that matches wins (as in the skill). */
 export type WorktreeBucket =
 	| "active" // recent activity or live agent — in-flight, do not touch
+	| "stalled" // claims to be running, but has not advanced in `recentHours`
 	| "uncommitted" // real dirty files
 	| "open_pr" // PR is OPEN
 	| "unmerged_no_pr" // commits ahead, not merged, not patch-equivalent
@@ -99,7 +106,26 @@ export function triageWorktree(s: WorktreeSignals, opts: TriageOptions): TriageR
 	const recentHours = opts.recentHours ?? DEFAULT_RECENT_HOURS;
 
 	// 1. Live agent or recent activity → in-flight. Never done.
+	//
+	// EXCEPT when the agent claims to be running and has stopped advancing. The
+	// PTY deliberately drops to a shell when the agent exits (sessions.ts), so a
+	// crashed or wedged agent leaves a live terminal behind and this check would
+	// otherwise call it healthy forever — the one case a liveness probe cannot
+	// see. Progress is measured by `transcriptMtimeMs` ALONE (the hook clock),
+	// never `lastActivityMs`: that folds in `gitStatus.updatedAt`, which the UI
+	// refreshes whenever a task panel is opened, so merely LOOKING at a wedged
+	// card would hide that it is wedged.
 	if (s.agentAlive) {
+		const progressAt = s.transcriptMtimeMs ?? s.createdAtMs ?? null;
+		const silentMs = progressAt == null ? 0 : opts.now - progressAt;
+		if (!s.agentAwaitingInput && silentMs >= recentHours * 3600_000) {
+			return {
+				bucket: "stalled",
+				done: false,
+				suggestedColumn: "needs_attention",
+				reason: `silent ${Math.round(silentMs / 3600_000)}h — may need restart`,
+			};
+		}
 		return { bucket: "active", done: false, suggestedColumn: null, reason: "live agent attached" };
 	}
 	const idleMs = opts.now - lastActivityMs(s);

--- a/packages/server/src/pty/stranded.ts
+++ b/packages/server/src/pty/stranded.ts
@@ -1,0 +1,47 @@
+/**
+ * Which agent sessions the PTY daemon has forgotten.
+ *
+ * The daemon is detached and outlives the app (see daemon.ts), so an agent that
+ * exits while the app is closed broadcasts its exit to nobody and is then
+ * deleted from the daemon's session map. Nothing records it: the session keeps
+ * `exitedAt: null` and its task sits in `running` forever — the board claims
+ * agents are working when none are. The daemon hands us the authoritative live
+ * set in `hello` on every connect (re-emitted by PtyClient as `attached`), so a
+ * connect is exactly the moment to notice the exits we slept through.
+ *
+ * Deliberately scoped to sessions older than this engine process. A session row
+ * is created BEFORE its spawn reaches the daemon (sessions.ts), so a respawned
+ * daemon's first `hello` legitimately omits terminals that are about to start;
+ * anything from this run is younger than `engineStartedAt` and is left alone.
+ * Sessions started in this run get their exit from the live `exit` event, which
+ * is the path that already works.
+ *
+ * Known gap: a daemon crash mid-run loses both the exit broadcast and these
+ * sessions' eligibility here. Rare — a connected client keeps the daemon alive,
+ * so it never idle-exits under a running app — and it self-heals on the next
+ * app start, when those sessions are older than the new engine.
+ *
+ * Pure module: no db, no I/O, no clock. Unit-tested in test/stranded.test.ts.
+ */
+
+/** The fields of an open `agent_sessions` row this decision needs. */
+export interface OpenSession {
+	id: string;
+	taskId: string;
+	terminalId: string;
+	startedAt: number | null;
+}
+
+/**
+ * Open sessions whose terminal the daemon no longer knows about, restricted to
+ * those predating this engine. Caller applies the exit each one missed.
+ */
+export function strandedSessions(
+	open: readonly OpenSession[],
+	liveTerminalIds: ReadonlySet<string>,
+	engineStartedAt: number,
+): OpenSession[] {
+	return open.filter(
+		(s) => !liveTerminalIds.has(s.terminalId) && (s.startedAt ?? 0) < engineStartedAt,
+	);
+}

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -4,6 +4,7 @@ import type { HookServer } from "./hooks/hook-server";
 import type { LoopRunner } from "./loops/runner";
 import type { MergeQueue } from "./merge-queue";
 import type { PtyClient } from "./pty/pty-client";
+import { triageTask } from "./task-triage";
 
 export interface Services {
 	db: AteamDb;
@@ -48,6 +49,7 @@ export function toTaskDTO(t: Task): TaskDTO {
 		gitStatus: t.gitStatus ?? null,
 		lastEventAt: t.lastEventAt ?? t.updatedAt ?? null,
 		isUnread: Boolean(t.isUnread),
+		triage: triageTask(t),
 	};
 }
 

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -49,6 +49,7 @@ export function toTaskDTO(t: Task): TaskDTO {
 		gitStatus: t.gitStatus ?? null,
 		lastEventAt: t.lastEventAt ?? t.updatedAt ?? null,
 		isUnread: Boolean(t.isUnread),
+		tags: t.tags ?? null,
 		triage: triageTask(t),
 	};
 }

--- a/packages/server/src/sessions.ts
+++ b/packages/server/src/sessions.ts
@@ -4,7 +4,7 @@
 // dispatcher's tasksCreate / ptySpawnAgent handlers.
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
-import { agentCommand, getAgent } from "@ateam/agents";
+import { agentCommand, generateTaskTags, getAgent } from "@ateam/agents";
 import { repo, type Task } from "@ateam/db";
 import { createTask as gitCreateTask } from "@ateam/git-core";
 import { buildAgentEnv, ensureClaudeHooks, ensureCodexHooks } from "./agent-setup";
@@ -131,5 +131,36 @@ export async function spawnAgentInTask(
 		agentId: agent.id,
 	});
 	notifyTaskUpdated(task.id);
+	void tagTaskInBackground(services, notifyTaskUpdated, task.id);
 	return { terminalId };
+}
+
+/**
+ * Label the task from its prompt, after the agent is already running.
+ *
+ * Deliberately fire-and-forget: the call takes a few seconds, and nothing the
+ * user is waiting on depends on it, so the card simply gains chips shortly
+ * after it appears. Only the first launch tags (later prompts are follow-ups,
+ * and a re-tag would fight a label the model already settled on), and a null
+ * result leaves `tags` unset so the client keeps its keyword fallback.
+ */
+async function tagTaskInBackground(
+	services: Services,
+	notifyTaskUpdated: (taskId: string) => void,
+	taskId: string,
+): Promise<void> {
+	const task = repo.getTask(services.db, taskId);
+	if (!task?.description || task.tags) return;
+	// Seed the vocabulary with what this project already uses, so the model
+	// reuses an existing label instead of coining a near-synonym.
+	const known = new Set<string>();
+	for (const t of repo.listTasks(services.db, task.projectId)) {
+		for (const tag of t.tags ?? []) known.add(tag);
+	}
+	const tags = await generateTaskTags(task.description, { knownTags: [...known] });
+	if (!tags) return;
+	// Re-read: the task may have been deleted while the model was thinking.
+	if (!repo.getTask(services.db, taskId)) return;
+	repo.updateTask(services.db, taskId, { tags });
+	notifyTaskUpdated(taskId);
 }

--- a/packages/server/src/sessions.ts
+++ b/packages/server/src/sessions.ts
@@ -69,6 +69,16 @@ export async function spawnAgentInTask(
 		cwd: task.worktreePath,
 	});
 
+	// Keep the prompt that started this task. It is the only full-sentence record
+	// of intent anywhere: `name` is a slug of its first six words, and the column
+	// it goes in was previously written by nothing, so every task in the db has a
+	// null description and the search-by-description path could never match. Only
+	// the FIRST launch writes it — later prompts are follow-ups in a conversation,
+	// not what the task is about — and a resume carries no prompt at all.
+	if (input.prompt?.trim() && !task.description) {
+		repo.updateTask(services.db, task.id, { description: input.prompt.trim() });
+	}
+
 	if (agent.id === "claude") {
 		await ensureClaudeHooks(task.worktreePath, services.notifyScriptPath);
 	} else if (agent.id === "codex") {

--- a/packages/server/src/task-triage.ts
+++ b/packages/server/src/task-triage.ts
@@ -1,0 +1,63 @@
+/**
+ * Triage straight from a task row — no git, no gh, no subprocess.
+ *
+ * `triageWorktree` already answers "is this done or still ongoing, and why",
+ * but its only caller was the board organizer's MCP `get_board` tool, which
+ * shells out to `gh pr view` per task. That is fine for one LLM turn and far
+ * too expensive to hang a UI off. Nearly every signal it wants is already
+ * persisted on the task, so this maps the row directly and gives every client
+ * the same verdict for free on every DTO.
+ *
+ * Fidelity note: `mergedAtMs` is NOT persisted, so the "merged but the
+ * conversation kept going" gap always reads as 0 here and a merged task
+ * classifies as `merged_done`. The gh-backed path in board-signals still makes
+ * that distinction. Persisting the merge time (the merge queue knows it) would
+ * close the gap; until then this is honest about erring toward `merged_done`
+ * for cards that are already in the Done column anyway.
+ *
+ * Pure module: no db, no I/O; `now` is injected. Unit-tested in
+ * test/task-triage.test.ts.
+ */
+
+import type { Task } from "@ateam/db";
+import type { TaskTriage } from "@ateam/protocol";
+import { triageWorktree, type WorktreeSignals } from "./loops/worktree-triage";
+
+/** The DB's PrState is lowercase; WorktreeSignals speaks gh's uppercase. */
+function toPrState(s: Task["prState"]): WorktreeSignals["prState"] {
+	if (s === "open") return "OPEN";
+	if (s === "merged") return "MERGED";
+	if (s === "closed") return "CLOSED";
+	return null;
+}
+
+/**
+ * The signals a task row can answer on its own. Callers with richer evidence
+ * (a live pid, a fresh `gh pr view`) spread this and override those fields —
+ * see board-signals.gatherSignals.
+ */
+export function signalsFromTask(task: Task): WorktreeSignals {
+	const gs = task.gitStatus;
+	return {
+		// The persisted status is trustworthy now that a reconnect closes out
+		// sessions whose exit went unobserved (see pty/stranded.ts).
+		agentAlive: task.agentStatus === "running" || task.agentStatus === "awaiting_input",
+		// Parked on a question, not stuck — keeps the stall rule off it.
+		agentAwaitingInput: task.agentStatus === "awaiting_input",
+		createdAtMs: task.createdAt ?? null,
+		// gitStatus.updatedAt tracks the last git refresh; lastEventAt tracks the
+		// last hook activity (our best proxy for conversation activity).
+		indexMtimeMs: gs?.updatedAt ?? null,
+		transcriptMtimeMs: task.lastEventAt ?? null,
+		dirtyRealCount: gs?.dirty ?? 0,
+		commitsAhead: gs?.ahead ?? 0,
+		prState: toPrState(task.prState),
+		mergedAtMs: null,
+	};
+}
+
+/** One task's verdict, as carried on its DTO. */
+export function triageTask(task: Task, now = Date.now()): TaskTriage {
+	const { bucket, done, reason } = triageWorktree(signalsFromTask(task), { now });
+	return { bucket, done, reason };
+}

--- a/packages/server/test/stranded.test.ts
+++ b/packages/server/test/stranded.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { type OpenSession, strandedSessions } from "../src/pty/stranded";
+
+const ENGINE_START = 10_000;
+
+function session(id: string, startedAt: number | null): OpenSession {
+	return { id, taskId: `task-${id}`, terminalId: `term-${id}`, startedAt };
+}
+
+describe("strandedSessions", () => {
+	it("closes an old session the daemon no longer knows about", () => {
+		const open = [session("a", ENGINE_START - 1000)];
+		expect(strandedSessions(open, new Set(), ENGINE_START).map((s) => s.id)).toEqual(["a"]);
+	});
+
+	it("leaves a session the daemon still reports alive", () => {
+		const open = [session("a", ENGINE_START - 1000)];
+		expect(strandedSessions(open, new Set(["term-a"]), ENGINE_START)).toEqual([]);
+	});
+
+	// The race this guard exists for: a session row is written before its spawn
+	// reaches the daemon, so a respawned daemon's first `hello` omits terminals
+	// that are about to start. Those belong to the live exit path, not here.
+	it("leaves a session started after the engine, even when absent from the live set", () => {
+		const open = [session("new", ENGINE_START + 5)];
+		expect(strandedSessions(open, new Set(), ENGINE_START)).toEqual([]);
+	});
+
+	it("treats a session started exactly at engine start as current", () => {
+		const open = [session("boundary", ENGINE_START)];
+		expect(strandedSessions(open, new Set(), ENGINE_START)).toEqual([]);
+	});
+
+	it("treats a null startedAt as ancient, so a legacy row is never left stranded", () => {
+		const open = [session("legacy", null)];
+		expect(strandedSessions(open, new Set(), ENGINE_START).map((s) => s.id)).toEqual(["legacy"]);
+	});
+
+	it("separates stranded from live and current in one pass", () => {
+		const open = [
+			session("dead", ENGINE_START - 5000),
+			session("alive", ENGINE_START - 5000),
+			session("fresh", ENGINE_START + 50),
+		];
+		expect(strandedSessions(open, new Set(["term-alive"]), ENGINE_START).map((s) => s.id)).toEqual([
+			"dead",
+		]);
+	});
+});

--- a/packages/server/test/task-triage.test.ts
+++ b/packages/server/test/task-triage.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "bun:test";
+import type { Task } from "@ateam/db";
+import { signalsFromTask, triageTask } from "../src/task-triage";
+
+const NOW = 1_700_000_000_000;
+const HOUR = 3_600_000;
+/** Older than triage's 2h "recent activity" window, so a card is not `active`. */
+const STALE = NOW - 5 * HOUR;
+
+function task(over: Partial<Task> = {}): Task {
+	return {
+		id: "t1",
+		projectId: "p1",
+		name: "a task",
+		description: null,
+		slug: "a-task",
+		branch: "a-task",
+		baseBranch: "main",
+		worktreePath: "/wt/a-task",
+		column: "todo",
+		agentStatus: null,
+		agentId: null,
+		prNumber: null,
+		prUrl: null,
+		prState: null,
+		mergeStatus: null,
+		gitStatus: null,
+		lastEventAt: STALE,
+		isUnread: false,
+		createdBy: "ateam",
+		createdAt: STALE,
+		updatedAt: STALE,
+		...over,
+	} as Task;
+}
+
+const git = (
+	over: Partial<{ ahead: number; behind: number; dirty: number; updatedAt: number }>,
+) => ({
+	ahead: 0,
+	behind: 0,
+	dirty: 0,
+	updatedAt: STALE,
+	...over,
+});
+
+describe("triageTask", () => {
+	it("calls a task with a live, advancing agent active, never done", () => {
+		const r = triageTask(task({ agentStatus: "running", lastEventAt: NOW - 30_000 }), NOW);
+		expect(r.bucket).toBe("active");
+		expect(r.done).toBe(false);
+	});
+
+	it("treats an agent waiting on the user as live too", () => {
+		expect(triageTask(task({ agentStatus: "awaiting_input" }), NOW).bucket).toBe("active");
+	});
+
+	it("calls a recently touched task active even with no agent", () => {
+		expect(triageTask(task({ lastEventAt: NOW - 60_000 }), NOW).bucket).toBe("active");
+	});
+
+	it("flags uncommitted work as ongoing", () => {
+		const r = triageTask(task({ gitStatus: git({ dirty: 3 }) }), NOW);
+		expect(r.bucket).toBe("uncommitted");
+		expect(r.done).toBe(false);
+		expect(r.reason).toContain("3 uncommitted");
+	});
+
+	it("flags an open PR as ongoing", () => {
+		const r = triageTask(task({ prState: "open", prNumber: 12 }), NOW);
+		expect(r.bucket).toBe("open_pr");
+		expect(r.done).toBe(false);
+	});
+
+	it("flags commits ahead with no merge as unmerged work", () => {
+		const r = triageTask(task({ gitStatus: git({ ahead: 2 }) }), NOW);
+		expect(r.bucket).toBe("unmerged_no_pr");
+		expect(r.reason).toContain("2 commit(s) ahead");
+	});
+
+	it("calls a merged PR done", () => {
+		const r = triageTask(task({ prState: "merged", prNumber: 12 }), NOW);
+		expect(r.bucket).toBe("merged_done");
+		expect(r.done).toBe(true);
+	});
+
+	// The bug the PTY cannot see: `exec $SHELL` keeps the terminal alive after the
+	// agent dies, so liveness alone says "healthy" forever.
+	it("calls a running agent that stopped advancing stalled", () => {
+		const r = triageTask(task({ agentStatus: "running", lastEventAt: NOW - 3 * HOUR }), NOW);
+		expect(r.bucket).toBe("stalled");
+		expect(r.done).toBe(false);
+		expect(r.reason).toContain("may need restart");
+	});
+
+	it("does not call an agent parked on a question stalled — it is waiting on the user", () => {
+		const r = triageTask(
+			task({ agentStatus: "awaiting_input", lastEventAt: NOW - 13 * HOUR }),
+			NOW,
+		);
+		expect(r.bucket).toBe("active");
+	});
+
+	it("leaves a running agent that is still advancing alone", () => {
+		const r = triageTask(task({ agentStatus: "running", lastEventAt: NOW - 60_000 }), NOW);
+		expect(r.bucket).toBe("active");
+	});
+
+	// A stale card whose panel was merely OPENED refreshes gitStatus.updatedAt.
+	// If the stall check used lastActivityMs (which folds that in), looking at a
+	// wedged card would hide that it is wedged.
+	it("stays stalled even when gitStatus was just refreshed by opening the panel", () => {
+		const r = triageTask(
+			task({
+				agentStatus: "running",
+				lastEventAt: NOW - 5 * HOUR,
+				gitStatus: git({ updatedAt: NOW - 1000 }),
+			}),
+			NOW,
+		);
+		expect(r.bucket).toBe("stalled");
+	});
+
+	it("flags a running card that never emitted a single hook event", () => {
+		const r = triageTask(
+			task({ agentStatus: "running", lastEventAt: null, createdAt: NOW - 4 * HOUR }),
+			NOW,
+		);
+		expect(r.bucket).toBe("stalled");
+	});
+
+	it("does not call an untouched card done", () => {
+		const r = triageTask(task(), NOW);
+		expect(r.bucket).toBe("not_started");
+		expect(r.done).toBe(false);
+	});
+});
+
+describe("signalsFromTask", () => {
+	// The db stores PrState lowercase; WorktreeSignals speaks gh's uppercase. A
+	// silent mismatch here would make every PR look like "no PR".
+	it("maps the db's lowercase PR state to gh's casing", () => {
+		expect(signalsFromTask(task({ prState: "open" })).prState).toBe("OPEN");
+		expect(signalsFromTask(task({ prState: "merged" })).prState).toBe("MERGED");
+		expect(signalsFromTask(task({ prState: "closed" })).prState).toBe("CLOSED");
+		expect(signalsFromTask(task({ prState: null })).prState).toBeNull();
+	});
+
+	it("reads counts off the git snapshot and survives a missing one", () => {
+		const s = signalsFromTask(task({ gitStatus: git({ ahead: 4, dirty: 7 }) }));
+		expect(s.commitsAhead).toBe(4);
+		expect(s.dirtyRealCount).toBe(7);
+
+		const none = signalsFromTask(task({ gitStatus: null }));
+		expect(none.commitsAhead).toBe(0);
+		expect(none.dirtyRealCount).toBe(0);
+	});
+});

--- a/packages/server/test/worktree-triage.test.ts
+++ b/packages/server/test/worktree-triage.test.ts
@@ -32,10 +32,50 @@ describe("triageWorktree — the false-done cases the reconciler gets wrong", ()
 		expect(r.suggestedColumn).toBeNull();
 	});
 
-	it("live agent is active regardless of git state", () => {
-		const r = triage(quiet({ agentAlive: true, prState: "MERGED", mergedAtMs: NOW - 5 * HOUR }));
+	it("live, advancing agent is active regardless of git state", () => {
+		const r = triage(
+			quiet({
+				agentAlive: true,
+				transcriptMtimeMs: NOW - 60_000,
+				prState: "MERGED",
+				mergedAtMs: NOW - 5 * HOUR,
+			}),
+		);
 		expect(r.bucket).toBe("active");
 		expect(r.done).toBe(false);
+	});
+
+	// The PTY execs a shell when the agent exits (sessions.ts), so liveness alone
+	// calls a crashed agent healthy forever. Progress, not liveness, decides.
+	it("live agent that stopped advancing is stalled, not active", () => {
+		const r = triage(quiet({ agentAlive: true, transcriptMtimeMs: NOW - 10 * HOUR }));
+		expect(r.bucket).toBe("stalled");
+		expect(r.done).toBe(false);
+		expect(r.suggestedColumn).toBe("needs_attention");
+	});
+
+	it("an agent parked on a question is never stalled, however long it waits", () => {
+		const r = triage(
+			quiet({
+				agentAlive: true,
+				agentAwaitingInput: true,
+				transcriptMtimeMs: NOW - 13 * HOUR,
+			}),
+		);
+		expect(r.bucket).toBe("active");
+	});
+
+	// lastActivityMs folds in indexMtimeMs, which the UI refreshes on opening a
+	// panel — using it here would let inspecting a wedged card hide the problem.
+	it("a fresh git-status refresh does not rescue a stalled agent", () => {
+		const r = triage(
+			quiet({
+				agentAlive: true,
+				transcriptMtimeMs: NOW - 10 * HOUR,
+				indexMtimeMs: NOW - 1000,
+			}),
+		);
+		expect(r.bucket).toBe("stalled");
 	});
 
 	it("merged but the conversation continued past merge is NOT done", () => {


### PR DESCRIPTION
Running several agents means coming back to a board you cannot triage. This makes the board honest about what is actually happening, ranks what to pick up next, and adds a topic axis.

## 1. Close out sessions whose exit nobody saw

The PTY daemon is detached and outlives the app, so an agent that exits while the app is closed broadcasts its exit to nobody and is then dropped from the daemon's map. Nothing recorded it, so the card sat in `running` forever.

The daemon already sends its authoritative live set as `hello` on every connect, re-emitted as `attached`, and **nothing consumed that event**. It does now.

Scoped to sessions older than the engine start, because a session row is written before its spawn reaches the daemon, so a respawned daemon's first hello legitimately omits terminals about to start.

Measured on a copy of a real board: **164 open sessions, 23 actually live, 156 closed, `running` went 34 to 2.**

The reconcile deliberately does not mark those cards unread. A backfill of exits from weeks ago is not news, and flagging 130 at once would make the unread signal worthless on day one. A live exit still marks unread.

## 2. Show the triage verdict that was only ever shown to a robot

`triageWorktree` already answered "is this done, and why", but its only caller was the organizer's MCP `get_board` tool, which shells out to `gh pr view` per task. `task-triage.ts` maps the same verdict straight off the row with no subprocess, so every client gets it on every DTO.

Also surfaces `isUnread` and `lastEventAt`, both already on the wire and rendered nowhere, adds a mark-read call (nothing ever cleared the flag), and adds a "What's next" order: blocked on you, then unread, then triage urgency, then longest-ignored first.

## 3. Detect an agent that went silent

The PTY runs `agent; exec $SHELL`, so it survives the agent by design. A crashed agent leaves a live terminal behind, which change 1 can never catch and which triage called "active" forever.

Progress now decides, not liveness. Two guards, both tested:
- An agent parked on a question is never stalled, it is waiting on you.
- Progress is measured from the hook clock alone, never `lastActivityMs`, which folds in `gitStatus.updatedAt`. The UI refreshes that when a panel opens, so otherwise merely looking at a wedged card would hide that it is wedged.

Catches **6 real cards silent 2h to 18h** on a real board.

## 4. Tags, on hover

Chips shown only on card hover, sharing the branch line's slot so hovering never reflows the board.

Keyword tagging was measured first and covered only **24% of 400 real tasks**: names are six slugified words of conversational English while the vocabulary is dev jargon. So tagging is model-assisted, with keywords as the fallback. On the same prompts keywords scored 1 of 6, the model scores 6 of 6.

`claude -p --strict-mcp-config --model sonnet`, prompt on stdin, cwd a temp dir so the target repo's CLAUDE.md never loads. About 4.2s, and it runs **after** the agent launches so nothing blocks. Every failure path (no CLI, timeout, code fence, prose, junk tags, task deleted mid-call) collapses to null and keeps the keyword reading.

Closed vocabulary with at most one newcomer per task, so tags cannot drift into `frontend` / `front-end` / `ui`.

Along the way: `spawnAgentInTask` now persists the originating prompt into `tasks.description`. That column existed, was on the DTO, and was written by nothing, so every task had a null description and the search-by-description path could never match.

## Notes

- **Protocol v5.** `TaskDTO` gained a required `triage` verdict and a `tags` field, and `CH.tasksMarkRead` was added. Boxes need their installer re-run.
- New `tags` column added through the existing additive-migration list. Tested against a copy of a real database: column added, 400 tasks intact, idempotent across repeated bootstraps.
- 272 tests pass, all packages typecheck, `App.tsx` lints one error better than main.

## Not verified

- The card visuals have not been reviewed rendered.
- The seam where `spawnAgentInTask` fires background tagging is typechecked but never exercised end to end, since that needs a real task, worktree, and billable agent run.
- A Codex turn running past the stall window could read as stalled, since Codex emits no per-tool hooks.