### PR TITLE
Board: stop the agent icon landing on top of the age label

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1438,15 +1438,15 @@ function Board({
 											</span>
 										)}
 										{t.prNumber && <span>PR #{t.prNumber}</span>}
-										{relativeAge(t.lastEventAt, Date.now()) && (
-											<span className="age">{relativeAge(t.lastEventAt, Date.now())}</span>
-										)}
-									</div>
-									{t.agentId && (
-										<span className="card-agent">
-											<AgentIcon agentId={t.agentId} size={15} />
+										{/* Age and agent icon share one right-aligned group: the icon used to
+									    be absolutely positioned and sat on top of the age label. */}
+										<span className="meta-end">
+											{relativeAge(t.lastEventAt, Date.now()) && (
+												<span className="age">{relativeAge(t.lastEventAt, Date.now())}</span>
+											)}
+											{t.agentId && <AgentIcon agentId={t.agentId} size={15} />}
 										</span>
-									)}
+									</div>
 								</motion.div>
 							);
 						})}

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -712,6 +712,7 @@ input {
 }
 .card .meta {
 	display: flex;
+	align-items: center;
 	gap: 8px;
 	margin-top: 8px;
 	font-size: 11px;
@@ -728,8 +729,14 @@ input {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
-.card .meta .age {
+/* Age + agent icon, right-aligned as one group so the icon never lands on top
+   of the age label. */
+.card .meta .meta-end {
 	margin-left: auto;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	opacity: 0.9;
 }
 /* "Something happened here while you were away." White, not the purple accent,
    to match the selected-card border. */
@@ -771,12 +778,6 @@ input {
 .ring.stalled {
 	background: transparent;
 	border: 1.5px solid var(--text-dim);
-}
-.card-agent {
-	position: absolute;
-	right: 10px;
-	bottom: 8px;
-	opacity: 0.9;
 }
 @keyframes pulse {
 	0%,


### PR DESCRIPTION
## What

On a Board card, the agent icon rendered on top of the "just now" age label.

The icon was `position: absolute; right: 10px; bottom: 8px`, which is exactly where `.age` sits: it is the last thing in the meta row and `margin-left: auto` pushes it to the same corner. Any age label wide enough put text under the icon.

## How

Put the icon in the flow instead of floating over it. Age and icon now share one right-aligned `.meta-end` group inside the meta row, so they cannot collide by construction. The `.card-agent` absolute block is gone.

## Verified

`tsconfig.web.json` (the project containing `App.tsx`) typechecks clean.

Screen-recording permission isn't available to the agent process, so instead of screenshotting the Electron window I rendered the real card markup against the real `index.css` in a browser and measured geometry across three cases: age + git status, age only, and icon with no age. Overlap is -6px in every case (a 6px gap), and the icon stays pinned 11px from the card's right edge even when the age label is absent.