### PR TITLE
Loops: a tick ending on schedule is not news

### DIFF
--- a/packages/db/src/repo.ts
+++ b/packages/db/src/repo.ts
@@ -162,6 +162,18 @@ export const repo = {
 	},
 
 	/**
+	 * The loop that owns this task, if any. A loop keeps its persistent task's
+	 * id in its config (`lastTaskId` on rows written before the persistent-task
+	 * pivot), so the reverse link is a scan of the handful of loop rows rather
+	 * than an index — gate calls on a once-per-session event, not a hot path.
+	 */
+	loopForTask(db: AteamDb, taskId: string): Loop | undefined {
+		return repo
+			.listLoops(db)
+			.find((l) => l.config?.taskId === taskId || l.config?.lastTaskId === taskId);
+	},
+
+	/**
 	 * Ensure a row exists for a loop instance, returning it. Existing rows keep
 	 * their persisted `enabled`/telemetry; only first creation seeds defaults.
 	 */

--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -85,6 +85,23 @@ function mapEventToColumn(eventType: string): KanbanColumn {
 	return "running";
 }
 
+/**
+ * Does this event count as news for the user? `isUnread` is a claim about
+ * novelty, and the renderer's triage order ranks ANY unread task above every
+ * triage bucket, so a card that re-arms the flag on a schedule permanently
+ * outranks real work.
+ *
+ * A loop's tick ends with a Stop on every run (hourly by default), and a
+ * scheduled job finishing on schedule is not news — that is the cron contract
+ * loops already declare: silent on success, loud on exception. So a loop's own
+ * card skips the Stop-driven flag and keeps the PermissionRequest one, which
+ * means the agent is blocked on the user and genuinely needs them.
+ */
+export function mapEventToUnread(eventType: string, ownedByLoop: boolean): boolean {
+	if (eventType === "PermissionRequest") return true;
+	return eventType === "Stop" && !ownedByLoop;
+}
+
 export async function createEngine(opts: EngineOptions): Promise<Engine> {
 	const { dataDir, daemonPath, execPath } = opts;
 	const emitter = new EventEmitter();
@@ -280,13 +297,17 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 			if (e.eventType === "Working" && task.column === column && task.agentStatus === status) {
 				return;
 			}
+			// Only a Stop is ever suppressed, so only a Stop pays for the lookup:
+			// `Working` fires on every tool use and must not hit the loops table.
+			const ownedByLoop = e.eventType === "Stop" && repo.loopForTask(db, task.id) !== undefined;
 			repo.updateTask(db, task.id, {
 				agentStatus: status,
 				column,
 				lastEventAt: Date.now(),
 				// Working/Start mean the user just interacted or launched — the
-				// task isn't "unread"; Stop/PermissionRequest are news for them.
-				isUnread: e.eventType === "Stop" || e.eventType === "PermissionRequest",
+				// task isn't "unread"; Stop/PermissionRequest are news for them,
+				// unless the Stop is just a loop's tick ending on schedule.
+				isUnread: mapEventToUnread(e.eventType, ownedByLoop),
 			});
 			sendTaskUpdated(task.id);
 		}

--- a/packages/server/test/loop-card-unread.test.ts
+++ b/packages/server/test/loop-card-unread.test.ts
@@ -1,0 +1,92 @@
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { AteamDb } from "@ateam/db";
+import { bootstrap, repo } from "@ateam/db";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import * as schema from "../../db/src/schema";
+import { mapEventToUnread } from "../src/engine";
+
+function createTestDb(): AteamDb {
+	const sqlite = new Database(":memory:");
+	sqlite.exec("PRAGMA foreign_keys = ON;");
+	bootstrap(sqlite);
+	return drizzle(sqlite, { schema }) as unknown as AteamDb;
+}
+
+let db: AteamDb;
+
+function seedTask(name: string): string {
+	const project = repo.upsertProject(db, {
+		repoPath: "/tmp/repo",
+		name: "Repo",
+		defaultBranch: "main",
+	});
+	if (!project) throw new Error("failed to seed project");
+	return repo.createTask(db, {
+		projectId: project.id,
+		name,
+		slug: name,
+		branch: `loop/${name}`,
+		baseBranch: "main",
+		worktreePath: `/tmp/${name}`,
+	}).id;
+}
+
+function seedLoop(id: string, config: Record<string, unknown>): void {
+	repo.ensureLoop(db, {
+		id,
+		definitionId: id,
+		scopeKey: null,
+		kind: "user",
+		templateId: "agent-session",
+		name: "Nightly",
+		projectId: null,
+		config,
+		cadenceMode: "fixed",
+		intervalMs: 3_600_000,
+		enabled: true,
+	});
+}
+
+beforeEach(() => {
+	db = createTestDb();
+});
+
+describe("mapEventToUnread", () => {
+	it("marks a normal task unread when its agent stops", () => {
+		expect(mapEventToUnread("Stop", false)).toBe(true);
+	});
+
+	it("stays silent when a loop's tick ends on schedule", () => {
+		expect(mapEventToUnread("Stop", true)).toBe(false);
+	});
+
+	it("still shouts when a loop is blocked on the user", () => {
+		expect(mapEventToUnread("PermissionRequest", true)).toBe(true);
+	});
+
+	it("is never news mid-turn", () => {
+		expect(mapEventToUnread("Working", false)).toBe(false);
+		expect(mapEventToUnread("Start", false)).toBe(false);
+	});
+});
+
+describe("repo.loopForTask", () => {
+	it("finds the loop that owns a task", () => {
+		const taskId = seedTask("owned");
+		seedLoop("loop-1", { prompt: "go", taskId });
+		expect(repo.loopForTask(db, taskId)?.id).toBe("loop-1");
+	});
+
+	it("finds it through the pre-pivot lastTaskId key", () => {
+		const taskId = seedTask("legacy");
+		seedLoop("loop-2", { prompt: "go", lastTaskId: taskId });
+		expect(repo.loopForTask(db, taskId)?.id).toBe("loop-2");
+	});
+
+	it("returns undefined for a task no loop owns", () => {
+		const mine = seedTask("mine");
+		seedLoop("loop-3", { prompt: "go", taskId: seedTask("theirs") });
+		expect(repo.loopForTask(db, mine)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
A loop's tick ends with a `Stop` hook on every run, and the hook handler marked the task unread on any `Stop`. The renderer's triage order ranks an unread task above every triage bucket (`triage-order.ts:45-47`), so a loop's card permanently outranked real work, and only a human opening it cleared the flag, which the next tick re-armed an hour later.

`Stop` on a loop-owned card no longer counts as news. `PermissionRequest` still does, so a loop blocked on the user still surfaces: silent on success, loud on exception, the cron contract loops already declare. The column mapping is untouched, so a finished tick still moves the card to `review`.

The loop to task link already existed as the loop row's `config.taskId`, so this adds a repo helper rather than a column, and it runs only on `Stop` (once per session), never on `Working` (once per tool use).

- `packages/db/src/repo.ts` — `loopForTask`, matching `config.taskId` and the pre-pivot `lastTaskId`
- `packages/server/src/engine.ts` — `mapEventToUnread`, a third pure mapper beside the status and column ones
- `packages/server/test/loop-card-unread.test.ts` — 7 tests over the rule and the lookup

`bun test` 342 pass / 0 fail, `bun run typecheck` clean.