### PR TITLE
Worktrees: bun install alone leaves them runnable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,6 @@ keep the copyright to your contribution.
 
 ## Development
 
-See the [README](./README.md) for setup (`bun install`, native module rebuild,
-and `bun run --filter @ateam/desktop dev`). Please run `bun test` and
+See the [README](./README.md) for setup (`bun install`, then
+`bun run --filter @ateam/desktop dev`). Please run `bun test` and
 `bun run typecheck` before opening a PR.

--- a/README.md
+++ b/README.md
@@ -42,10 +42,15 @@ Identity and all GitHub operations come from the `gh` CLI.
 - **git** ≥ 2.31, **gh** (authenticated: `gh auth status`)
 - At least one agent CLI on PATH: `claude`, `opencode`, or `codex`
 
-> Note: if your `node` is x86_64 (Rosetta) while Bun + Electron are arm64, the
-> desktop dev/build scripts run under Bun's runtime (`bunx --bun`) so the right
-> native binaries are used. After `bun install`, native modules are rebuilt for
-> Electron via `bun run --filter @ateam/desktop rebuild`.
+> Note: `bun install` rebuilds better-sqlite3 and node-pty for Electron on its
+> own, via a `postinstall` hook in `apps/desktop`. You do not need a second
+> command, and a fresh task worktree is runnable straight after installing.
+>
+> The hook is not optional bookkeeping. Everything Bun's script runner spawns on
+> macOS runs translated, picking the x86_64 slice of a universal `node`, so
+> `prebuild-install` resolves `process.arch` as x64 and fetches a `darwin-x64`
+> better-sqlite3 that Electron cannot load. The rebuild replaces it with the
+> arm64 Electron-ABI build.
 
 ## Layout
 
@@ -170,8 +175,7 @@ whole setup with you:
 ## Develop
 
 ```bash
-bun install
-bun run --filter @ateam/desktop rebuild   # native modules for Electron (arm64)
+bun install                                # also rebuilds natives for Electron
 bun run --filter @ateam/desktop dev        # launch the app (Electron + Vite HMR)
 ```
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,6 +8,7 @@
     "build": "bunx --bun electron-vite build",
     "start": "bash scripts/brand-dev-electron.sh && bunx --bun electron-vite preview",
     "brand-dev": "bash scripts/brand-dev-electron.sh",
+    "postinstall": "bash scripts/rebuild-natives.sh",
     "rebuild": "electron-rebuild -f -w better-sqlite3,node-pty --arch arm64",
     "dist": "bunx --bun electron-vite build && electron-builder --mac dmg --arm64",
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.web.json"

--- a/apps/desktop/scripts/rebuild-natives.sh
+++ b/apps/desktop/scripts/rebuild-natives.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Rebuild the native modules Electron dlopen()s, so a fresh checkout — or a new
+# task worktree — is runnable straight after `bun install`, with no second step.
+#
+# Why this is an install hook and not a documented command: `bun install` fetches
+# better-sqlite3 built for the host's *Node* ABI, which Electron cannot load, and
+# on Apple Silicon it fetches the wrong architecture too (see below). As a manual
+# step it got skipped: 17 of the 30 worktrees that had deps installed were holding
+# an unloadable x86_64 binary when this hook was added.
+#
+# `-f` is required, not defensive: without it electron-rebuild treats the x86_64
+# binary bun just downloaded as already-built and skips it, leaving the worktree
+# broken. Measured cost of forcing: ~10s once per install. The release path runs
+# its own forced rebuild inside the staging dir (see package-mac.sh).
+set -euo pipefail
+
+# CI installs the workspace on Linux to typecheck and test; no Electron there.
+[ "$(uname -s)" = Darwin ] || exit 0
+
+# Everything bun's script runner spawns runs TRANSLATED: it picks the x86_64
+# slice of universal binaries, so inside this script `uname -m` reports x86_64
+# and `arch` reports i386 even on an M-series Mac. That is also why bun's install
+# leaves a darwin-x64 better-sqlite3 behind: prebuild-install sees process.arch
+# as x64. `sysctl hw.optional.arm64` describes the HARDWARE, not the calling
+# process, so it survives the translation and is the one honest probe here.
+if [ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" = 1 ]; then
+	ARCH=arm64
+else
+	ARCH=x64
+fi
+
+exec electron-rebuild -f -w better-sqlite3,node-pty --arch "$ARCH"

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/desktop": {
       "name": "@ateam/desktop",
-      "version": "0.1.35",
+      "version": "0.1.42",
       "dependencies": {
         "better-sqlite3": "^11.8.1",
         "electron-updater": "^6.8.3",


### PR DESCRIPTION
A new task worktree starts with no `node_modules` (gitignored, so `git worktree add` never materializes it), and the install that followed produced a tree Electron could not load. It needed a manual `bun run rebuild` afterwards, and that step got skipped: **17 of the 30 worktrees that had deps installed were holding an x86_64 better-sqlite3** that dies with `ERR_DLOPEN_FAILED` on launch.

This hooks the rebuild onto `apps/desktop`'s `postinstall`, so `bun install` alone is sufficient. Bun runs a workspace member's lifecycle scripts on a root install, so it fires for the whole monorepo without coupling the root to the desktop app.

### Why the binaries were the wrong architecture

Everything Bun's script runner spawns on macOS runs translated, picking the x86_64 slice of the universal `/usr/local/bin/node`. `prebuild-install` therefore resolves `process.arch` as `x64` and downloads a `darwin-x64` build. Reproduced outside the repo with a bare `bun add better-sqlite3`; pnpm on the same machine and the same `package.json` produces arm64.

Two consequences shaped the script:

- **`-f` is required, not defensive.** Without it electron-rebuild treats the x86_64 binary Bun just downloaded as already-built and skips it, leaving the worktree broken. Caught by testing, not by reading.
- **`uname -m` cannot be used to pick the arch.** The same translation makes `uname -m` report `x86_64` and `arch` report `i386` inside the hook, which silently produced x64 binaries. The arch is probed with `sysctl -n hw.optional.arm64`, which describes the hardware rather than the calling process.

### Verification

On a wiped worktree, a bare `bun install` takes 11s and yields arm64 binaries that load under Electron ABI 132, with a real pty spawn returning its output and an in-memory sqlite query succeeding. Guarded to Darwin, so CI's Linux `bun install --frozen-lockfile` is a no-op (verified with a stubbed `uname`). Typecheck clean, 285 tests pass after syncing with `main`.

All 17 broken worktrees have been repaired locally; the scan now reports 33 worktrees with deps and 0 holding an x86_64 binary.