### PR TITLE
Board: keep the selected card clear of the side panel

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1388,6 +1388,29 @@ function Board({
 	/** Engine badge for a task (e.g. a box alias), or null to show none (Local). */
 	originLabel: (t: TaskDTO) => string | null;
 }) {
+	// The side panel is sticky over the right edge of the board (the board keeps
+	// its full width rather than reflowing), so a selected card in a right-hand
+	// column sits underneath it. Scroll it clear: `.card.selected` reserves the
+	// panel's width as scroll-margin-right, and "nearest" then no-ops whenever
+	// the card is already in the clear, so we never yank a board the user placed.
+	const selectedRef = useRef<HTMLDivElement | null>(null);
+	const revealSelected = useCallback(() => {
+		const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+		selectedRef.current?.scrollIntoView({
+			behavior: reduced ? "auto" : "smooth",
+			block: "nearest",
+			inline: "nearest",
+		});
+	}, []);
+	// Selecting doesn't move the card, so reveal it in the same commit that opens
+	// the panel. A task that later changes status animates to its new column, and
+	// mid-flight the card's box is a transform of the old spot — scrolling then
+	// would chase a moving target, so that case waits for the layout animation
+	// to land (below) instead of keying this effect on the column.
+	useEffect(() => {
+		if (selectedId) revealSelected();
+	}, [selectedId, revealSelected]);
+
 	return (
 		// Clicking empty board space deselects; card clicks stopPropagation.
 		<div className="board" onClick={onDeselect}>
@@ -1400,12 +1423,18 @@ function Board({
 						</h3>
 						{items.map((t) => {
 							const tags = tagsFor(t);
+							const isSelected = t.id === selectedId;
 							return (
 								<motion.div
 									key={t.id}
 									layout
 									transition={springy}
-									className={`card ${t.id === selectedId ? "selected" : ""}`}
+									ref={isSelected ? selectedRef : undefined}
+									// Fires after any layout animation settles — a status change
+									// carrying the card to another column, or cards above it coming
+									// and going. Re-check from the card's final resting box.
+									onLayoutAnimationComplete={isSelected ? revealSelected : undefined}
+									className={`card ${isSelected ? "selected" : ""}`}
 									onClick={(e) => {
 										e.stopPropagation();
 										onSelect(t.id);

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -13,6 +13,9 @@
 	--amber: #fbbf24;
 	--red: #f87171;
 	--blue: #60a5fa;
+	/* Side-panel width, and so the board's right-hand no-go zone: the panel is
+	   sticky over it, so the selected card reserves it as scroll-margin. */
+	--panel-w: 480px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
@@ -678,6 +681,12 @@ input {
 }
 .card.selected {
 	border-color: #ffffff;
+	/* A selected card means the side panel is open (going full-width hides the
+	   board), and the panel is sticky over the board's right edge. Reserving its
+	   width here is what lets scrollIntoView({inline:"nearest"}) land the card
+	   beside the panel instead of behind it — and stay a no-op when it already is.
+	   +14px matches the board's padding, so the card doesn't kiss the panel. */
+	scroll-margin-right: calc(var(--panel-w) + 14px);
 }
 .card .name {
 	font-size: 13px;
@@ -833,7 +842,7 @@ input {
 
 /* ---- task panel ---- */
 .panel {
-	flex: 0 0 480px; /* fixed width; board scrolls beside it, not squeezed */
+	flex: 0 0 var(--panel-w); /* fixed width; board scrolls beside it, not squeezed */
 	/* Flex min-width:auto would let the terminal's canvas (sized while the
 	   panel was full-width) clamp the panel and stop it collapsing back to
 	   480px — the basis must always win over content min-width. Same on the


### PR DESCRIPTION
Clicking a card in Merging or Done opened the side panel directly on top of the card you just clicked.

The panel is `position: sticky; right: 0` at a fixed 480px, and `.board` is `flex: 0 0 100%` and deliberately does not reflow when the panel opens, so the panel overlays the board's right 480px rather than shrinking it.

## Fix

The selected card reserves the panel's width as `scroll-margin-right` and scrolls itself into view with `block`/`inline: "nearest"`. `nearest` plus the scroll margin is what does the work: it scrolls the minimum needed and is a no-op once the card is already clear, so a board the user scrolled by hand never gets yanked.

Two triggers:

- an effect on `selectedId`, since selecting does not move the card
- `onLayoutAnimationComplete` on the selected card, for a task that later moves to a different status. Mid-flight, framer-motion renders the card as a transform of its old slot, so measuring then would chase a moving target. It waits for the spring to land, then re-checks from the final box.

Panel width moves into a `--panel-w` token so the reserved gutter cannot drift from the panel it is reserving for.

Respects `prefers-reduced-motion`.

## Verified

Whether Chromium honours `scroll-margin-right` for `inline: "nearest"` under a sticky overlay was the real uncertainty, so the layout was rebuilt standalone and measured:

| Case | Result |
| --- | --- |
| Card in Done (rightmost) | scrolls 493px, lands 13px clear of the panel |
| Card in Merging | scrolls 160px, the minimum needed |
| Card in Review / Backlog | `scrollLeft` stays 0, no-op |
| Card deep in Done | both axes: board scrolls down 743px and clear of the panel |
| Task moved into Done, deep down | scrolled fully into view, both axes |
| App's min window (900px, default sidebar) | still clears fully |

Below roughly 630px of content width the card cannot clear the 480px panel because there is no room. It degrades correctly by scrolling as far as it can, and reaching it means dragging the sidebar past ~270px on a minimum-size window, where the panel already covers nearly the whole board.

285 tests pass, full typecheck clean, biome unchanged from baseline.