### PR TITLE
New tasks branch off a freshly fetched origin/<base>

### DIFF
--- a/packages/git-core/src/git-client.ts
+++ b/packages/git-core/src/git-client.ts
@@ -24,9 +24,22 @@ const BASE_OPTIONS = {
  *
  * `GIT_TERMINAL_PROMPT=0` makes credential-less HTTPS remotes fail fast instead
  * of blocking on a prompt no one can answer (the app has no terminal attached).
+ *
+ * `abort` swaps that inactivity budget for a WALL-CLOCK cap, for the callers
+ * where finishing is optional rather than required (a best-effort refresh on an
+ * interactive path). simple-git's abort plugin kills the spawned process when
+ * the signal fires, so a stalled network costs the caller's budget, not five
+ * minutes. Callers that MUST complete (the merge queue) pass nothing and keep
+ * the inactivity semantics.
  */
-export function gitFor(worktreePath: string): SimpleGit {
-	return simpleGit(worktreePath, BASE_OPTIONS).env({
+export function gitFor(
+	worktreePath: string,
+	options?: { abort?: AbortSignal },
+): SimpleGit {
+	return simpleGit(worktreePath, {
+		...BASE_OPTIONS,
+		...(options?.abort && { abort: options.abort }),
+	}).env({
 		...process.env,
 		GIT_OPTIONAL_LOCKS: "0",
 		GIT_TERMINAL_PROMPT: "0",

--- a/packages/git-core/src/task.ts
+++ b/packages/git-core/src/task.ts
@@ -24,12 +24,59 @@ export interface TaskInfo {
 	worktreePath: string;
 }
 
+/**
+ * Wall-clock budget for the pre-flight fetch. Freshness here is best-effort, so
+ * the cap is what an interactive "create task" click can absorb, not how long a
+ * fetch might legitimately take.
+ */
+const FETCH_TIMEOUT_MS = 5_000;
+
+/**
+ * Refresh `refs/remotes/origin/<base>` before we branch off it.
+ *
+ * That ref is a LOCAL CACHE, and nothing on this path used to update it: the
+ * only fetches in git-core are in `updateFromBase` and the merge flow, so the
+ * cache went stale until someone happened to merge or hit "update from base".
+ * Merges that land elsewhere (the GitHub UI, another clone, a teammate) are
+ * invisible here by construction, so no amount of reacting to our own merges
+ * can keep it warm. Fetching at the moment of use is the only formulation that
+ * doesn't depend on having witnessed the write.
+ *
+ * Best-effort, never required: offline, no remote, or a headless box with no
+ * credentials all fall through to the chain below (cached ref, then the local
+ * branch, then HEAD). Creating a task must never need the network.
+ *
+ * The bare `fetch origin <base>` refspec writes only `refs/remotes/origin/*` --
+ * never a local branch, never any worktree's checkout. (Contrast the
+ * `<base>:<base>` form in merge.ts, which does write a local branch and leans
+ * on git's own "checked out" refusal to stay safe.) Killing it mid-flight is
+ * safe too: refs are written at the end, so the worst case is a temp packfile
+ * that gc reclaims.
+ *
+ * One measured caveat: aborting kills `git`, but its `git-remote-https` child
+ * survives, orphaned, until the OS gives up on the TCP connect (~75s on macOS).
+ * The caller is already unblocked at FETCH_TIMEOUT_MS, and the strays are idle
+ * and self-reaping -- git exposes no connect timeout (only http.lowSpeed*,
+ * which covers transfer rate, not connect), so bounding it any tighter would
+ * mean bypassing simple-git entirely for this one call.
+ */
+async function fetchBase(repoPath: string, baseBranch: string): Promise<void> {
+	try {
+		await gitFor(repoPath, {
+			abort: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		}).raw(["fetch", "origin", baseBranch]);
+	} catch {
+		/* best-effort -- branch off whatever ref we already have */
+	}
+}
+
 /** Resolve the start point for a new task branch: prefer the pushed base. */
 async function resolveStartPoint(
 	repoPath: string,
 	baseBranch: string,
 ): Promise<string> {
 	const git = gitFor(repoPath);
+	await fetchBase(repoPath, baseBranch);
 	if (await refExists(git, `refs/remotes/origin/${baseBranch}`)) {
 		return `origin/${baseBranch}`;
 	}

--- a/packages/git-core/test/git-core.test.ts
+++ b/packages/git-core/test/git-core.test.ts
@@ -73,6 +73,39 @@ describe("project", () => {
 	});
 });
 
+describe("createTask freshness", () => {
+	it("branches off the latest origin/<base>, not a stale cached ref", async () => {
+		// The clone's refs/remotes/origin/main is now behind the real remote --
+		// exactly the state a repo sits in between merges.
+		const advanced = await advanceOrigin(repo);
+		expect(await branchSha(repo.work, "refs/remotes/origin/main")).not.toBe(
+			advanced,
+		);
+
+		const task = await createTask({ repoPath: repo.work, name: "fresh" });
+
+		expect(await headSha(task.worktreePath)).toBe(advanced);
+	});
+
+	it("still creates the task when the remote is unreachable", async () => {
+		const advanced = await advanceOrigin(repo);
+		const cached = await branchSha(repo.work, "refs/remotes/origin/main");
+		await simpleGit(repo.work).raw([
+			"remote",
+			"set-url",
+			"origin",
+			join(repo.dir, "does-not-exist.git"),
+		]);
+
+		const task = await createTask({ repoPath: repo.work, name: "offline" });
+
+		// Falls back to the cached ref instead of failing: creating a task must
+		// never require the network.
+		expect(await headSha(task.worktreePath)).toBe(cached);
+		expect(cached).not.toBe(advanced);
+	});
+});
+
 describe("createTask isolation", () => {
 	it("creates a co-located worktree without disturbing the main worktree", async () => {
 		const headBefore = await simpleGit(repo.work).raw([


### PR DESCRIPTION
## The problem

`resolveStartPoint` branched off `refs/remotes/origin/<base>`, which is a **local cache**, and nothing on the task creation path ever refreshed it. The only fetches in `git-core` live in `updateFromBase` and the merge flow, so the cached ref stayed stale until someone happened to merge or hit "update from base".

Measured on a real checkout: the cached `origin/main` was **25 days old**, and a task created from it was born behind the remote tip.

Reacting to our own merges cannot fix this. Merges that land elsewhere (the GitHub UI, another clone, a teammate) are invisible here by construction, so fetching **at the moment of use** is the only formulation that does not depend on having witnessed the write.

## The change

`resolveStartPoint` now fetches the base ref first.

- **Best effort, never required.** Any failure (offline, no remote, a headless box with no credentials) falls through to the existing chain: cached ref, then local branch, then `HEAD`. Creating a task must never need the network, and Loops create tasks headlessly where no one can flip an offline switch.
- **Wall-clock capped at 5s** via simple-git's abort plugin. `gitFor` gains an optional abort signal so only this call trades the 5-minute *inactivity* budget for a wall-clock cap. The merge queue, which must complete rather than give up, keeps the old semantics.
- **Isolation preserved.** The bare `fetch origin <base>` refspec writes only `refs/remotes/origin/*`, never a local branch and never a worktree checkout. (Contrast the `<base>:<base>` form in `merge.ts`, which does write a local branch.)

Deliberately **no TTL**. Skipping the fetch when the cache is recent would reintroduce the exact symptom in the common workflow: merge a PR, immediately create the next task. During development of this change the remote tip moved twice in under an hour. It is additive later if a large repo ever makes the fetch hurt.

## Verification

- Full suite **288 pass, 0 fail**; typecheck clean.
- **Negative control**: with the fetch removed, the new test fails on the stale-vs-fresh sha mismatch, so it reproduces the bug rather than merely passing.
- **Real remote, end to end**: rewound `origin/main` to a stale sha, then `createTask` landed on the true tip in **735ms**, fetch included.
- **Dead network, end to end**: origin pointed at an unroutable IP, `createTask` fell back to the cached ref and still created the task in **5.36s**. `fsck` clean afterwards.

## Known caveat (documented in code)

Aborting kills `git`, but its `git-remote-https` child survives orphaned until the OS abandons the TCP connect (~75s on macOS). The caller is unblocked at 5s and the strays are idle and self-reaping. Git exposes no connect timeout (only `http.lowSpeed*`, which covers transfer rate), so bounding it tighter would mean bypassing simple-git entirely for this one call.