### PR TITLE
New task: stay in the view you are already in

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -730,11 +730,17 @@ export function App() {
 			// The created task's project is a member of the active card, so its tasks
 			// are already unioned into the board once loaded.
 			await loadTasks(projectId);
+			// Land the new task in whatever the user is actually looking at: a
+			// task open full-width hands its panel to the new one, the board
+			// opens it beside itself, and Mission Control just grows a tile.
+			// `panelMode` survives deselection, so "full" only counts while a
+			// task is really on screen — otherwise the board would jump to a
+			// full-width panel the user never opened.
+			if (!(selectedTaskId && panelMode === "full")) setPanelMode("side");
 			setSelectedTaskId(task.id);
-			// Keep whatever panel mode the user is already in: if they're
-			// browsing the board (side), open the new task beside it; if they're
-			// already full-width, stay full-width.
-			setView("board");
+			// Loops shows only loop-owned tasks, so a new task would land
+			// somewhere it can't be seen; every other view keeps its place.
+			if (view === "loops") setView("board");
 			const { terminalId } = await window.ateam.pty.spawnAgent({
 				taskId: task.id,
 				agentId: input.agentId,


### PR DESCRIPTION
Creating a task forced the Board view, and because `panelMode` outlives deselection (clicking the Board or Mission Control tab clears the selection but leaves the mode at `full`), the next task you created could open full-width over the view you were actually looking at.

Now the new task lands where you already are:

- Board + side panel: opens beside the board (unchanged).
- Board grid with nothing open, even after a previous full-width task: stays on the board, side panel.
- Mission Control grid: stays on Mission Control, the task just appears as a tile.
- Mission Control with a task open full-width: the new task takes that panel, still under Mission Control.
- Loops: falls back to the Board, since a plain task is not visible in LoopsPanel.

Typecheck passes.