### PR TITLE
Sidebar: every accordion label stays visible, each list scrolls itself

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -850,7 +850,7 @@ export function App() {
 								</span>
 							</div>
 						) : (
-							<>
+							<div className="side-section">
 								{/* PROJECTS accordion */}
 								<div className="section-head">
 									<button
@@ -867,219 +867,232 @@ export function App() {
 									</button>
 									<IconButton icon={FolderPlus} label="Add project" onClick={addProject} />
 								</div>
-								{!projectsCollapsed &&
-									unifiedProjects.map((card) => {
-										const alert = cardAlert(card);
-										// Selecting/detaching acts on the local copy if present, else the first.
-										const primary = card.members.find((m) => m.alias === null) ?? card.members[0];
-										if (!primary) return null;
-										const active = card.members.some((m) => m.projectId === activeProjectId);
-										// Show the environments this repo spans (Local · box) when it's on more
-										// than just this Mac — that's the multi-engine cue.
-										const multiEnv =
-											card.members.length > 1 || card.members.some((m) => m.alias !== null);
-										return (
-											// Double-click (or the hover button) detaches the project into its
-											// own window. Row and open-button are siblings so the button's
-											// click can't nest inside the row button.
-											<div
-												key={card.key}
-												className="proj-row"
-												onDoubleClick={() => window.ateam.window.openProject(primary.projectId)}
-											>
-												<button
-													type="button"
-													className={`proj ${active ? "active" : ""}`}
-													onClick={() => selectProject(primary.projectId)}
+								{!projectsCollapsed && (
+									<div className="side-list">
+										{unifiedProjects.map((card) => {
+											const alert = cardAlert(card);
+											// Selecting/detaching acts on the local copy if present, else the first.
+											const primary = card.members.find((m) => m.alias === null) ?? card.members[0];
+											if (!primary) return null;
+											const active = card.members.some((m) => m.projectId === activeProjectId);
+											// Show the environments this repo spans (Local · box) when it's on more
+											// than just this Mac — that's the multi-engine cue.
+											const multiEnv =
+												card.members.length > 1 || card.members.some((m) => m.alias !== null);
+											return (
+												// Double-click (or the hover button) detaches the project into its
+												// own window. Row and open-button are siblings so the button's
+												// click can't nest inside the row button.
+												<div
+													key={card.key}
+													className="proj-row"
+													onDoubleClick={() => window.ateam.window.openProject(primary.projectId)}
 												>
-													<span
-														className={`dot ${alert ? `alert ${alert}` : ""}`}
-														style={!alert && card.color ? { background: card.color } : undefined}
-													/>
-													<span className="proj-name" title={primary.project.repoPath}>
-														{card.name}
-													</span>
-													{multiEnv && (
-														// One icon per environment — a monitor for this Mac, a server per
-														// box — instead of the names, which crowded the row as soon as a
-														// repo spanned more than one box. The name is the hover title
-														// (and the accessible name, so the row still reads its
-														// environments aloud). Monitor, not Laptop: lucide draws Laptop
-														// only 15 units tall inside the 24-unit box against Server's 20,
-														// so the pair looked mismatched at the same `size`. Monitor is
-														// 18 and exactly as wide, which reads as even.
-														<span className="proj-envs">
-															{card.members.map((m) => {
-																const name = aliasLabel(m.alias);
-																return (
-																	<span
-																		key={m.alias ?? "local"}
-																		className="proj-env"
-																		title={name}
-																		role="img"
-																		aria-label={name}
-																	>
-																		{m.alias === null ? (
-																			<Monitor size={12} strokeWidth={1.75} aria-hidden="true" />
-																		) : (
-																			<Server size={12} strokeWidth={1.75} aria-hidden="true" />
-																		)}
-																	</span>
-																);
-															})}
+													<button
+														type="button"
+														className={`proj ${active ? "active" : ""}`}
+														onClick={() => selectProject(primary.projectId)}
+													>
+														<span
+															className={`dot ${alert ? `alert ${alert}` : ""}`}
+															style={!alert && card.color ? { background: card.color } : undefined}
+														/>
+														<span className="proj-name" title={primary.project.repoPath}>
+															{card.name}
 														</span>
-													)}
-												</button>
-												<span className="proj-open">
-													<IconButton
-														icon={ExternalLink}
-														label="Open in new window"
-														size={14}
-														onClick={() => window.ateam.window.openProject(primary.projectId)}
-													/>
-												</span>
-											</div>
-										);
-									})}
-							</>
+														{multiEnv && (
+															// One icon per environment — a monitor for this Mac, a server per
+															// box — instead of the names, which crowded the row as soon as a
+															// repo spanned more than one box. The name is the hover title
+															// (and the accessible name, so the row still reads its
+															// environments aloud). Monitor, not Laptop: lucide draws Laptop
+															// only 15 units tall inside the 24-unit box against Server's 20,
+															// so the pair looked mismatched at the same `size`. Monitor is
+															// 18 and exactly as wide, which reads as even.
+															<span className="proj-envs">
+																{card.members.map((m) => {
+																	const name = aliasLabel(m.alias);
+																	return (
+																		<span
+																			key={m.alias ?? "local"}
+																			className="proj-env"
+																			title={name}
+																			role="img"
+																			aria-label={name}
+																		>
+																			{m.alias === null ? (
+																				<Monitor size={12} strokeWidth={1.75} aria-hidden="true" />
+																			) : (
+																				<Server size={12} strokeWidth={1.75} aria-hidden="true" />
+																			)}
+																		</span>
+																	);
+																})}
+															</span>
+														)}
+													</button>
+													<span className="proj-open">
+														<IconButton
+															icon={ExternalLink}
+															label="Open in new window"
+															size={14}
+															onClick={() => window.ateam.window.openProject(primary.projectId)}
+														/>
+													</span>
+												</div>
+											);
+										})}
+									</div>
+								)}
+							</div>
 						)}
 
 						{/* TASKS accordion — active tasks of the selected project */}
-						<div className="section-head tasks-head">
-							<button
-								type="button"
-								className="section-toggle"
-								onClick={() => setTasksCollapsed((c) => !c)}
-							>
-								{tasksCollapsed ? (
-									<ChevronRight size={14} strokeWidth={2} />
-								) : (
-									<ChevronDown size={14} strokeWidth={2} />
-								)}
-								<span>Tasks</span>
-							</button>
-							<span style={{ display: "flex", gap: 2 }}>
-								<Menu
-									icon={ArrowUpDown}
-									label="Order tasks"
-									items={[
-										{
-											label: "What's next",
-											icon: taskSort === "next" ? Check : undefined,
-											onClick: () => setTaskSort("next"),
-										},
-										{
-											label: "By status",
-											icon: taskSort === "status" ? Check : undefined,
-											onClick: () => setTaskSort("status"),
-										},
-										{
-											label: "Last updated first",
-											icon: taskSort === "updated" ? Check : undefined,
-											onClick: () => setTaskSort("updated"),
-										},
-										{
-											label: "Custom (drag to reorder)",
-											icon: taskSort === "custom" ? Check : undefined,
-											onClick: () => setTaskSort("custom"),
-										},
-									]}
-								/>
-								<IconButton
-									icon={Plus}
-									label="New task"
-									onClick={newTask}
-									disabled={!activeProjectId}
-								/>
-							</span>
-						</div>
-						{!tasksCollapsed &&
-							(!activeProjectId ? (
-								<div className="tree-empty">Select a project</div>
-							) : visibleSidebarTasks.length === 0 ? (
-								<div className="tree-empty">
-									{tagFilter ? "No matching tasks" : "No active tasks"}
-								</div>
-							) : taskSort === "custom" && !tagFilter ? (
-								// Custom order: drag rows up/down; Motion animates the shuffle.
-								// Disabled while a tag filter is on — reordering a filtered subset
-								// would drop the hidden tasks from the saved order.
-								<Reorder.Group
-									as="div"
-									axis="y"
-									values={orderedSidebarTasks.map((t) => t.id)}
-									onReorder={reorderTasks}
+						<div className="side-section">
+							<div className="section-head tasks-head">
+								<button
+									type="button"
+									className="section-toggle"
+									onClick={() => setTasksCollapsed((c) => !c)}
 								>
-									{orderedSidebarTasks.map((t) => (
-										<Reorder.Item as="div" key={t.id} value={t.id} transition={springy}>
-											<TaskRow
-												task={t}
-												selected={t.id === selectedTaskId}
-												onClick={() => openTask(t)}
-												onDelete={() => deleteTask(t)}
-											/>
-										</Reorder.Item>
-									))}
-								</Reorder.Group>
-							) : (
-								// Sorted modes: layout animation glides rows to their new spot
-								// when a status change or update reorders them.
-								visibleSidebarTasks.map((t) => (
-									<motion.div key={t.id} layout transition={springy}>
-										<TaskRow
-											task={t}
-											selected={t.id === selectedTaskId}
-											onClick={() => openTask(t)}
-											onDelete={() => deleteTask(t)}
-										/>
-									</motion.div>
-								))
-							))}
+									{tasksCollapsed ? (
+										<ChevronRight size={14} strokeWidth={2} />
+									) : (
+										<ChevronDown size={14} strokeWidth={2} />
+									)}
+									<span>Tasks</span>
+								</button>
+								<span style={{ display: "flex", gap: 2 }}>
+									<Menu
+										icon={ArrowUpDown}
+										label="Order tasks"
+										items={[
+											{
+												label: "What's next",
+												icon: taskSort === "next" ? Check : undefined,
+												onClick: () => setTaskSort("next"),
+											},
+											{
+												label: "By status",
+												icon: taskSort === "status" ? Check : undefined,
+												onClick: () => setTaskSort("status"),
+											},
+											{
+												label: "Last updated first",
+												icon: taskSort === "updated" ? Check : undefined,
+												onClick: () => setTaskSort("updated"),
+											},
+											{
+												label: "Custom (drag to reorder)",
+												icon: taskSort === "custom" ? Check : undefined,
+												onClick: () => setTaskSort("custom"),
+											},
+										]}
+									/>
+									<IconButton
+										icon={Plus}
+										label="New task"
+										onClick={newTask}
+										disabled={!activeProjectId}
+									/>
+								</span>
+							</div>
+							{!tasksCollapsed && (
+								<div className="side-list">
+									{!activeProjectId ? (
+										<div className="tree-empty">Select a project</div>
+									) : visibleSidebarTasks.length === 0 ? (
+										<div className="tree-empty">
+											{tagFilter ? "No matching tasks" : "No active tasks"}
+										</div>
+									) : taskSort === "custom" && !tagFilter ? (
+										// Custom order: drag rows up/down; Motion animates the shuffle.
+										// Disabled while a tag filter is on — reordering a filtered subset
+										// would drop the hidden tasks from the saved order.
+										<Reorder.Group
+											as="div"
+											axis="y"
+											values={orderedSidebarTasks.map((t) => t.id)}
+											onReorder={reorderTasks}
+										>
+											{orderedSidebarTasks.map((t) => (
+												<Reorder.Item as="div" key={t.id} value={t.id} transition={springy}>
+													<TaskRow
+														task={t}
+														selected={t.id === selectedTaskId}
+														onClick={() => openTask(t)}
+														onDelete={() => deleteTask(t)}
+													/>
+												</Reorder.Item>
+											))}
+										</Reorder.Group>
+									) : (
+										// Sorted modes: layout animation glides rows to their new spot
+										// when a status change or update reorders them.
+										visibleSidebarTasks.map((t) => (
+											<motion.div key={t.id} layout transition={springy}>
+												<TaskRow
+													task={t}
+													selected={t.id === selectedTaskId}
+													onClick={() => openTask(t)}
+													onDelete={() => deleteTask(t)}
+												/>
+											</motion.div>
+										))
+									)}
+								</div>
+							)}
+						</div>
 
 						{/* LOOPS accordion — the active repo's scheduled agent sessions.
 						    Each loop owns one persistent task; clicking a row opens that
 						    task's terminal (or the Loops tab before its first run).
-						    loops-side-head floats it to the sidebar's bottom while there
-						    is spare room; a long task list pushes it down naturally. */}
-						<div className="section-head tasks-head loops-side-head">
-							<button
-								type="button"
-								className="section-toggle"
-								onClick={() => setLoopsCollapsed((c) => !c)}
-							>
-								{loopsCollapsed ? (
-									<ChevronRight size={14} strokeWidth={2} />
-								) : (
-									<ChevronDown size={14} strokeWidth={2} />
-								)}
-								<span>Loops</span>
-							</button>
-							<IconButton
-								icon={Plus}
-								label="New loop"
-								onClick={() => setView("loops")}
-								disabled={!activeProjectId}
-							/>
+						    loops-side-section floats it to the sidebar's bottom while
+						    there is spare room; a long task list pushes it down. */}
+						<div className="side-section loops-side-section">
+							<div className="section-head tasks-head">
+								<button
+									type="button"
+									className="section-toggle"
+									onClick={() => setLoopsCollapsed((c) => !c)}
+								>
+									{loopsCollapsed ? (
+										<ChevronRight size={14} strokeWidth={2} />
+									) : (
+										<ChevronDown size={14} strokeWidth={2} />
+									)}
+									<span>Loops</span>
+								</button>
+								<IconButton
+									icon={Plus}
+									label="New loop"
+									onClick={() => setView("loops")}
+									disabled={!activeProjectId}
+								/>
+							</div>
+							{!loopsCollapsed && (
+								<div className="side-list">
+									{activeLoops.length === 0 ? (
+										<div className="tree-empty">No loops</div>
+									) : (
+										activeLoops.map((l) => {
+											const task = l.taskId
+												? (activeTasks.find((t) => t.id === l.taskId) ?? null)
+												: null;
+											return (
+												<LoopRow
+													key={l.id}
+													loop={l}
+													task={task}
+													selected={task != null && task.id === selectedTaskId}
+													onClick={() => (task ? openTask(task) : setView("loops"))}
+												/>
+											);
+										})
+									)}
+								</div>
+							)}
 						</div>
-						{!loopsCollapsed &&
-							(activeLoops.length === 0 ? (
-								<div className="tree-empty">No loops</div>
-							) : (
-								activeLoops.map((l) => {
-									const task = l.taskId
-										? (activeTasks.find((t) => t.id === l.taskId) ?? null)
-										: null;
-									return (
-										<LoopRow
-											key={l.id}
-											loop={l}
-											task={task}
-											selected={task != null && task.id === selectedTaskId}
-											onClick={() => (task ? openTask(task) : setView("loops"))}
-										/>
-									);
-								})
-							))}
 					</>
 				)}
 			</aside>
@@ -1993,10 +2006,7 @@ function TaskPanel({
 			<div className="panel-body">
 				{/* Keep the terminal mounted (xterm state survives) while the
 				    changes view is open — just hide it. */}
-				<div
-					className="term-wrap"
-					style={{ display: changesOpen || editorOpen ? "none" : "flex" }}
-				>
+				<div className="term-wrap" style={{ display: changesOpen || editorOpen ? "none" : "flex" }}>
 					{terminalId ? (
 						<TerminalView
 							terminalId={terminalId}

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -128,8 +128,31 @@ input {
 	border-right: 1px solid var(--border);
 	display: flex;
 	flex-direction: column;
-	/* Bounded by the .app grid row above; scroll the project/task lists rather
-	   than overflow off-screen (the collapsed .sidebar.rail already does this). */
+	/* Bounded by the .app grid row above and never scrolled as a whole: each
+	   accordion scrolls its own list instead, so every section header stays on
+	   screen. (The collapsed .sidebar.rail is a flat tile strip and still
+	   scrolls itself.) */
+	min-height: 0;
+	overflow: hidden;
+}
+
+/* One accordion: a header that never scrolls away plus a list that scrolls
+   inside whatever height the section gets. Basis 0 + grow splits the sidebar
+   between the expanded sections; max-content caps a section to its own rows so
+   flexbox freezes it there and hands the leftover to the sections that still
+   need it (a two-row Projects doesn't scroll just because Tasks is long). */
+.side-section {
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 0;
+	/* min-height: 0, not the default auto: auto resolves to the list's own
+	   content height, which would push a long list straight out of the sidebar
+	   and take the sections below it off screen. */
+	min-height: 0;
+	max-height: max-content;
+}
+.side-list {
+	flex: 1 1 auto;
 	min-height: 0;
 	overflow-y: auto;
 	overflow-x: hidden;
@@ -2230,10 +2253,11 @@ input {
 .tasknode.loop-paused {
 	opacity: 0.5;
 }
-/* Float the LOOPS section to the sidebar's bottom while there's spare room;
-   once the task list overflows, the auto margin collapses and it simply
-   follows the content. */
-.loops-side-head {
+/* Float the LOOPS section to the sidebar's bottom while there's spare room —
+   free space only exists once every section is capped at its content height,
+   so as soon as the lists fill the sidebar the auto margin collapses and the
+   section simply follows Tasks. */
+.loops-side-section {
 	margin-top: auto;
 }
 


### PR DESCRIPTION
The sidebar was a single scroll container, so a long task list pushed the LOOPS header (and eventually TASKS) off screen.

Each accordion is now its own bounded section: the header never scrolls away, and the rows under it scroll inside whatever height the section gets. The sidebar itself no longer scrolls, it is exactly the window height.

- `.side-section { flex: 1 1 0; min-height: 0; max-height: max-content }` splits the height between the expanded sections, and caps a short one at its own rows so flexbox hands the leftover to the sections that need it (a two-row PROJECTS does not scroll just because TASKS is long).
- `min-height: 0` is load-bearing: the default `auto` resolves to the list's content height and pushes a long list straight out of the sidebar.
- `.side-list` is the scroller. Collapsed sections cap at their header height. Rail mode is unchanged.
- The LOOPS bottom-float moved from the header to the section wrapper: free space only exists once every section is capped at its content height, so the auto margin still collapses as soon as the lists fill the sidebar.

Verified with headless renders of the real CSS at 3/40/2 rows, 2/4/2 rows, and 25/40/15 rows at the 600px minimum window height: all three labels visible in every case, and LOOPS still floats to the bottom when there is room. Typecheck, biome and the 335 tests pass.