### PR TITLE
Loops: an optional follow-up turn after the agent's first reply

### DIFF
--- a/apps/desktop/src/renderer/src/components/LoopsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/LoopsPanel.tsx
@@ -52,6 +52,7 @@ function envLabel(origins: Origins, id: string): string {
 interface LoopDraft {
 	name: string;
 	prompt: string;
+	followUp: string;
 	projectId: string;
 	agentId: string;
 	everyMin: string;
@@ -86,6 +87,7 @@ function LoopForm({
 	const draft = drafts.get(draftKey);
 	const [name, setName] = useState(draft?.name ?? editing?.title ?? "");
 	const [prompt, setPrompt] = useState(draft?.prompt ?? editing?.prompt ?? "");
+	const [followUp, setFollowUp] = useState(draft?.followUp ?? editing?.followUp ?? "");
 	const [projectId, setProjectId] = useState(
 		draft?.projectId ?? editing?.projectId ?? projects[0]?.id ?? "",
 	);
@@ -100,8 +102,8 @@ function LoopForm({
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
-		drafts.set(draftKey, { name, prompt, projectId, agentId, everyMin });
-	}, [draftKey, name, prompt, projectId, agentId, everyMin]);
+		drafts.set(draftKey, { name, prompt, followUp, projectId, agentId, everyMin });
+	}, [draftKey, name, prompt, followUp, projectId, agentId, everyMin]);
 
 	const close = (done: () => void) => {
 		drafts.delete(draftKey);
@@ -120,7 +122,7 @@ function LoopForm({
 					id: editing.id,
 					name: name.trim() || "Loop",
 					intervalMs: Number(everyMin) * 60_000,
-					config: { prompt: prompt.trim(), agentId },
+					config: { prompt: prompt.trim(), agentId, followUp: followUp.trim() },
 				});
 			} else {
 				// The chosen project decides the environment: its engine (this Mac or
@@ -130,7 +132,7 @@ function LoopForm({
 					name: name.trim() || "Loop",
 					projectId,
 					intervalMs: Number(everyMin) * 60_000,
-					config: { prompt: prompt.trim(), agentId },
+					config: { prompt: prompt.trim(), agentId, followUp: followUp.trim() },
 				});
 			}
 			// Re-list rather than trust the call's return: the call ran on ONE
@@ -200,6 +202,16 @@ function LoopForm({
 							value={prompt}
 							placeholder="Update dependencies and open a PR."
 							onChange={(e) => setPrompt(e.target.value)}
+						/>
+					</label>
+				</div>
+				<div className="loop-form-row">
+					<label>
+						Follow-up (optional) — sent once, after the agent's first reply
+						<textarea
+							value={followUp}
+							placeholder="/check"
+							onChange={(e) => setFollowUp(e.target.value)}
 						/>
 					</label>
 				</div>

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -29,7 +29,12 @@
 // plus a `recommended` flag (it used to be a flat, pre-filtered row). Both are
 // shape changes the cleanup dialog reads directly, so an older engine would feed
 // it rows with no `task` at all — the handshake must catch that skew first.
-export const PROTOCOL_VERSION = 6;
+// v7: LoopDTO gained `followUp`, and the follow-up turn is delivered by the
+// engine's own turn-end hook. The skew is silent otherwise: a new desktop would
+// happily save a follow-up onto an older box, which stores the config key,
+// ignores it at launch, and never continues the turn — a field that looks saved
+// and does nothing. Better to say "update the older side" at the handshake.
+export const PROTOCOL_VERSION = 7;
 
 export type KanbanColumn = "todo" | "running" | "needs_attention" | "review" | "merged";
 
@@ -186,6 +191,8 @@ export interface LoopDTO {
 	prompt: string | null;
 	/** Which coding agent each run launches (agent-session loops). */
 	agentId: string | null;
+	/** Optional second turn, sent once after the agent's first reply. */
+	followUp: string | null;
 	/** The loop's one persistent task — every run is a fresh session in it. */
 	taskId: string | null;
 	intervalMs: number | null;

--- a/packages/server/src/agent-setup/index.ts
+++ b/packages/server/src/agent-setup/index.ts
@@ -18,7 +18,11 @@ TID="\${ATEAM_TERMINAL_ID:-\${GROVE_TERMINAL_ID:-}}"
 [ -z "$PORT" ] && exit 0
 [ -z "$TID" ] && exit 0
 EVENT="\${1:-Stop}"
-curl -s -m 2 "http://127.0.0.1:\${PORT}/hook/complete?terminalId=\${TID}&eventType=\${EVENT}&sessionId=\${CLAUDE_SESSION_ID:-}" >/dev/null 2>&1 || true
+# The reply is empty (204) unless this terminal has a follow-up armed, in which
+# case it is the agent's own continuation JSON and stdout is where it belongs.
+# A timeout or an unreachable app also yields empty, i.e. the old behaviour.
+BODY=$(curl -s -m 2 "http://127.0.0.1:\${PORT}/hook/complete?terminalId=\${TID}&eventType=\${EVENT}&sessionId=\${CLAUDE_SESSION_ID:-}" 2>/dev/null || true)
+[ -n "$BODY" ] && printf '%s' "$BODY"
 exit 0
 `;
 
@@ -38,7 +42,11 @@ case "$1" in
 	*approval*) EVENT="PermissionRequest" ;;
 	*) exit 0 ;;
 esac
-curl -s -m 2 "http://127.0.0.1:\${PORT}/hook/complete?terminalId=\${TID}&eventType=\${EVENT}" >/dev/null 2>&1 || true
+# Same follow-up echo as notify.sh. The notify program is fire-and-forget, so a
+# follow-up only reaches the agent through .codex/hooks.json, where Stop shares
+# Claude's hook schema.
+BODY=$(curl -s -m 2 "http://127.0.0.1:\${PORT}/hook/complete?terminalId=\${TID}&eventType=\${EVENT}" 2>/dev/null || true)
+[ -n "$BODY" ] && printf '%s' "$BODY"
 exit 0
 `;
 

--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -19,6 +19,7 @@ import type {
 	TaskDTO,
 } from "@ateam/protocol";
 import { ensureGhShim, ensureNotifyScript } from "./agent-setup";
+import { FollowUps } from "./follow-ups";
 import { type HookEvent, HookServer, type MergeRequestEvent } from "./hooks/hook-server";
 import { applySetStatus, buildBoardView } from "./loops/board-signals";
 import { LoopRunner } from "./loops/runner";
@@ -142,6 +143,7 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 	repo.updateSettings(db, { hookPort });
 
 	const mergeQueue = new MergeQueue({ db, onTaskUpdated: sendTaskUpdated });
+	const followUps = new FollowUps();
 	// Loops are user-created only; nothing is registered here. A loop tick
 	// starts an agent session through the same task-create + spawn path the
 	// composer uses. (`services` is declared just below and also holds this
@@ -172,6 +174,10 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 		setStatus: async (req) => applySetStatus(db, req, sendTaskUpdated),
 	});
 
+	// A finished turn with a follow-up armed continues instead of stopping. The
+	// lookup consumes, so it can only ever fire once per launch.
+	hooks.setFollowUpResolver((terminalId, eventType) => followUps.take(terminalId, eventType));
+
 	const services: Services = {
 		db,
 		pty,
@@ -182,6 +188,7 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 		hookPort,
 		mergeQueue,
 		loopRunner,
+		followUps,
 	};
 
 	// Record an agent's exit: close the session and file its card. Shared by the
@@ -220,6 +227,8 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 		// after its process is gone — the gap that previously stranded cards in
 		// the running column. Code that needs liveness must ask the PTY daemon
 		// (pty.has), not this status.
+		// The pane is gone, so a follow-up armed for it can never be delivered.
+		followUps.discard(e.terminalId);
 		const session = repo.getSessionByTerminal(db, e.terminalId);
 		if (!session) return;
 		if (session.exitedAt == null) applyAgentExit(session.id, session.taskId, Date.now(), true);

--- a/packages/server/src/follow-ups.ts
+++ b/packages/server/src/follow-ups.ts
@@ -1,0 +1,49 @@
+/**
+ * One-shot follow-ups — a second turn the agent takes by itself, right after
+ * the first response of a run (the "run /check once you've analysed it" move).
+ *
+ * Delivery is the agent's OWN continuation contract, never keystrokes. When a
+ * turn ends, the status hook already pings the hook server; if that terminal
+ * has a follow-up armed, the reply is `{"decision":"block","reason":"<text>"}`,
+ * which the hook script hands back on stdout and the agent acts on. Verified
+ * against Claude Code 2.1.251, where `decision: "block"` is the documented Stop
+ * output and both a slash command and a plain sentence travel this path
+ * identically. This is what keeps Ateam out of typing into a live TUI — see
+ * `loops/agent-loops.design.md`, "zero PTY injection".
+ *
+ * Two properties this module owns:
+ *
+ *   - **Only a real turn end fires it.** `Stop` alone qualifies. A permission
+ *     prompt reports `PermissionRequest`, so a follow-up can never be delivered
+ *     into a pending question.
+ *   - **Consume-once.** The entry is dropped the instant it is handed out, so a
+ *     run can never continue itself twice. The agent's own `stop_hook_active`
+ *     backstop sits underneath that, but it is not what we rely on.
+ */
+export class FollowUps {
+	private pending = new Map<string, string>();
+
+	/** Arm the follow-up for a terminal, at launch. Blank text arms nothing. */
+	arm(terminalId: string, text: string | undefined): void {
+		const trimmed = text?.trim();
+		if (trimmed) this.pending.set(terminalId, trimmed);
+	}
+
+	/** Hand out this terminal's follow-up, once, and only at a real turn end. */
+	take(terminalId: string, eventType: string): string | undefined {
+		if (eventType !== "Stop") return undefined;
+		const text = this.pending.get(terminalId);
+		if (text !== undefined) this.pending.delete(terminalId);
+		return text;
+	}
+
+	/** Forget an unused follow-up — the pane died before any turn ended. */
+	discard(terminalId: string): void {
+		this.pending.delete(terminalId);
+	}
+
+	/** Armed count, for tests. */
+	get size(): number {
+		return this.pending.size;
+	}
+}

--- a/packages/server/src/hooks/hook-server.ts
+++ b/packages/server/src/hooks/hook-server.ts
@@ -16,6 +16,13 @@ export interface MergeRequestEvent {
 	strategy?: string;
 }
 
+/**
+ * Asks whether a finished turn should be continued with a follow-up prompt.
+ * Returning text turns the agent's own `Stop` into another turn; returning
+ * undefined lets it stop. Consuming is the resolver's job (see `FollowUps`).
+ */
+export type FollowUpResolver = (terminalId: string, eventType: string) => string | undefined;
+
 /** Only localhost origins may reach the MCP endpoint (DNS-rebinding guard). */
 const LOCAL_ORIGIN = /^https?:\/\/(127\.0\.0\.1|localhost)(:\d+)?$/;
 
@@ -28,11 +35,17 @@ const LOCAL_ORIGIN = /^https?:\/\/(127\.0\.0\.1|localhost)(:\d+)?$/;
 export class HookServer extends EventEmitter {
 	private server?: http.Server;
 	private board?: BoardHandlers;
+	private followUp?: FollowUpResolver;
 	port = 0;
 
 	/** Wire the Board Organizer's request/response tool handlers. */
 	setBoardHandlers(handlers: BoardHandlers): void {
 		this.board = handlers;
+	}
+
+	/** Wire the one-shot follow-up lookup consulted at every turn end. */
+	setFollowUpResolver(resolve: FollowUpResolver): void {
+		this.followUp = resolve;
 	}
 
 	async start(preferred?: number): Promise<number> {
@@ -132,6 +145,15 @@ export class HookServer extends EventEmitter {
 							eventType,
 							sessionId,
 						} satisfies HookEvent);
+					}
+					// A turn that ends with a follow-up armed continues instead of
+					// stopping: this body IS the agent's Stop-hook output, echoed
+					// straight back by notify.sh. Every other request keeps the
+					// empty 204 it has always returned, so a session without a
+					// follow-up behaves exactly as before.
+					const followUp = terminalId ? this.followUp?.(terminalId, eventType) : undefined;
+					if (followUp) {
+						return json(200, { decision: "block", reason: followUp });
 					}
 					res.writeHead(204);
 					res.end();

--- a/packages/server/src/loops/agent-loops.design.md
+++ b/packages/server/src/loops/agent-loops.design.md
@@ -56,13 +56,32 @@ exactly what justifies a thin per-agent adapter (the greybeard-`install.js` /
 
 | Agent | Native seam | Ateam already has | Binding |
 |---|---|---|---|
-| **Claude Code** | native `/loop` skill (self-paced; carries into backgrounded sessions) — [docs](https://code.claude.com/docs/en/scheduled-tasks.md) | launch args / PTY | Launch the session with `/loop <prompt>`. Cadence + self-pacing live in the agent; Ateam holds the record + a hard cap. The Stop-hook "continue" is **undocumented** for Claude, so we use the native command, not a hook. |
+| **Claude Code** | native `/loop` skill (self-paced; carries into backgrounded sessions) — [docs](https://code.claude.com/docs/en/scheduled-tasks.md), **and** the same `Stop`-hook block-and-continue as Codex | launch args / PTY / hook server | Open-ended self-paced loops: launch with `/loop <prompt>`; cadence lives in the agent, Ateam holds the record + a hard cap. Bounded continuations: the Stop hook (see below). |
 | **Codex** | `Stop` hook returns `{"decision":"block","reason":"…"}` to keep going — [docs](https://developers.openai.com/codex/hooks) (its in-session `/loop`/cron is only [proposed #25466](https://github.com/openai/codex/issues/25466), **not shipped**) | writes `.codex/hooks.json` + runs the hook server | On `Stop`, a hook script GETs `/loop/decide` → server runs `decideContinuation` → returns `block`+prompt to continue, or allows the stop. **Zero PTY injection.** Lowest-effort native win. |
 | **OpenCode** | `session.idle` plugin event + plugin API to inject a prompt (no native loop/cron at all) — [docs](https://opencode.ai/docs/plugins/); community proof: [opencode-loop](https://github.com/ByBrawe/opencode-loop) | plugin registration | A small plugin: on `session.idle`, call `/loop/decide`; if continue, inject the prompt. Same shared decision. |
 
 The "brain" (continue? next prompt?) is one shared function; only the *binding*
 differs — and for Codex/OpenCode the binding is a hook/plugin file Ateam already
 knows how to write, so the cross-agent layer is cheap.
+
+### Correction (2026-08-31): Claude's Stop hook DOES block-and-continue
+
+The matrix above originally said the Stop-hook "continue" was undocumented for
+Claude. That was true when this was written (2026-07-03) and is no longer. In
+Claude Code 2.1.251 the bundled hooks reference documents `"decision": "block"`
+for Stop, with `reason` as the instruction the agent then acts on, plus a
+`stop_hook_active` flag in the hook's stdin payload and a
+`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` backstop. Verified by running it, not just by
+reading it: a Stop hook returning `{"decision":"block","reason":"/somecommand"}`
+made the agent execute that slash command instead of stopping, and a plain
+sentence in `reason` is followed the same way.
+
+`follow-ups.ts` is the first user of that seam: a Loop's optional follow-up is
+one extra turn taken right after the first response. It changes nothing about
+the "zero PTY injection" rule above, which still holds and is why keystroke
+delivery was rejected for it. Note the split: the native `/loop` is still the
+right engine for an open-ended self-paced loop, while the Stop hook is the right
+one for a bounded, externally-supplied continuation.
 
 ## Termination is mandatory (why the cap is not optional)
 

--- a/packages/server/src/loops/runner.ts
+++ b/packages/server/src/loops/runner.ts
@@ -265,6 +265,7 @@ export class LoopRunner {
 				cadence: cadence?.mode ?? "self_paced",
 				prompt: typeof row.config?.prompt === "string" ? row.config.prompt : null,
 				agentId: typeof row.config?.agentId === "string" ? row.config.agentId : null,
+				followUp: typeof row.config?.followUp === "string" ? row.config.followUp : null,
 				// The loop's persistent task (lastTaskId = pre-persistent-era key).
 				taskId:
 					typeof row.config?.taskId === "string"

--- a/packages/server/src/loops/templates.ts
+++ b/packages/server/src/loops/templates.ts
@@ -48,11 +48,21 @@ const agentSession: LoopTemplate = {
 	params: [
 		{ key: "prompt", label: "Prompt", type: "string", default: "" },
 		{ key: "agentId", label: "Agent", type: "string", default: "claude" },
+		{
+			key: "followUp",
+			label: "Follow-up",
+			type: "string",
+			default: "",
+			help: "Sent once, after the agent's first reply. A slash command or a sentence.",
+		},
 	],
 	build: (config) => async (ctx) => {
 		const prompt = str(config.prompt)?.trim();
 		const projectId = str(config.projectId);
 		const agentId = str(config.agentId) ?? "claude";
+		// Optional: the agent takes one more turn on this the moment its first
+		// response lands. Empty means the run is a single turn, as before.
+		const followUp = str(config.followUp)?.trim();
 		if (!prompt) throw new Error("Loop has no prompt");
 		if (!projectId) throw new Error("Loop has no project");
 		// The runner injects the row id so a run can read/update its own record.
@@ -99,7 +109,7 @@ const agentSession: LoopTemplate = {
 			ctx.stopTaskSessions(task.id);
 		}
 
-		await ctx.spawnAgent({ taskId: task.id, agentId, prompt });
+		await ctx.spawnAgent({ taskId: task.id, agentId, prompt, followUp });
 		if (loopId && row) {
 			// Persist the link under `taskId`; drop the legacy key it migrated from.
 			const { lastTaskId: _legacy, ...rest } = row.config ?? {};

--- a/packages/server/src/loops/types.ts
+++ b/packages/server/src/loops/types.ts
@@ -21,6 +21,8 @@ export interface LoopSessionOps {
 		taskId: string;
 		agentId: string;
 		prompt: string;
+		/** Optional second turn, taken right after the first response. */
+		followUp?: string;
 	}) => Promise<{ terminalId: string }>;
 	/** Kill a task's live PTYs (the previous run's idle pane). */
 	stopTaskSessions: (taskId: string) => void;

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -1,5 +1,6 @@
 import type { AgentSession, AteamDb, Project, Task } from "@ateam/db";
 import type { ProjectDTO, SessionDTO, TaskDTO } from "@ateam/protocol";
+import type { FollowUps } from "./follow-ups";
 import type { HookServer } from "./hooks/hook-server";
 import type { LoopRunner } from "./loops/runner";
 import type { MergeQueue } from "./merge-queue";
@@ -16,6 +17,8 @@ export interface Services {
 	hookPort: number;
 	mergeQueue: MergeQueue;
 	loopRunner: LoopRunner;
+	/** One-shot follow-up turns, armed at launch and consumed at turn end. */
+	followUps: FollowUps;
 }
 
 export function toProjectDTO(p: Project): ProjectDTO {

--- a/packages/server/src/sessions.ts
+++ b/packages/server/src/sessions.ts
@@ -20,6 +20,12 @@ export interface SpawnAgentInput {
 	agentMode?: boolean;
 	prompt?: string;
 	files?: string[];
+	/**
+	 * One extra turn to take right after the first response, delivered through
+	 * the agent's own turn-end hook (see `follow-ups.ts`). A slash command and a
+	 * plain sentence are both just text here.
+	 */
+	followUp?: string;
 }
 
 /** Create a task (branch + worktree + row) in a project and announce it. */
@@ -124,6 +130,10 @@ export async function spawnAgentInTask(
 		cwd: task.worktreePath,
 		env,
 	});
+
+	// Arm before the first turn can possibly end. The entry is consumed by the
+	// turn-end hook, or dropped if the pane dies first.
+	services.followUps.arm(terminalId, input.followUp);
 
 	repo.updateTask(services.db, task.id, {
 		column: "running",

--- a/packages/server/test/follow-ups.test.ts
+++ b/packages/server/test/follow-ups.test.ts
@@ -1,0 +1,157 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureNotifyScript } from "../src/agent-setup";
+import { FollowUps } from "../src/follow-ups";
+import { HookServer } from "../src/hooks/hook-server";
+
+describe("FollowUps", () => {
+	it("arms and hands out the text once", () => {
+		const f = new FollowUps();
+		f.arm("t1", "/check");
+		expect(f.take("t1", "Stop")).toBe("/check");
+		// Consume-once is the termination guarantee: a run cannot continue itself
+		// a second time even if the agent stops again.
+		expect(f.take("t1", "Stop")).toBeUndefined();
+		expect(f.size).toBe(0);
+	});
+
+	it("only fires at a real turn end", () => {
+		const f = new FollowUps();
+		f.arm("t1", "/check");
+		// A pending permission prompt must never consume the follow-up, or the
+		// answer to a question would be swallowed as the follow-up turn.
+		expect(f.take("t1", "PermissionRequest")).toBeUndefined();
+		expect(f.take("t1", "Working")).toBeUndefined();
+		expect(f.take("t1", "Stop")).toBe("/check");
+	});
+
+	it("arms nothing for blank text, and trims", () => {
+		const f = new FollowUps();
+		f.arm("t1", "   ");
+		f.arm("t2", undefined);
+		f.arm("t3", "  run the checks  ");
+		expect(f.size).toBe(1);
+		expect(f.take("t3", "Stop")).toBe("run the checks");
+	});
+
+	it("keeps terminals independent and drops on discard", () => {
+		const f = new FollowUps();
+		f.arm("t1", "one");
+		f.arm("t2", "two");
+		f.discard("t1");
+		expect(f.take("t1", "Stop")).toBeUndefined();
+		expect(f.take("t2", "Stop")).toBe("two");
+	});
+});
+
+// The shape below is the agent's own Stop-hook contract, verified against
+// Claude Code 2.1.251: a `decision: "block"` reply is what turns a finished
+// turn into another one, with `reason` as the instruction it acts on.
+describe("hook server /hook/complete", () => {
+	const hooks = new HookServer();
+	const started = hooks.start(0);
+	afterAll(() => hooks.stop());
+
+	const complete = async (terminalId: string, eventType: string) => {
+		const port = await started;
+		const res = await fetch(
+			`http://127.0.0.1:${port}/hook/complete?terminalId=${terminalId}&eventType=${eventType}`,
+		);
+		const text = await res.text();
+		return { status: res.status, body: text ? JSON.parse(text) : null };
+	};
+
+	it("answers an empty 204 when nothing is armed", async () => {
+		await started;
+		const follow = new FollowUps();
+		hooks.setFollowUpResolver((id, ev) => follow.take(id, ev));
+		// The unchanged path every session without a follow-up takes: no body,
+		// so notify.sh prints nothing and the agent stops as it always has.
+		const r = await complete("term-none", "Stop");
+		expect(r.status).toBe(204);
+		expect(r.body).toBeNull();
+	});
+
+	it("returns the continuation JSON for an armed terminal, once", async () => {
+		await started;
+		const follow = new FollowUps();
+		hooks.setFollowUpResolver((id, ev) => follow.take(id, ev));
+		follow.arm("term-armed", "/check");
+
+		const first = await complete("term-armed", "Stop");
+		expect(first.status).toBe(200);
+		expect(first.body).toEqual({ decision: "block", reason: "/check" });
+
+		const second = await complete("term-armed", "Stop");
+		expect(second.status).toBe(204);
+		expect(second.body).toBeNull();
+	});
+
+	it("does not continue a turn that ended on a permission prompt", async () => {
+		await started;
+		const follow = new FollowUps();
+		hooks.setFollowUpResolver((id, ev) => follow.take(id, ev));
+		follow.arm("term-ask", "/check");
+
+		const asked = await complete("term-ask", "PermissionRequest");
+		expect(asked.status).toBe(204);
+		// Still armed: it fires on the turn end that actually follows.
+		const stopped = await complete("term-ask", "Stop");
+		expect(stopped.body).toEqual({ decision: "block", reason: "/check" });
+	});
+
+	it("still emits the status event it always did", async () => {
+		await started;
+		const follow = new FollowUps();
+		hooks.setFollowUpResolver((id, ev) => follow.take(id, ev));
+		follow.arm("term-evt", "/check");
+		const seen: string[] = [];
+		hooks.on("hook", (e) => seen.push(`${e.terminalId}:${e.eventType}`));
+		await complete("term-evt", "Stop");
+		expect(seen).toContain("term-evt:Stop");
+	});
+});
+
+// The notify script is generated shell: nothing typechecks it, and a quoting
+// slip would only show up as an agent that silently never continues. So run the
+// REAL script against a REAL server and read the bytes Claude would read.
+describe("notify.sh follow-up echo", () => {
+	it("prints the continuation JSON, and nothing when unarmed", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "ateam-followup-"));
+		const scriptPath = await ensureNotifyScript(dir);
+		const hooks = new HookServer();
+		const port = await hooks.start(0);
+		const follow = new FollowUps();
+		hooks.setFollowUpResolver((id, ev) => follow.take(id, ev));
+		follow.arm("term-sh", "/check");
+
+		const run = async (eventType: string) => {
+			const proc = Bun.spawn(["sh", scriptPath, eventType], {
+				env: {
+					...process.env,
+					ATEAM_HOOK_PORT: String(port),
+					ATEAM_TERMINAL_ID: "term-sh",
+				},
+				stdout: "pipe",
+			});
+			const out = await new Response(proc.stdout).text();
+			await proc.exited;
+			return { out, code: proc.exitCode };
+		};
+
+		const armed = await run("Stop");
+		expect(JSON.parse(armed.out)).toEqual({ decision: "block", reason: "/check" });
+		expect(armed.code).toBe(0);
+
+		// Consumed: the next turn end prints nothing at all, which is what every
+		// ordinary session sees on every Stop.
+		const spent = await run("Stop");
+		expect(spent.out).toBe("");
+		expect(spent.code).toBe(0);
+
+		hooks.stop();
+		await rm(dir, { recursive: true, force: true });
+	});
+});


### PR DESCRIPTION
A loop's tick is often two moves, not one: analyse, then check the analysis. Doing both in a single prompt works less well, because the check is worth running against an answer the agent has already committed to.

So a loop gains **one optional field**. Blank means a run is a single turn, exactly as before. The text is opaque: a slash command (`/check`) and a plain sentence both work, and nothing parses or special-cases either.

## Delivery: the agent's own turn-end contract, never keystrokes

The status hook already pings the hook server on every `Stop`. If that terminal has a follow-up armed, the reply is now `{"decision":"block","reason":"<text>"}`, which the notify script echoes to stdout and the agent acts on. Sessions with nothing armed keep the empty 204 they have always had, so their behaviour is byte-identical.

This keeps the "zero PTY injection" rule in `agent-loops.design.md`. That doc said Claude's Stop-hook continue was undocumented, which was true in July and is not now; it is corrected here, verified by running it rather than by reading it.

Two properties live in `follow-ups.ts` and are what make it safe:

- **Only a real turn end fires it.** `Stop` alone qualifies, so a follow-up can never be delivered into a pending permission prompt.
- **Consume-once**, so a run cannot continue itself twice. The agent's own `stop_hook_active` cap sits underneath that rather than being relied on.

## Version skew

`PROTOCOL_VERSION` goes to 8, and `followUps: 8` is registered in `FEATURE_MIN_VERSION` (which landed on main mid-branch). The read side degrades harmlessly, but the write side does not: a v7 box stores the config key, ignores it, and never continues the turn. Since v7 a mismatch no longer refuses, so the bump alone protects nobody. The field is disabled with an explanatory label when the loop's project lives on an older box, mirroring how `cleanup` is gated.

## Tests

Unit behaviour, the hook server's HTTP contract, and the **real generated `notify.sh` run against a real server**, since that script is generated shell that nothing typechecks. 304 pass.

## Known gaps

- OpenCode sessions get no hooks at all, so a follow-up set on one is inert. Not gated in the UI.
- Not yet watched end to end in a live interactive session: the sandbox blocks synthetic TTY input, and the workspace-trust dialog blocks unattended interactive launches. Verified in print mode, where both a slash command and a sentence continue the turn correctly.