### PR TITLE
Sidebar: hovering a tagged task no longer nudges the row taller

### DIFF
--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -811,6 +811,13 @@ input {
 	flex: none;
 	gap: 3px;
 	margin-right: 20px;
+	/* Zero cross-size, so chips take horizontal room (squeezing the name, which
+	   already ellipsizes) but contribute nothing to the row's height: the chip
+	   is 17.5px against a 15px name line box, so in normal flow revealing it on
+	   hover grew the row by 2px under the cursor. Centred overflow keeps the
+	   chip on the row's midline, and the row stays put whatever size it is. */
+	height: 0;
+	align-items: center;
 }
 .tasknode-row:hover .tasknode .row-tags {
 	display: flex;


### PR DESCRIPTION
The sidebar's hover-only tag chips were revealed with `display: none → flex` in normal flow, so on hover they became a flex item in the row. A chip is **17.5px** tall (9.5px text + 6px padding + 2px border) against a **15px** name line box, so the row grew by exactly **2px** under the cursor — the one thing the comment above `row-tags` in `App.tsx` said it wouldn't do.

The fix is one rule on the container, not on the chip:

```css
.tasknode .row-tags {
	height: 0;
	align-items: center;
}
```

Chips still take horizontal room and squeeze the name (which already ellipsizes, as designed) but contribute zero cross-size, so the row cannot move. The chips are untouched, so the sidebar still matches the board card's.

Measured against this stylesheet with the real `TaskRow` markup in a browser: resting 25px, hovered 25px, jump 0, chip centred (`offCentre: 0`) and fully inside the row. It holds by construction rather than by arithmetic — stress-tested with a deliberately oversized 38px chip, the row still stays at 25px.

Not verified by hovering a tagged task in the running Electron app; the measurement is finer than the eye for a 2px shift.