### PR TITLE
Boxes: upgrade themselves on connect, and an install that actually restarts

### DIFF
--- a/apps/desktop/src/main/host.ts
+++ b/apps/desktop/src/main/host.ts
@@ -148,6 +148,8 @@ export interface Host {
 	connected(): Promise<HostStatus[]>;
 	/** id → owning-engine alias (null = local), from the aggregate's learned registry. */
 	origins(): Record<string, string | null>;
+	/** alias → why the last self-initiated connect failed (empty once it succeeds). */
+	failures(): Record<string, string>;
 	/** Start the in-app editor on the task's engine and resolve the URL THIS
 	 *  client loads for it (localhost, ssh forward, or tailnet endpoint) — or
 	 *  report that the engine still needs code-server installed. */
@@ -185,6 +187,11 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 	// alias → backend; `null` is the always-held local engine (insertion order: local
 	// first). Boxes are added on connect and removed on disconnect.
 	const backends = new Map<string | null, Backend>([[null, local]]);
+	// Why a box the app connected to BY ITSELF didn't come up. A connect the user
+	// asked for rejects to its caller, which surfaces the message; the startup sweep
+	// has no caller, so its failures used to vanish into a catch and read to the user
+	// as an ordinary offline box. Keyed by alias, cleared the moment one succeeds.
+	const connectFailures = new Map<string, string>();
 	// Per-alias event unsubscribers, so disconnecting one box stops only its stream.
 	const unbinders = new Map<string | null, () => void>();
 	// Per-alias health probes (ws only) — cleared on disconnect so a dropped box
@@ -326,6 +333,7 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 			throw new Error(mismatchMessage(alias, info.protocolVersion, wire));
 		}
 
+		connectFailures.delete(alias);
 		recordConnection(db, {
 			hostAlias: alias,
 			transport: wire ?? "ssh",
@@ -394,9 +402,14 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 	function forget(alias: string): void {
 		disconnect(alias); // no-op if not held; drops the live engine if it is
 		forgetConnection(db, alias);
+		connectFailures.delete(alias);
 		// disconnect only broadcasts when the box was held — a never-connected row
 		// changes the list too, so always tell the renderer to re-read it.
 		broadcastConnections();
+	}
+
+	function failures(): Record<string, string> {
+		return Object.fromEntries(connectFailures);
 	}
 
 	function origins(): Record<string, string | null> {
@@ -626,12 +639,18 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 	// the renderer reconciles additively — so tasks fill in as engines answer.
 	for (const c of listConnections(db)) {
 		if (!c.known) continue;
-		void connect(c.alias).catch(() => {
-			// Unreachable or asleep. connect() already closed its own transport, and the
-			// connections list still renders the box from the offline cache, so leaving it
-			// disconnected is the honest outcome. A box that is merely BEHIND is not an
-			// error any more: connect() upgrades it over SSH and comes back held, which is
-			// the only path that reaches an SSH box without waiting for a user gesture.
+		void connect(c.alias).catch((err: unknown) => {
+			// Unreachable, asleep, or an upgrade that didn't take. connect() already closed
+			// its own transport, and the connections list still renders the box from the
+			// offline cache, so leaving it disconnected is the honest outcome. The REASON,
+			// though, is only known here: this is the one connect nobody awaits, so record
+			// it instead of dropping it. Without that, a failed upgrade looks exactly like
+			// a sleeping box, and the message explaining it dies in this catch.
+			// A box that is merely BEHIND is not an error any more: connect() upgrades it
+			// over SSH and comes back held, which is the only path that reaches an SSH box
+			// without waiting for a user gesture.
+			connectFailures.set(c.alias, err instanceof Error ? err.message : String(err));
+			broadcastConnections();
 		});
 	}
 
@@ -666,6 +685,7 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 		forget,
 		connected,
 		origins,
+		failures,
 		editorUrl,
 		provision,
 		install,
@@ -686,6 +706,7 @@ export function registerHostIpc(host: Host): void {
 	ipcMain.handle(HOST_CH.forget, (_e, alias: string) => host.forget(alias));
 	ipcMain.handle(HOST_CH.connected, () => host.connected());
 	ipcMain.handle(HOST_CH.origins, () => host.origins());
+	ipcMain.handle(HOST_CH.failures, () => host.failures());
 	ipcMain.handle(HOST_CH.provision, (_e, alias: string, input: { cloneUrl: string }) =>
 		host.provision(alias, input),
 	);

--- a/apps/desktop/src/main/host.ts
+++ b/apps/desktop/src/main/host.ts
@@ -113,6 +113,20 @@ const CONNECT_TIMEOUT_MS = 20_000;
 const WS_PING_INTERVAL_MS = 15_000;
 const WS_PING_TIMEOUT_MS = 10_000;
 
+/**
+ * Why a box was refused, and the one move that fixes it from where the user is.
+ * "Update the older side" was true and useless: on the phone there is no side to
+ * update, and on a box behind an SSH alias the desktop has already tried.
+ */
+function mismatchMessage(alias: string, boxVersion: number, wire: HostTransport | null): string {
+	const head = `"${alias}" speaks protocol v${boxVersion}, this app speaks v${PROTOCOL_VERSION}.`;
+	if (boxVersion > PROTOCOL_VERSION) return `${head} Update Ateam: the box is ahead of it.`;
+	if (wire === "ws") {
+		return `${head} It's reachable only over its Tailscale endpoint, so this app can't update it. Re-run the installer on the box over SSH.`;
+	}
+	return `${head} Updating it over SSH didn't take. Check the install log for what failed.`;
+}
+
 /** The push-events forwarded from every held backend to every window. */
 const FORWARDED: { event: BackendEvent; channel: string }[] = [
 	{ event: "taskUpdated", channel: CH.evtTaskUpdated },
@@ -270,7 +284,19 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 		return sshClientTransport(alias, [REMOTE_ATTACH], { sshFlags: editorForwardFlags(alias) });
 	}
 
-	async function connect(alias: string | null): Promise<HostStatus> {
+	/**
+	 * Connect a box, bringing it up to THIS app's protocol first if it is behind.
+	 *
+	 * `healed` marks the retry that `install()` makes after upgrading a box, so a box
+	 * that comes back still mismatched reports that instead of installing forever.
+	 *
+	 * Self-healing rather than an "update" button because the button scales the wrong
+	 * way: one press per box per protocol bump, and the phone has no press to give.
+	 * This is what VS Code Remote-SSH and Zed already do with their remote servers,
+	 * the client's version deciding the server's, installed on connect. It fires only
+	 * on a box that is BEHIND and reachable over SSH, never on the routine path.
+	 */
+	async function connect(alias: string | null, healed = false): Promise<HostStatus> {
 		// local is permanent; connecting to it (or to an already-held box) is a no-op.
 		if (alias === null) return statusOf(local, null);
 		const existing = backends.get(alias);
@@ -289,9 +315,15 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 		}
 		if (info.protocolVersion !== PROTOCOL_VERSION) {
 			client.close();
-			throw new Error(
-				`Protocol mismatch: "${alias}" speaks v${info.protocolVersion}, this app speaks v${PROTOCOL_VERSION}. Update the older side.`,
-			);
+			// Upward only. A box AHEAD of this app must not be downgraded: the desktop
+			// auto-updates, so the honest fix there is to let it. Upward-only is also what
+			// keeps two desktops on different versions from reinstalling a shared box back
+			// and forth, which is a real risk here because a box has ONE $HOME/ateam-app
+			// rather than the per-version directory VS Code keys its server by.
+			if (!healed && wire !== "ws" && info.protocolVersion < PROTOCOL_VERSION) {
+				return install(alias); // streams the installer's log, and ends by connecting
+			}
+			throw new Error(mismatchMessage(alias, info.protocolVersion, wire));
 		}
 
 		recordConnection(db, {
@@ -391,12 +423,20 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 		// derive the box's OWN tailnet IP on the box, so the phone's WebSocket listener
 		// is set up automatically when the box is on Tailscale. An empty ATEAM_WS_ADDR
 		// means "daemon service only, no listener" — install.sh treats it as unset.
+		// Pin the box to THIS app's release, the way VS Code keys its remote server to
+		// the client's commit. Unpinned, the box takes `releases/latest` and drifts away
+		// from the desktop the moment a newer release lands, which is the skew this whole
+		// path exists to close. Packaged builds only: a dev build's version has no tag
+		// behind it, and install.sh dies on a tag with no release, so dev keeps taking
+		// the latest, deliberately loud rather than a silent fallback that would leave a
+		// mismatched box and no clue why.
+		const pin = app.isPackaged ? `ATEAM_VERSION=v${app.getVersion()} ` : "";
 		const pipeline = wsAddr
-			? `curl -fsSL ${INSTALL_URL} | ATEAM_WS_ADDR=${wsAddr} bash -s -- --service`
+			? `curl -fsSL ${INSTALL_URL} | ${pin}ATEAM_WS_ADDR=${wsAddr} bash -s -- --service`
 			: // Single-quoted JS so the shell's ${ip:+…} parameter expansion stays literal.
 				"ip=$(command -v tailscale >/dev/null 2>&1 && tailscale ip -4 2>/dev/null | head -1 || true); " +
-				`curl -fsSL ${INSTALL_URL} ` +
-				'| ATEAM_WS_ADDR="${ip:+$ip:' +
+				`curl -fsSL ${INSTALL_URL} | ${pin}` +
+				'ATEAM_WS_ADDR="${ip:+$ip:' +
 				WS_DEFAULT_PORT +
 				'}" bash -s -- --service';
 
@@ -411,7 +451,7 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 		// We just reached the box over SSH, so its transport is ssh — seed that row so
 		// connect() resolves it even when `dest` is a user@host with no ssh_config entry.
 		recordConnection(db, { hostAlias: dest, transport: "ssh" });
-		return connect(dest);
+		return connect(dest, true);
 	}
 
 	// The encrypted provider-credentials store, created lazily (needs app to be ready).
@@ -587,9 +627,11 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 	for (const c of listConnections(db)) {
 		if (!c.known) continue;
 		void connect(c.alias).catch(() => {
-			// Unreachable, asleep, or version-mismatched. connect() already closed its
-			// own transport, and the connections list still renders the box from the
-			// offline cache, so leaving it disconnected is the honest outcome.
+			// Unreachable or asleep. connect() already closed its own transport, and the
+			// connections list still renders the box from the offline cache, so leaving it
+			// disconnected is the honest outcome. A box that is merely BEHIND is not an
+			// error any more: connect() upgrades it over SSH and comes back held, which is
+			// the only path that reaches an SSH box without waiting for a user gesture.
 		});
 	}
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -135,6 +135,7 @@ const host: AteamHost = {
 	forget: (alias) => ipcRenderer.invoke(HOST_CH.forget, alias),
 	connected: () => ipcRenderer.invoke(HOST_CH.connected),
 	origins: () => ipcRenderer.invoke(HOST_CH.origins),
+	failures: () => ipcRenderer.invoke(HOST_CH.failures),
 	provision: (alias, input) => ipcRenderer.invoke(HOST_CH.provision, alias, input),
 	install: (dest, opts) => ipcRenderer.invoke(HOST_CH.install, dest, opts),
 	createBox: (spec) => ipcRenderer.invoke(HOST_CH.createBox, spec),

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -114,6 +114,8 @@ export function App() {
 	// The ~/.ssh/config boxes a task can be sent to run on (the composer's "Run on"
 	// list). Connecting + cloning the repo onto one happens at task-create time.
 	const [connections, setConnections] = useState<ConnectionDTO[]>([]);
+	// alias → why the box didn't come up when the app connected to it by itself.
+	const [connFailures, setConnFailures] = useState<Record<string, string>>({});
 	// Which agents each connected engine actually has installed (its system:hello
 	// agents), keyed by alias ("local" for this Mac). Drives per-environment agent
 	// availability in the composer — you can only pick an agent the box really has.
@@ -303,6 +305,7 @@ export function App() {
 	useEffect(() => {
 		const load = () => {
 			void window.ateamHost.list().then(setConnections);
+			void window.ateamHost.failures().then(setConnFailures);
 			void window.ateamHost.connected().then((list) => {
 				const map: Record<string, string[]> = {};
 				for (const s of list) map[s.alias ?? "local"] = s.info.agents;
@@ -444,9 +447,13 @@ export function App() {
 				// `known` is only set by a successful connect, so a config alias we've
 				// never reached is one the engine has probably never been installed on.
 				needsSetup: !c.known,
+				// Set only for a connect the app made on its own, where there was no
+				// caller to show the error to — an upgrade that failed reads as an
+				// ordinary offline box without it.
+				error: connFailures[c.alias],
 			})),
 		];
-	}, [connections, canRemote, hasLocalMember, activeMembers]);
+	}, [connections, canRemote, hasLocalMember, activeMembers, connFailures]);
 
 	// The active card's board unions tasks from every engine that has the repo.
 	const activeTasks = activeCard

--- a/apps/desktop/src/renderer/src/components/EnvironmentPicker.tsx
+++ b/apps/desktop/src/renderer/src/components/EnvironmentPicker.tsx
@@ -24,6 +24,10 @@ export type EnvOption = {
 	transport?: "ssh" | "ws";
 	/** In ~/.ssh/config but never connected — so almost certainly has no engine yet. */
 	needsSetup?: boolean;
+	/** Why the app's own last connect attempt failed. Outranks the other sub-labels:
+	 *  a box that couldn't be reached or couldn't be upgraded is the reason it looks
+	 *  idle, and it's the only one of these the user can act on. */
+	error?: string;
 };
 
 export function EnvironmentPicker({
@@ -214,7 +218,11 @@ export function EnvironmentPicker({
 									</span>
 									<span className="conn-txt">
 										<span className="conn-title">{env.label}</span>
-										{env.disabled && env.alias !== null ? (
+										{env.error ? (
+											<span className="conn-sub conn-sub-err" title={env.error}>
+												{env.error}
+											</span>
+										) : env.disabled && env.alias !== null ? (
 											<span className="conn-sub">repo needs a git remote to run here</span>
 										) : env.needsSetup ? (
 											<span className="conn-sub">not set up — click to install the engine</span>

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -1773,6 +1773,10 @@ input {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+/* Truncated to the row like every other sub-label; the full text is the title. */
+.conn-sub-err {
+	color: var(--red);
+}
 .conn-spin {
 	animation: spin 0.7s linear infinite;
 	color: var(--text-dim);

--- a/apps/desktop/src/shared/host.ts
+++ b/apps/desktop/src/shared/host.ts
@@ -16,6 +16,8 @@ export const HOST_CH = {
 	connected: "host:connected",
 	/** projectId/taskId → owning engine alias (null = local), for per-origin badges/routing. */
 	origins: "host:origins",
+	/** alias → why the last automatic connect attempt failed (see AteamHost.failures). */
+	failures: "host:failures",
 	/** Clone+register a repo onto a specific box (connect it first). */
 	provision: "host:provision",
 	/** Install the ateam engine on a reachable SSH box, then connect to it. */
@@ -125,6 +127,13 @@ export interface AteamHost {
 	connected(): Promise<HostStatus[]>;
 	/** id → owning-engine alias (null = local) for each entity the engines have surfaced. */
 	origins(): Promise<Record<string, string | null>>;
+	/**
+	 * alias → the message from the last connect this app made on its OWN initiative
+	 * (the startup sweep). Those failures have no caller to reject to, so without
+	 * this a box that failed to come up is indistinguishable from one that is merely
+	 * asleep. A successful connect clears the entry.
+	 */
+	failures(): Promise<Record<string, string>>;
 	/** Connect the box if needed, then clone+register a repo ON it from its remote URL
 	 *  (so a task can run there). Returns the box's project row for that repo. */
 	provision(alias: string, input: { cloneUrl: string }): Promise<ProjectDTO>;

--- a/apps/mobile/src/connection.ts
+++ b/apps/mobile/src/connection.ts
@@ -73,8 +73,14 @@ export async function connect(url: string, opts: ConnectOptions = {}): Promise<C
 	}
 	if (info.protocolVersion !== PROTOCOL_VERSION) {
 		client.close();
+		// "Update the older side" points at no side a phone can reach: there is no SSH
+		// here, and an older box has no upgrade call to make (this handshake is refused
+		// before any call would land). So name the machine that CAN fix it. The desktop
+		// upgrades a box it connects to, which is what makes that sentence actionable.
 		throw new Error(
-			`Protocol mismatch: box speaks v${info.protocolVersion}, app speaks v${PROTOCOL_VERSION}. Update the older side.`,
+			info.protocolVersion < PROTOCOL_VERSION
+				? `This box runs an older Ateam (protocol v${info.protocolVersion}; this app speaks v${PROTOCOL_VERSION}). Open Ateam on your Mac and connect to the box: that updates it over SSH.`
+				: `This box runs a newer Ateam (protocol v${info.protocolVersion}; this app speaks v${PROTOCOL_VERSION}). Update the app on this phone.`,
 		);
 	}
 

--- a/docs/online-ateam.md
+++ b/docs/online-ateam.md
@@ -116,7 +116,12 @@ installs **Node 22** via nvm into your home directory and uses that — the laun
 pins the exact interpreter the modules were built for, so a later `nvm use` can't
 break it.
 
-Re-run the same command to upgrade. Three knobs, all optional:
+Re-run the same command to upgrade. It stops the daemon still running the old dist,
+then checks that the process answering afterwards is a different one, so an upgrade
+can no longer report success while the previous version keeps serving. Live agents
+are untouched: they belong to a separate PTY daemon the installer never signals.
+
+Three knobs, all optional:
 
 | Knob | Effect |
 | --- | --- |
@@ -347,7 +352,7 @@ The connection menu surfaces the real error inline. Common ones:
 | --- | --- |
 | **"No servers in ~/.ssh/config"** in the menu | Add a `Host` entry (step 3). |
 | Connect hangs or fails | Check `ssh <box>` works, Tailscale is up on **both** ends (`tailscale status`), and `ateam` is on the box's login PATH: `ssh <box> "bash -lc 'command -v ateam'"`. |
-| **"Protocol mismatch"** | The Mac app and box server are different versions — re-run the installer on the box (step 1), or update the desktop app, so both speak the same protocol. |
+| **"Protocol mismatch"** | A box running behind the Mac app is now upgraded on connect: the app reinstalls it over SSH at its own version, streaming the install log. You only see this error if the box is *ahead* of the app (update the Mac app), or if that upgrade failed, in which case the log says why. On the phone there is no SSH, so the fix is to open Ateam on your Mac and connect to the box once. |
 | Board is empty after connecting | The box has no registered projects yet — add one from the box's filesystem via **Add project** (or register a repo path on the box). |
 | Agents run but commits fail | The box has no git identity — `git config --global user.name/user.email` (step 0). |
 | The agent picker is empty | The agent CLI isn't on the box's **login** PATH: `ssh <box> "bash -lc 'command -v claude'"`. |

--- a/docs/online-ateam.md
+++ b/docs/online-ateam.md
@@ -352,7 +352,7 @@ The connection menu surfaces the real error inline. Common ones:
 | --- | --- |
 | **"No servers in ~/.ssh/config"** in the menu | Add a `Host` entry (step 3). |
 | Connect hangs or fails | Check `ssh <box>` works, Tailscale is up on **both** ends (`tailscale status`), and `ateam` is on the box's login PATH: `ssh <box> "bash -lc 'command -v ateam'"`. |
-| **"Protocol mismatch"** | A box running behind the Mac app is now upgraded on connect: the app reinstalls it over SSH at its own version, streaming the install log. You only see this error if the box is *ahead* of the app (update the Mac app), or if that upgrade failed, in which case the log says why. On the phone there is no SSH, so the fix is to open Ateam on your Mac and connect to the box once. |
+| **"Protocol mismatch"** | A box running behind the Mac app is now upgraded on connect: the app reinstalls it over SSH at its own version, streaming the install log. You only see this error if the box is *ahead* of the app (update the Mac app), or if that upgrade failed, in which case the box's row in the **Run on** list carries the reason. On the phone there is no SSH, so the fix is to open Ateam on your Mac and connect to the box once. |
 | Board is empty after connecting | The box has no registered projects yet — add one from the box's filesystem via **Add project** (or register a repo path on the box). |
 | Agents run but commits fail | The box has no git identity — `git config --global user.name/user.email` (step 0). |
 | The agent picker is empty | The agent CLI isn't on the box's **login** PATH: `ssh <box> "bash -lc 'command -v claude'"`. |

--- a/packages/server/scripts/install.sh
+++ b/packages/server/scripts/install.sh
@@ -44,6 +44,22 @@ die() {
 	exit 1
 }
 
+# The running engine daemon, identified by the one command line it always has:
+# APP_DIR is fixed, and the systemd unit execs that same launcher.
+DAEMON_PAT='ateam-app/cli\.js daemon'
+# `|| true` earns its place: pgrep exits 1 when nothing matches, and under
+# `pipefail` that becomes the substitution's status, which would trip `set -e` on
+# the ordinary "no daemon running" case.
+daemon_pid() { pgrep -f "$DAEMON_PAT" 2>/dev/null | head -1 || true; }
+
+# One `system:hello` through the same relay a real client uses, so what this
+# reports is what a client would see. `attach` is a persistent relay: it never
+# self-exits after replying, so cap it and keep the first line.
+handshake() {
+	printf '{"t":"req","id":1,"method":"system:hello","args":[]}\n' |
+		timeout 25 bash -lc 'ateam attach --stdio' 2>/dev/null | head -1 || true
+}
+
 if [ "$(id -u)" = 0 ]; then die "run this as the user that will own the agents, not as root"; fi
 command -v curl >/dev/null || die "curl is required"
 command -v tar >/dev/null || die "tar is required"
@@ -83,7 +99,7 @@ install_node22() {
 	set -eu
 }
 
-step "[1/6] locate a Node ≥ 22"
+step "[1/7] locate a Node ≥ 22"
 NODE="$(find_node)"
 if [ -z "$NODE" ]; then
 	install_node22
@@ -94,7 +110,7 @@ info "node: $NODE ($("$NODE" --version))"
 
 # ------------------------------------------------------------- download ------
 
-step "[2/6] fetch the server dist"
+step "[2/7] fetch the server dist"
 TARBALL="$TMP/ateam-server.tar.gz"
 if [ -n "${ATEAM_TARBALL:-}" ] && [ -f "$ATEAM_TARBALL" ]; then
 	info "source: $ATEAM_TARBALL (local)"
@@ -118,7 +134,7 @@ for f in cli.js daemon.js package.json; do
 	[ -f "$TMP/$f" ] || die "malformed tarball: missing $f"
 done
 
-step "[3/6] install to $APP_DIR"
+step "[3/7] install to $APP_DIR"
 mkdir -p "$APP_DIR" "$BIN_DIR"
 cp "$TMP/cli.js" "$TMP/daemon.js" "$TMP/package.json" "$APP_DIR/"
 
@@ -132,7 +148,7 @@ NPM="$(dirname "$NODE")/npm"
 
 natives_load() { (cd "$APP_DIR" && "$NODE" -e 'require("better-sqlite3");require("node-pty")' >/dev/null 2>&1); }
 
-step "[4/6] install native modules (prebuilt — no compiler needed)"
+step "[4/7] install native modules (prebuilt — no compiler needed)"
 (cd "$APP_DIR" && PATH="$(dirname "$NODE"):$PATH" "$NPM" install --omit=dev --no-audit --no-fund >/dev/null 2>&1) ||
 	die "npm install failed in $APP_DIR"
 
@@ -150,7 +166,7 @@ info "better-sqlite3 + node-pty load OK"
 
 # -------------------------------------------------------------- launcher ----
 
-step "[5/6] install the 'ateam' launcher on the login PATH"
+step "[5/7] install the 'ateam' launcher on the login PATH"
 # Node is pinned by absolute path: the launcher must use the SAME runtime the
 # natives were installed for, whatever a login shell's PATH happens to resolve.
 printf '#!/bin/sh\nexec %s "%s/cli.js" "$@"\n' "$NODE" "$APP_DIR" >"$BIN_DIR/ateam"
@@ -176,17 +192,55 @@ if ! bash -lc 'command -v ateam' >/dev/null 2>&1; then
 fi
 info "login shell resolves: $(bash -lc 'command -v ateam')"
 
+# ------------------------------------------------------------- restart ------
+
+step "[6/7] stop the daemon still running the old dist"
+# An upgrade that does not restart is not an upgrade. A running daemon holds its
+# code in MEMORY, so overwriting cli.js above changes nothing about what it
+# serves: the box keeps answering `system:hello` with the PREVIOUS protocol
+# version, and every client goes on refusing it ("update the older side") however
+# many times this installer is re-run, with the new dist sitting on disk beside it.
+#
+# Live agents are untouched. They belong to the PTY daemon (pty/daemon.ts), a
+# separate detached process this never signals; the engine reattaches to it on
+# start, and it only idle-exits once it has neither sessions nor clients. Clients
+# see a blip and no more: the desktop reconnects over SSH, the phone reattaches.
+#
+# Stopped rather than restarted, because nothing needs to own the socket yet: the
+# verify below spawns one from the NEW dist (which is what `ateam attach` does
+# when none is live), and --service hands that to systemd right after.
+OLD_PID="$(daemon_pid)"
+if [ -n "$OLD_PID" ]; then
+	pkill -f "$DAEMON_PAT" 2>/dev/null || true
+	sleep 1
+	info "stopped the old daemon (pid $OLD_PID); its agents keep running"
+	# A systemd-managed daemon comes straight back on its own here (a signal counts
+	# as failure, so `Restart=on-failure` fires), and that is fine: whatever starts
+	# from now on runs the dist installed above. So this deliberately does NOT wait
+	# for the pid to stay gone, which would race that restart and fail a healthy
+	# box. The invariant that actually matters is asserted by the verify below.
+else
+	info "no daemon was running"
+fi
+
 # -------------------------------------------------------------- verify ------
 
-step "[6/6] verify the handshake"
-# `attach` is a persistent relay — it never self-exits after replying, so cap it
-# and keep the first line. A real client holds the connection open instead.
-HELLO="$(printf '{"t":"req","id":1,"method":"system:hello","args":[]}\n' |
-	timeout 25 bash -lc 'ateam attach --stdio' 2>/dev/null | head -1 || true)"
+step "[7/7] verify the handshake"
+# Spawns a daemon from the dist just installed, so this proves the NEW code runs
+# on this box's Node (where an ABI break surfaces) and prints the version every
+# client will now see.
+HELLO="$(handshake)"
 case "$HELLO" in
 *protocolVersion*) info "OK  $HELLO" ;;
 *) die "handshake failed: ${HELLO:-<no reply>}" ;;
 esac
+# The one assertion that catches a silent no-op upgrade: the process answering
+# must not be the one that predates this install. A handshake alone cannot tell
+# the difference, which is why every stale box still reported a healthy install.
+NEW_PID="$(daemon_pid)"
+if [ -n "$OLD_PID" ] && [ "$NEW_PID" = "$OLD_PID" ]; then
+	die "pid $OLD_PID survived, so this box is still serving the OLD dist: stop it and re-run"
+fi
 
 # ------------------------------------------------------------------ gh ------
 
@@ -351,21 +405,42 @@ if [ "$WANT_SERVICE" = 1 ]; then
 	$SYSTEMCTL daemon-reload
 	$SYSTEMCTL enable ateam.service >/dev/null 2>&1 || true
 
-	# Never kill a daemon out from under running agents. If one is already up
-	# outside systemd, hand over deliberately rather than silently. Test for a live
-	# PROCESS, not for the socket file: a crashed daemon leaves the file behind, and
-	# that stale socket would otherwise make this skip starting the service.
-	if pgrep -f 'ateam-app/cli\.js daemon' >/dev/null 2>&1 && ! $SYSTEMCTL is-active --quiet ateam.service; then
-		info "a daemon is already running outside systemd — enabled for next boot."
-		info "to hand it over now (agents keep running; the PTY daemon is untouched):"
-		info "     pkill -f 'ateam-app/cli.js daemon' && $SYSTEMCTL start ateam"
-	else
-		$SYSTEMCTL start ateam.service
-		sleep 2
-		$SYSTEMCTL is-active --quiet ateam.service &&
-			info "service active; starts on boot" ||
-			die "service failed to start — $SYSTEMCTL status ateam"
+	# Take the socket back, then RESTART. Two reasons this is not `start`:
+	#   1. `start` on an already-active unit does nothing, so an upgrade left the
+	#      OLD process serving. That is the bug this installer shipped with, and it
+	#      is why boxes stayed on an old protocol through repeated installs.
+	#   2. `ateam daemon` deliberately bows out when a live daemon already owns the
+	#      socket, so a service started around one (the verify step's, or one that
+	#      an `ateam attach` spawned) exits 0 and the old code keeps answering.
+	# Running agents survive both, for the reason spelled out at [6/7].
+	if [ -n "$(daemon_pid)" ] && ! $SYSTEMCTL is-active --quiet ateam.service; then
+		info "handing the out-of-systemd daemon over to the service"
+		pkill -f "$DAEMON_PAT" 2>/dev/null || true
+		sleep 1
 	fi
+	$SYSTEMCTL restart ateam.service
+
+	# Prove the SERVICE is what answers now, and that it answers with the dist just
+	# installed. `is-active` alone passed happily while a stale daemon held the
+	# socket, which is precisely how the old protocol survived an "upgrade".
+	SVC_PID=""
+	for _ in 1 2 3 4 5 6 7 8 9 10; do
+		sleep 1
+		if $SYSTEMCTL is-active --quiet ateam.service; then
+			SVC_PID="$(daemon_pid)"
+			if [ -n "$SVC_PID" ]; then break; fi
+		fi
+	done
+	if [ -z "$SVC_PID" ]; then die "service failed to start: $SYSTEMCTL status ateam"; fi
+	if [ -n "$OLD_PID" ] && [ "$SVC_PID" = "$OLD_PID" ]; then
+		die "pid $OLD_PID survived the restart, so the service is still the OLD dist"
+	fi
+	HELLO="$(handshake)"
+	case "$HELLO" in
+	*protocolVersion*) info "service active (pid $SVC_PID); starts on boot" ;;
+	*) die "service is up but the handshake failed: ${HELLO:-<no reply>} ($SYSTEMCTL status ateam)" ;;
+	esac
+	info "serving: $HELLO"
 
 	if [ "$SERVICE_SCOPE" = user ]; then
 		info ""


### PR DESCRIPTION
A box could sit on an old protocol through any number of installs, and every
client refused it with advice nobody could act on.

## The installer never restarted anything

`install.sh` overwrote `cli.js` on disk but never stopped the daemon, which holds
its code in memory. The box kept answering `system:hello` with the previous
version, so re-running the installer changed nothing a client could see. The
`--service` path had the same hole from the other end: `systemctl start` on an
already-active unit is a no-op, and the handover it needed was only ever printed
as advice for the user to run by hand. Both endpoints then "verified" with a
handshake, which a stale daemon answers perfectly well, so every one of these
boxes reported a healthy install.

It now stops the old daemon before verifying, restarts the unit instead of
starting it, and asserts the thing a handshake cannot: the pid answering
afterwards is not the one that predates the install. Live agents are unaffected
either way, since they belong to the PTY daemon, a separate process nothing here
signals.

Because `INSTALL_URL` reads raw `main`, the fixed script reaches every stale box
the moment this lands, without anything needing to be pre-installed on it.

## The desktop refused instead of fixing

`connect()` threw "update the older side", which is no instruction at all on a
phone, where there is no side to update. It now upgrades a box that is behind by
reinstalling it over SSH at the app's own version, reusing `install()` so the
streamed log and the reconnect come for free. Upward only: a box ahead of the app
is never downgraded, which also stops two desktops on different versions from
reinstalling a shared box back and forth. `ATEAM_VERSION` pins a healed box to the
version the client speaks rather than letting it drift to `releases/latest`, on
packaged builds only so a dev build stays loud instead of failing on a tag with no
release. The phone's message now names the machine that can actually fix it.

## A failure that used to look like an offline box

The startup sweep is the one connect nobody awaits, and its catch threw the reason
away. Fine while every failure meant "asleep", but the sweep now also upgrades, so
a failed upgrade rendered exactly like a sleeping box. Failures are recorded per
alias and read back through a small IPC method shaped like `origins()`; the picker
shows the reason on the box's own row. A map rather than an event because the
sweep can fail before the renderer has subscribed, so the map is the truth and the
existing connections-changed broadcast is only an invalidation.

## Verification

Run live against a box that had been stuck on protocol v2 through repeated
installs:

- plain path: `stopped the old daemon (pid 3171)`, then `protocolVersion: 5`, engine pid 3171 to 301138
- `--service` path: real handover, `service active (pid 301643)`, handshake against the service rather than just `is-active`
- PTY daemon pid 3183, 23 days uptime, unchanged across both runs, so anything attached would have survived

Not covered by a test: the new picker row. The repo has no renderer test setup, and
reaching that row at runtime needs a seeded scratch instance with a project and a
failing box. The IPC contract is compile-checked (preload is typed as `AteamHost`)
and the clear-on-recovery path is traced, but the row itself has not been seen on
screen.
