### PR TITLE
Cleanup: list every worktree, recommend instead of filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,9 @@ agent terminals, session search (the topbar box answers in a popover listing
 matching tasks and the past sessions that discussed them, with an AI row that
 finds a session from a description of the work, reading Claude Code / Codex /
 OpenCode transcripts),
-safe cleanup of merged worktrees, and signed/notarized builds
+worktree cleanup (every worktree listed with the facts you decide on — age, PR
+state, ahead/dirty counts — and the merged-clean-idle ones flagged as
+recommended), and signed/notarized builds
 with in-app auto-update. The git engine and db layer are unit-tested; the
 Electron main process is boot-verified with native modules.
 

--- a/apps/desktop/src/renderer/src/components/CleanupDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/CleanupDialog.tsx
@@ -1,15 +1,57 @@
-import { MessageSquare, Trash2, X } from "lucide-react";
-import { useEffect, useState } from "react";
 import type { CleanupCandidate } from "@ateam/protocol";
+import { GitPullRequest, MessageSquare, Trash2, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { relativeAge } from "../triage-order";
 import { IconButton } from "./IconButton";
 import { TerminalView } from "./Terminal";
 
 /**
- * Interactive cleanup: a sidebar of worktrees advised for deletion + the live
- * terminal of the selected one. Per item you either Delete it (removes the
- * worktree) or Keep & continue (dismiss the advice and jump back into its
- * terminal). Both remove it from the list; the dialog stays open for the rest.
+ * Interactive cleanup: a sidebar of worktrees + the live terminal of the
+ * selected one. Per item you either Delete it (removes the worktree) or Keep &
+ * continue (dismiss it and jump back into its terminal). Both remove it from
+ * the list; the dialog stays open for the rest.
+ *
+ * The list is deliberately NOT pre-filtered. The old rule (merged + idle +
+ * clean) decided for you and hid everything else; it now rides along as
+ * `recommended` — advice, sorted to the top — because whether a worktree is
+ * worth keeping turns on things only you weigh: how long since it moved,
+ * whether its PR landed, whether the dirt left behind matters. Every deciding
+ * factor is on the row, and "Recommended" narrows the list to the sweep's own
+ * picks when you just want the safe ones gone.
  */
+
+/** Sweep's picks first, then stalest first — the longest-ignored surfaces. */
+function byCleanupOrder(a: CleanupCandidate, b: CleanupCandidate): number {
+	if (a.recommended !== b.recommended) return a.recommended ? -1 : 1;
+	return (a.task.lastEventAt ?? 0) - (b.task.lastEventAt ?? 0);
+}
+
+/** The factors the decision turns on, as one compact line. */
+function Factors({ item, now }: { item: CleanupCandidate; now: number }) {
+	const t = item.task;
+	const age = relativeAge(t.lastEventAt, now);
+	return (
+		<span className="cleanup-factors">
+			{age && <span>{age} ago</span>}
+			{t.prNumber ? (
+				<span className={`pr ${t.prState ?? ""}`}>
+					<GitPullRequest size={11} strokeWidth={2} />#{t.prNumber} {t.prState ?? ""}
+				</span>
+			) : (
+				<span className="muted">no PR</span>
+			)}
+			{t.gitStatus && (t.gitStatus.ahead > 0 || t.gitStatus.dirty > 0) && (
+				<span>
+					{t.gitStatus.ahead > 0 && `↑${t.gitStatus.ahead}`}
+					{t.gitStatus.ahead > 0 && t.gitStatus.dirty > 0 && " · "}
+					{t.gitStatus.dirty > 0 && `${t.gitStatus.dirty} changed`}
+				</span>
+			)}
+			{item.terminalId && <span>live session</span>}
+		</span>
+	);
+}
+
 export function CleanupDialog({
 	projectId,
 	confirm,
@@ -24,39 +66,55 @@ export function CleanupDialog({
 	const [items, setItems] = useState<CleanupCandidate[]>([]);
 	const [selectedId, setSelectedId] = useState<string | null>(null);
 	const [loading, setLoading] = useState(true);
+	const [onlyRecommended, setOnlyRecommended] = useState(false);
+	// One clock for every age label, so the rows can't disagree with each other.
+	const now = useMemo(() => Date.now(), []);
 
 	useEffect(() => {
 		void window.ateam.tasks.cleanupCandidates(projectId).then((list) => {
-			setItems(list);
-			setSelectedId(list[0]?.id ?? null);
+			const sorted = [...list].sort(byCleanupOrder);
+			setItems(sorted);
+			setSelectedId(sorted[0]?.task.id ?? null);
 			setLoading(false);
 		});
 	}, [projectId]);
 
+	const shown = onlyRecommended ? items.filter((i) => i.recommended) : items;
+	const recommendedCount = items.filter((i) => i.recommended).length;
+
 	const dismiss = (id: string) => {
 		setItems((prev) => {
-			const next = prev.filter((i) => i.id !== id);
-			setSelectedId((cur) => (cur === id ? (next[0]?.id ?? null) : cur));
+			const next = prev.filter((i) => i.task.id !== id);
+			setSelectedId((cur) => (cur === id ? (next[0]?.task.id ?? null) : cur));
 			if (next.length === 0) onClose();
 			return next;
 		});
 	};
 
 	const del = async (item: CleanupCandidate) => {
+		// Nothing is pre-filtered any more, so a delete can land on unmerged or
+		// dirty work. Ask before that one, on the facts, rather than hiding it.
+		if (!item.recommended) {
+			const ok = await confirm(
+				`Delete "${item.task.name}"?`,
+				`This worktree is not recommended for cleanup (${item.reason}). Its branch and any work in it go away.`,
+			);
+			if (!ok) return;
+		}
 		try {
-			await window.ateam.tasks.remove({ id: item.id, deleteBranch: true });
+			await window.ateam.tasks.remove({ id: item.task.id, deleteBranch: true });
 		} catch (e) {
 			// git refuses to remove a dirty/unmerged worktree without --force.
 			const msg = e instanceof Error ? e.message : String(e);
 			if (/modified or untracked|not fully merged|use --force/i.test(msg)) {
 				const ok = await confirm(
 					"Force delete?",
-					`"${item.name}" has uncommitted/untracked changes or an unmerged branch. Delete it anyway?`,
+					`"${item.task.name}" has uncommitted/untracked changes or an unmerged branch. Delete it anyway?`,
 				);
 				if (!ok) return;
 				try {
 					await window.ateam.tasks.remove({
-						id: item.id,
+						id: item.task.id,
 						deleteBranch: true,
 						force: true,
 					});
@@ -70,10 +128,10 @@ export function CleanupDialog({
 			}
 		}
 		reload();
-		dismiss(item.id);
+		dismiss(item.task.id);
 	};
 
-	const selected = items.find((i) => i.id === selectedId) ?? null;
+	const selected = shown.find((i) => i.task.id === selectedId) ?? null;
 
 	return (
 		<div className="overlay" onMouseDown={onClose}>
@@ -81,9 +139,26 @@ export function CleanupDialog({
 				<div className="cleanup-head">
 					<strong>Clean up worktrees</strong>
 					<span className="muted" style={{ marginLeft: 8 }}>
-						{items.length} to review
+						{items.length} worktree{items.length === 1 ? "" : "s"} · {recommendedCount} recommended
 					</span>
 					<span style={{ flex: 1 }} />
+					<div className="cleanup-filter">
+						<button
+							type="button"
+							className={onlyRecommended ? "" : "on"}
+							onClick={() => setOnlyRecommended(false)}
+						>
+							All
+						</button>
+						<button
+							type="button"
+							className={onlyRecommended ? "on" : ""}
+							onClick={() => setOnlyRecommended(true)}
+							title="Only the ones the sweep would remove: merged, clean, no live session"
+						>
+							Recommended
+						</button>
+					</div>
 					<IconButton icon={X} label="Close" onClick={onClose} />
 				</div>
 
@@ -91,20 +166,26 @@ export function CleanupDialog({
 					<div className="cleanup-list">
 						{loading ? (
 							<div className="tree-empty">Scanning…</div>
-						) : items.length === 0 ? (
-							<div className="tree-empty">Nothing to clean</div>
+						) : shown.length === 0 ? (
+							<div className="tree-empty">
+								{onlyRecommended ? "Nothing recommended" : "Nothing to clean"}
+							</div>
 						) : (
-							items.map((it) => (
+							shown.map((it) => (
 								<button
 									type="button"
-									key={it.id}
-									className={`cleanup-item ${it.id === selectedId ? "selected" : ""}`}
-									onClick={() => setSelectedId(it.id)}
+									key={it.task.id}
+									className={`cleanup-item ${it.task.id === selectedId ? "selected" : ""} ${
+										it.recommended ? "recommended" : ""
+									}`}
+									onClick={() => setSelectedId(it.task.id)}
 								>
-									<span className="tname">{it.name}</span>
-									<span className="sub">
-										{it.branch} · {it.reason}
+									<span className="tname">
+										{it.task.name}
+										{it.recommended && <span className="rec-dot" title={it.reason} />}
 									</span>
+									<span className="sub">{it.task.branch}</span>
+									<Factors item={it} now={now} />
 								</button>
 							))
 						)}
@@ -115,16 +196,20 @@ export function CleanupDialog({
 							<>
 								<div className="cleanup-detail-head">
 									<div style={{ minWidth: 0 }}>
-										<div className="title">{selected.name}</div>
-										<div className="branch muted">
-											{selected.branch} · {selected.reason}
+										<div className="title">
+											{selected.task.name}
+											{selected.recommended && <span className="rec-tag">recommended</span>}
 										</div>
+										<div className="branch muted">
+											{selected.task.branch} · {selected.reason}
+										</div>
+										<div className="branch muted">{selected.task.triage.reason}</div>
 									</div>
 									<div style={{ display: "flex", gap: 6, flex: "none" }}>
 										<button
 											type="button"
 											className="navbtn"
-											onClick={() => dismiss(selected.id)}
+											onClick={() => dismiss(selected.task.id)}
 											title="Keep this worktree and jump back into its terminal"
 										>
 											<MessageSquare size={14} strokeWidth={1.75} />
@@ -144,13 +229,8 @@ export function CleanupDialog({
 								{selected.terminalId ? (
 									<TerminalView terminalId={selected.terminalId} />
 								) : (
-									<div
-										className="term"
-										style={{ display: "grid", placeItems: "center" }}
-									>
-										<span className="muted">
-											No live terminal — the agent session has ended.
-										</span>
+									<div className="term" style={{ display: "grid", placeItems: "center" }}>
+										<span className="muted">No live terminal — the agent session has ended.</span>
 									</div>
 								)}
 							</>

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -1869,7 +1869,31 @@ input {
 	flex: 1;
 	min-height: 0;
 	display: grid;
-	grid-template-columns: 240px 1fr;
+	/* Wider than the old 240px: each row now carries its deciding factors
+	   (age, PR, git counts) under the branch, not just a one-word reason. */
+	grid-template-columns: 300px 1fr;
+}
+/* All / Recommended — narrows the list to the sweep's own picks. */
+.cleanup-filter {
+	display: flex;
+	gap: 2px;
+	margin-right: 8px;
+	background: var(--bg-elev-2);
+	border-radius: 6px;
+	padding: 2px;
+}
+.cleanup-filter button {
+	background: transparent;
+	border: none;
+	border-radius: 4px;
+	color: var(--text-dim);
+	font-size: 11px;
+	padding: 3px 8px;
+	cursor: pointer;
+}
+.cleanup-filter button.on {
+	background: var(--bg-elev);
+	color: var(--text);
 }
 .cleanup-list {
 	border-right: 1px solid var(--border);
@@ -1901,6 +1925,52 @@ input {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+.cleanup-item .tname {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+/* The sweep would take this one — advice, not a filter. */
+.cleanup-item .rec-dot {
+	flex: none;
+	width: 5px;
+	height: 5px;
+	border-radius: 50%;
+	background: var(--green);
+}
+.cleanup-factors {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px;
+	margin-top: 3px;
+	font-size: 10px;
+	color: var(--text-dim);
+}
+.cleanup-factors .pr {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+}
+.cleanup-factors .pr.open {
+	color: var(--green);
+}
+.cleanup-factors .pr.merged {
+	color: var(--text-dim);
+}
+.cleanup-factors .pr.closed {
+	color: var(--red);
+}
+.cleanup-detail-head .rec-tag {
+	margin-left: 8px;
+	font-size: 10px;
+	font-weight: 400;
+	color: var(--green);
+	border: 1px solid var(--green);
+	border-radius: 4px;
+	padding: 1px 5px;
+	vertical-align: middle;
 }
 .cleanup-item .sub {
 	font-size: 11px;

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -25,11 +25,18 @@
 // `tags` field, and CH.tasksMarkRead was added. Same skew again — an old engine
 // sends cards with no `triage`, which the board reads on EVERY card, and answers
 // markRead with "Unknown method".
-export const PROTOCOL_VERSION = 5;
+// v6: TaskDTO gained `prState`, and CleanupCandidate now carries a whole TaskDTO
+// plus a `recommended` flag (it used to be a flat, pre-filtered row). Both are
+// shape changes the cleanup dialog reads directly, so an older engine would feed
+// it rows with no `task` at all — the handshake must catch that skew first.
+export const PROTOCOL_VERSION = 6;
 
 export type KanbanColumn = "todo" | "running" | "needs_attention" | "review" | "merged";
 
 export type AgentStatus = "idle" | "running" | "awaiting_input" | "stopped";
+
+/** State of the branch's pull request, when one exists. */
+export type PrState = "open" | "merged" | "closed";
 
 /**
  * Why a task is where it is, in urgency order — the done-vs-ongoing judgment
@@ -93,6 +100,8 @@ export interface TaskDTO {
 	mergeStatus: MergeStatus | null;
 	prNumber: number | null;
 	prUrl: string | null;
+	/** open / merged / closed, or null when the branch has no PR. */
+	prState: PrState | null;
 	gitStatus: GitStatusSnapshot | null;
 	/** Last agent/lifecycle activity (falls back to row update time). */
 	lastEventAt: number | null;
@@ -302,16 +311,22 @@ export interface ConnectionDTO {
 	known: boolean;
 }
 
-// A worktree advised for cleanup, shown in the cleanup dialog with its terminal.
+/**
+ * One worktree in the cleanup dialog. EVERY task in the project is listed —
+ * the old rule (merged + no live session + clean tree) no longer filters the
+ * list, it only advises through `recommended`, so the call stays with the user
+ * and is made on the factors the whole task carries: last activity, PR state,
+ * ahead/dirty counts, triage verdict.
+ */
 export interface CleanupCandidate {
-	id: string;
-	name: string;
-	branch: string;
-	worktreePath: string;
-	reason: string;
+	/** The task itself, so the dialog can show every deciding factor. */
+	task: TaskDTO;
 	/** A live PTY session to show/continue, or null if the session ended. */
 	terminalId: string | null;
-	agentStatus: AgentStatus | null;
+	/** The conservative rule's verdict: safe to sweep. */
+	recommended: boolean;
+	/** Why it is — or is not — recommended. */
+	reason: string;
 }
 
 /**

--- a/packages/server/src/dispatcher.ts
+++ b/packages/server/src/dispatcher.ts
@@ -8,7 +8,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSy
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { listAgents } from "@ateam/agents";
-import { repo } from "@ateam/db";
+import { repo, type Task } from "@ateam/db";
 import {
 	cloneRepo,
 	commit,
@@ -27,6 +27,7 @@ import {
 } from "@ateam/git-core";
 import {
 	CH,
+	type CleanupCandidate,
 	type CreateLoopInput,
 	type DirEntryDTO,
 	type GitStatusSnapshot,
@@ -103,36 +104,46 @@ export function createDispatcher(engine: Engine): Dispatcher {
 	// Lazy: no code-server process exists until the first editor:open.
 	const editorHost = createEditorHost();
 
-	// ---- cleanup: remove only merged + idle + clean worktrees ----
-	// A task is removable ONLY when it merged, has no live agent session, and its
-	// working tree is clean. Everything else is kept — never deleting unmerged
-	// work or a task an agent is still using.
+	// ---- cleanup: merged + idle + clean is a RECOMMENDATION, not a filter ----
+	// The rule below (merged, no live agent session, clean working tree) is the
+	// only thing the unattended sweep will delete. The interactive dialog no
+	// longer hides everything that fails it: it lists every task and shows this
+	// verdict as advice, because whether a worktree is worth keeping turns on
+	// factors only the user weighs — how stale it is, whether its PR landed,
+	// whether the leftover dirt matters.
+	async function cleanupVerdict(
+		task: Task,
+	): Promise<{ recommended: boolean; reason: string; live: boolean }> {
+		const live = repo.listSessionsByTask(db, task.id).some((s) => services.pty.has(s.terminalId));
+		const isMerged = task.column === "merged" || task.prState === "merged";
+		if (!isMerged) return { recommended: false, reason: "not merged", live };
+		if (live) return { recommended: false, reason: "agent still active", live };
+		// Only merged + idle tasks reach the subprocess, so listing everything
+		// costs no more git calls than the old pre-filtered list did. The whole
+		// probe is guarded, not just the command: `gitFor` itself throws when the
+		// worktree directory is gone (deleted by hand, or pruned elsewhere), and
+		// an unguarded throw here would fail the entire candidate listing. A
+		// vanished tree has nothing left to lose, so it stays sweepable.
+		let dirty = false;
+		try {
+			dirty = (await gitFor(task.worktreePath).raw(["status", "--porcelain"])).trim() !== "";
+		} catch {
+			dirty = false;
+		}
+		if (dirty) return { recommended: false, reason: "uncommitted/untracked changes", live };
+		return { recommended: true, reason: "merged, clean, no live session", live };
+	}
+
+	// A task is removable by the unattended sweep ONLY when `cleanupVerdict`
+	// recommends it — never deleting unmerged work or a task an agent still uses.
 	async function classifyForCleanup(projectId: string) {
 		const allTasks = repo.listTasks(db, projectId);
 		const removable: typeof allTasks = [];
 		const kept: { task: (typeof allTasks)[number]; reason: string }[] = [];
 		for (const task of allTasks) {
-			const isMerged = task.column === "merged" || task.prState === "merged";
-			if (!isMerged) {
-				kept.push({ task, reason: "not merged" });
-				continue;
-			}
-			const live = repo.listSessionsByTask(db, task.id).some((s) => services.pty.has(s.terminalId));
-			if (live) {
-				kept.push({ task, reason: "agent still active" });
-				continue;
-			}
-			const dirty =
-				(
-					await gitFor(task.worktreePath)
-						.raw(["status", "--porcelain"])
-						.catch(() => "")
-				).trim() !== "";
-			if (dirty) {
-				kept.push({ task, reason: "uncommitted/untracked changes" });
-				continue;
-			}
-			removable.push(task);
+			const v = await cleanupVerdict(task);
+			if (v.recommended) removable.push(task);
+			else kept.push({ task, reason: v.reason });
 		}
 		return { removable, kept };
 	}
@@ -263,41 +274,24 @@ export function createDispatcher(engine: Engine): Dispatcher {
 			return toTaskDTO(row!);
 		},
 
-		// Candidates for the interactive cleanup dialog: every task that isn't
-		// actively running. Each carries a live terminalId when its PTY is still
-		// around, so the dialog can show the conversation and let the user continue.
-		[CH.tasksCleanupCandidates]: async (projectId: string) => {
-			const out: {
-				id: string;
-				name: string;
-				branch: string;
-				worktreePath: string;
-				reason: string;
-				terminalId: string | null;
-				agentStatus: string | null;
-			}[] = [];
+		// Candidates for the interactive cleanup dialog: EVERY task in the project,
+		// each with the sweep's verdict as advice (`recommended`) and the whole
+		// task DTO, so the dialog can lay out the factors the user decides on —
+		// last activity, PR state, ahead/dirty counts, triage. A live terminalId
+		// rides along when the PTY is still around, so the conversation is there
+		// to read before deciding, and "Keep & continue" lands back in it.
+		[CH.tasksCleanupCandidates]: async (projectId: string): Promise<CleanupCandidate[]> => {
+			const out: CleanupCandidate[] = [];
 			for (const task of repo.listTasks(db, projectId)) {
-				const busy = task.agentStatus === "running" || task.agentStatus === "awaiting_input";
-				// Done tasks are always proposed — merged work is cleanup material
-				// even when its agent session is technically still alive.
-				if (busy && task.column !== "merged") continue;
+				const v = await cleanupVerdict(task);
 				const live = repo
 					.listSessionsByTask(db, task.id)
 					.find((s) => services.pty.has(s.terminalId));
-				const reason =
-					task.column === "merged"
-						? "merged"
-						: task.agentStatus === "idle" || task.agentStatus === "stopped"
-							? "agent idle"
-							: "no recent activity";
 				out.push({
-					id: task.id,
-					name: task.name,
-					branch: task.branch,
-					worktreePath: task.worktreePath,
-					reason,
+					task: toTaskDTO(task),
 					terminalId: live?.terminalId ?? null,
-					agentStatus: task.agentStatus ?? null,
+					recommended: v.recommended,
+					reason: v.reason,
 				});
 			}
 			return out;

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -46,6 +46,7 @@ export function toTaskDTO(t: Task): TaskDTO {
 		mergeStatus: t.mergeStatus ?? null,
 		prNumber: t.prNumber ?? null,
 		prUrl: t.prUrl ?? null,
+		prState: t.prState ?? null,
 		gitStatus: t.gitStatus ?? null,
 		lastEventAt: t.lastEventAt ?? t.updatedAt ?? null,
 		isUnread: Boolean(t.isUnread),

--- a/packages/server/test/dispatcher.test.ts
+++ b/packages/server/test/dispatcher.test.ts
@@ -112,6 +112,64 @@ describe("createDispatcher", () => {
 		expect(await d.handle(CH.projectsList, [])).toEqual([]);
 	});
 
+	// Cleanup used to hide everything its rule rejected, so an unmerged or busy
+	// worktree was simply not offered. The list is now the whole project and the
+	// rule only advises — that is the difference this asserts.
+	it("offers every task for cleanup, flagging only the sweep-safe ones", async () => {
+		const db = createTestDb();
+		const { engine } = makeEngine(db);
+		// One live terminal, so "merged but the agent is still in it" is real.
+		(engine.services.pty as unknown as { has: (id: string) => boolean }).has = (id) =>
+			id === "live-term";
+		const d = createDispatcher(engine);
+
+		const project = repo.upsertProject(db, { repoPath: "/r/c", name: "C", defaultBranch: "main" });
+		const mk = (name: string) =>
+			repo.createTask(db, {
+				projectId: project!.id,
+				name,
+				slug: name,
+				branch: name,
+				baseBranch: "main",
+				// Nonexistent path: the git probe is guarded and reads a vanished
+				// worktree as clean, which is the behaviour we want asserted here.
+				worktreePath: `/r/c/.ateam/worktrees/${name}`,
+			});
+
+		const ongoing = mk("ongoing"); // todo, no PR → not merged
+		const swept = mk("swept");
+		repo.updateTask(db, swept.id, { column: "merged", prNumber: 7, prState: "merged" });
+		const busy = mk("busy");
+		repo.updateTask(db, busy.id, { column: "merged", prState: "merged" });
+		repo.createSession(db, {
+			taskId: busy.id,
+			agentId: "claude",
+			terminalId: "live-term",
+			cwd: "/r/c",
+		});
+
+		const list = (await d.handle(CH.tasksCleanupCandidates, [project!.id])) as Array<{
+			task: { id: string; prState: string | null; prNumber: number | null };
+			recommended: boolean;
+			reason: string;
+			terminalId: string | null;
+		}>;
+
+		// Every task is listed — nothing is filtered out of the decision any more.
+		expect(list.map((c) => c.task.id).sort()).toEqual([ongoing.id, swept.id, busy.id].sort());
+
+		const by = (id: string) => list.find((c) => c.task.id === id)!;
+		expect(by(swept.id).recommended).toBe(true);
+		expect(by(ongoing.id)).toMatchObject({ recommended: false, reason: "not merged" });
+		expect(by(busy.id)).toMatchObject({ recommended: false, reason: "agent still active" });
+		// The live PTY rides along so the dialog can show the conversation.
+		expect(by(busy.id).terminalId).toBe("live-term");
+		expect(by(ongoing.id).terminalId).toBeNull();
+		// The factors the user decides on come from the task itself.
+		expect(by(swept.id).task.prNumber).toBe(7);
+		expect(by(swept.id).task.prState).toBe("merged");
+	});
+
 	// A brand-new project from a client with no native folder dialog (the phone): the
 	// folder doesn't exist yet, so register+init must create it before git-initing.
 	it("creates the folder and inits a repo when registering a brand-new project", async () => {


### PR DESCRIPTION
The cleanup dialog only ever showed what its rule accepted, so an unmerged or still-busy worktree was never offered and the call was made for you. The rule (merged + no live session + clean tree) is now **advice**: every task in the project is listed, the sweep-safe ones flagged and sorted first, and each row carries the factors the decision actually turns on.

### What you see now

Each row: name, branch, then `6d ago · #12 merged · ↑2 · 3 changed · live session`, with a green dot on the sweep's own picks. Header counts `N worktrees · M recommended`, with an All / Recommended toggle for when you just want the safe ones gone. The detail pane adds the triage verdict.

### Changes

- one `cleanupVerdict(task)` feeds both the dialog's advice and the unattended sweep (`tasks:cleanup`), which still deletes only what it recommends — nothing got less safe
- `CleanupCandidate` carries the whole `TaskDTO` (reusing what the board already computes) instead of a flat pre-filtered row; `TaskDTO` gains `prState`, so open/merged/closed is distinguishable
- deleting a non-recommended worktree confirms first, with the reason ("not merged", "agent still active"), on top of the existing force-delete confirm
- the dirty probe is fully guarded: `gitFor` throws when the worktree directory is gone, and an unguarded throw would have failed the entire listing. A vanished tree reads as clean, i.e. still sweepable
- `PROTOCOL_VERSION` → 6: both DTO shape changes are read directly by the dialog, so the handshake should catch the skew

### Verification

Full typecheck and the suite (286 tests) pass, including a new dispatcher test asserting all three cases — recommended / "not merged" / "agent still active" — appear in one list with their terminal and PR factors.

Not visually verified: `screencapture` is blocked from the agent shell, so the 300px list column with its new factor line wants one human look.