### PR TITLE
Search: typing costs a pass over an array, not a gigabyte off disk

### DIFF
--- a/apps/desktop/src/renderer/src/components/TaskSearch.tsx
+++ b/apps/desktop/src/renderer/src/components/TaskSearch.tsx
@@ -9,12 +9,16 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
  *   `#tag …`  filters the board and sidebar (see matchesTagQuery in App).
  *   anything  searches, and answers in this popover — never by hiding cards.
  *
- * The popover answers in two passes. Task names match instantly and locally;
- * the sessions that TALKED about it arrive a moment later from the engine's
- * transcript index. The last row is always the AI search, which is how you find
- * a session whose words you no longer remember. It stays visible even when
- * there are results, because "none of these is the one" is exactly when you
- * want it, and it is the only way to discover the feature exists.
+ * Typing matches the tasks ALREADY IN THIS WINDOW — name, branch, description —
+ * and nothing else. It costs a pass over an array, so there is nothing to
+ * debounce and nothing to cancel. Transcripts are deliberately not in that
+ * path: reading a board's session history is hundreds of MB off disk, and
+ * paying it per keystroke made the box the most expensive control in the app.
+ *
+ * The last row is always the AI search, and it is what reads the transcripts —
+ * one deliberate click, for the session whose words you no longer remember. It
+ * stays visible even when there are results, because "none of these is the one"
+ * is exactly when you want it, and it is the only way to discover it exists.
  */
 
 /**
@@ -26,8 +30,7 @@ type Row =
 	| { kind: "result"; key: string; name: string; subtitle: string; meta: string; open: () => void }
 	| { kind: "ai" };
 
-const DEBOUNCE_MS = 200;
-/** Task-name matches shown before session matches get their turn. */
+/** Task matches shown above the AI row. */
 const MAX_TASK_ROWS = 6;
 
 export function TaskSearch({
@@ -48,78 +51,60 @@ export function TaskSearch({
 	onOpenTask: (task: TaskDTO) => void;
 	onOpenSession: (hit: SessionHitDTO) => void;
 }) {
-	const [sessionHits, setSessionHits] = useState<SessionHitDTO[]>([]);
-	const [aiHits, setAiHits] = useState<SessionHitDTO[] | null>(null);
-	const [busy, setBusy] = useState(false);
-	const [dismissed, setDismissed] = useState(false);
-	const [cursor, setCursor] = useState(0);
+	// The answer, the request in flight, the dismissal and the highlighted row are
+	// each stamped with the question they belong to, and read back only when that
+	// stamp still matches. Nothing has to be reset when the question changes: a
+	// stale stamp simply stops matching. The old version reset them from an
+	// effect keyed on `projectIds`, which the parent rebuilds every render — a
+	// fresh array re-ran the effect, the effect set state, the state re-rendered
+	// the parent. Derived state cannot spin that way.
+	const [answer, setAnswer] = useState<{ key: string; hits: SessionHitDTO[] } | null>(null);
+	const [pending, setPending] = useState<string | null>(null);
+	const [dismissed, setDismissed] = useState<string | null>(null);
+	const [caret, setCaret] = useState<{ scope: string; index: number }>({ scope: "", index: 0 });
 	const boxRef = useRef<HTMLDivElement>(null);
-	// Only the newest search may write results: a slower earlier answer arriving
-	// late would otherwise replace the one being read.
-	const runId = useRef(0);
+	// Only the newest ask may write results: a slower earlier answer arriving late
+	// would otherwise replace the one being read.
+	const latest = useRef(0);
 
 	const trimmed = query.trim();
+	// What the popover is currently answering. Compared by value, so the parent
+	// handing us a new-but-equal `projectIds` array is not a new question.
+	const key = `${projectIds.join("\u0000")}\u0000${trimmed}`;
 	// A tag query is a filter, and the board is already showing its answer.
 	const isFilter = trimmed.startsWith("#");
-	const open = trimmed !== "" && !isFilter && !dismissed;
-
-	const reset = useCallback(() => {
-		runId.current++;
-		setSessionHits([]);
-		setAiHits(null);
-		setBusy(false);
-		setCursor(0);
-	}, []);
-
-	// Lexical pass: instant, free, and re-run as the query settles.
-	useEffect(() => {
-		setDismissed(false);
-		reset();
-		if (trimmed === "" || isFilter || projectIds.length === 0) return;
-		const run = ++runId.current;
-		const timer = setTimeout(async () => {
-			const lists = await Promise.all(
-				projectIds.map((projectId) =>
-					window.ateam.search.sessions({ projectId, query: trimmed }).catch(() => []),
-				),
-			);
-			if (run === runId.current) setSessionHits(interleave(lists));
-		}, DEBOUNCE_MS);
-		return () => clearTimeout(timer);
-	}, [trimmed, isFilter, projectIds, reset]);
+	const open = trimmed !== "" && !isFilter && dismissed !== key;
+	const aiHits = answer?.key === key ? answer.hits : null;
+	const busy = pending === key;
 
 	const askAi = useCallback(async () => {
-		if (!trimmed || projectIds.length === 0 || busy) return;
-		const run = ++runId.current;
-		setBusy(true);
+		if (!trimmed || projectIds.length === 0 || pending === key) return;
+		const run = ++latest.current;
+		setPending(key);
 		try {
 			const lists = await Promise.all(
 				projectIds.map((projectId) =>
 					window.ateam.search.sessions({ projectId, query: trimmed, ai: true }).catch(() => []),
 				),
 			);
-			if (run !== runId.current) return;
-			setAiHits(interleave(lists));
-			setCursor(0);
+			if (run === latest.current) setAnswer({ key, hits: interleave(lists) });
 		} finally {
-			if (run === runId.current) setBusy(false);
+			if (run === latest.current) setPending(null);
 		}
-	}, [trimmed, projectIds, busy]);
+	}, [key, trimmed, projectIds, pending]);
 
 	const rows = useMemo<Row[]>(() => {
 		if (!open) return [];
 		if (aiHits) return aiHits.map((hit) => sessionRow(hit, onOpenSession));
 		const needle = trimmed.toLowerCase();
-		const named = new Set<string>();
 		const out: Row[] = [];
 		for (const task of tasks) {
-			if (named.size >= MAX_TASK_ROWS) break;
+			if (out.length >= MAX_TASK_ROWS) break;
 			const matched =
 				task.name.toLowerCase().includes(needle) ||
 				task.branch.toLowerCase().includes(needle) ||
 				(task.description?.toLowerCase().includes(needle) ?? false);
 			if (!matched) continue;
-			named.add(task.id);
 			out.push({
 				kind: "result",
 				key: task.id,
@@ -129,38 +114,36 @@ export function TaskSearch({
 				open: () => onOpenTask(task),
 			});
 		}
-		// A session match for a task already listed by name adds nothing but a
-		// duplicate row; the name match is the stronger signal, so it stands.
-		for (const hit of sessionHits) {
-			if (!named.has(hit.taskId)) out.push(sessionRow(hit, onOpenSession));
-		}
 		out.push({ kind: "ai" });
 		return out;
-	}, [open, aiHits, trimmed, tasks, sessionHits, onOpenTask, onOpenSession]);
+	}, [open, aiHits, trimmed, tasks, onOpenTask, onOpenSession]);
 
-	useEffect(() => {
-		if (cursor >= rows.length) setCursor(0);
-	}, [rows.length, cursor]);
+	// Highlight, scoped to the list it was chosen from: a new question, or the
+	// AI's answer replacing the task matches, starts back at the top. Clamped
+	// here rather than corrected by an effect, so it can never point off the end.
+	const scope = aiHits ? `ai\u0000${key}` : key;
+	const cursor = Math.min(caret.scope === scope ? caret.index : 0, Math.max(0, rows.length - 1));
+	const moveCursor = (index: number) => setCaret({ scope, index });
 
 	useEffect(() => {
 		if (!open) return;
 		const onClick = (e: MouseEvent) => {
-			if (!boxRef.current?.contains(e.target as Node)) setDismissed(true);
+			if (!boxRef.current?.contains(e.target as Node)) setDismissed(key);
 		};
 		document.addEventListener("mousedown", onClick);
 		return () => document.removeEventListener("mousedown", onClick);
-	}, [open]);
+	}, [open, key]);
 
 	const activate = (row: Row) => {
 		if (row.kind === "ai") return void askAi();
 		row.open();
-		setDismissed(true);
+		setDismissed(key);
 	};
 
 	const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === "Escape" && open) {
 			e.preventDefault();
-			setDismissed(true);
+			setDismissed(key);
 		} else if (e.key === "Enter") {
 			e.preventDefault();
 			const row = rows[cursor];
@@ -168,7 +151,7 @@ export function TaskSearch({
 		} else if (open && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
 			e.preventDefault();
 			const step = e.key === "ArrowDown" ? 1 : -1;
-			setCursor((c) => Math.max(0, Math.min(rows.length - 1, c + step)));
+			moveCursor(Math.max(0, Math.min(rows.length - 1, cursor + step)));
 		}
 	};
 
@@ -181,7 +164,7 @@ export function TaskSearch({
 				value={query}
 				onChange={(e) => onQuery(e.target.value)}
 				onKeyDown={onKeyDown}
-				onFocus={() => setDismissed(false)}
+				onFocus={() => setDismissed(null)}
 				aria-label="Search tasks"
 			/>
 			{query && (
@@ -206,7 +189,7 @@ export function TaskSearch({
 								role="option"
 								aria-selected={i === cursor}
 								disabled={busy}
-								onMouseEnter={() => setCursor(i)}
+								onMouseEnter={() => moveCursor(i)}
 								onClick={() => void askAi()}
 							>
 								<span className="ts-hit-name">
@@ -224,7 +207,7 @@ export function TaskSearch({
 								className={`ts-hit ${i === cursor ? "on" : ""}`}
 								role="option"
 								aria-selected={i === cursor}
-								onMouseEnter={() => setCursor(i)}
+								onMouseEnter={() => moveCursor(i)}
 								onClick={() => activate(row)}
 							>
 								<span className="ts-hit-name">{row.name}</span>

--- a/packages/server/src/session-search/index.ts
+++ b/packages/server/src/session-search/index.ts
@@ -29,11 +29,11 @@ const SHORTLIST = 20;
 const RESULTS = 8;
 
 /**
- * shortcut: the digest index is rebuilt from disk on a cache miss and held for
- * TTL_MS, rather than persisted. A full rebuild is ~1s for this repo's history
- * because only a project's own worktrees are read; if that stops being true
- * (thousands of tasks), persist digests keyed by path+mtime and rebuild the
- * delta instead.
+ * How long a built index is reused before the stores are checked again. The
+ * rebuild behind it is nearly free: each source memoizes its parsed digests by
+ * path+mtime, so a rebuild stats the files and re-reads only the session you
+ * are still in. The memo lives for the life of the process rather than on disk
+ * — persist it only if a cold first search ever becomes the complaint.
  */
 const TTL_MS = 60_000;
 
@@ -45,22 +45,27 @@ interface CacheEntry {
 }
 const cache = new Map<string, CacheEntry>();
 
-function buildIndex(worktrees: string[]): SessionDigest[] {
-	const out: SessionDigest[] = [];
-	for (const source of SOURCES) {
-		try {
-			out.push(...source.digestsFor(worktrees));
-		} catch {
-			// One harness's store being unreadable must not hide the others.
-		}
-	}
-	return out;
+async function buildIndex(worktrees: string[]): Promise<SessionDigest[]> {
+	const lists = await Promise.all(
+		SOURCES.map(async (source) => {
+			try {
+				return await source.digestsFor(worktrees);
+			} catch {
+				// One harness's store being unreadable must not hide the others.
+				return [];
+			}
+		}),
+	);
+	return lists.flat();
 }
 
 export interface SessionSearchInput {
 	projectId: string;
 	query: string;
-	/** Run the model re-rank. Off = the instant, free, lexical answer. */
+	/** Run the model re-rank. Off = the lexical answer alone.
+	 *  The desktop only ever asks with `ai: true`: typing is answered from the
+	 *  tasks already in the window (name, branch, description), and reading the
+	 *  transcripts is what the "find the session that did this" row buys. */
 	ai?: boolean;
 	/** Which agent answers the re-rank; defaults to the configured agent. */
 	agentId?: string;
@@ -80,7 +85,9 @@ export async function searchSessions(
 
 	const cached = cache.get(input.projectId);
 	const digests =
-		cached && Date.now() - cached.at < TTL_MS ? cached.digests : buildIndex([...byWorktree.keys()]);
+		cached && Date.now() - cached.at < TTL_MS
+			? cached.digests
+			: await buildIndex([...byWorktree.keys()]);
 	cache.set(input.projectId, { at: Date.now(), digests });
 
 	// Resolve against the CURRENT tasks, not the cached ones: a task removed

--- a/packages/server/src/session-search/sources/claude.ts
+++ b/packages/server/src/session-search/sources/claude.ts
@@ -4,28 +4,41 @@
 // We deliberately do NOT reproduce Claude's cwd→directory slug rule. It is
 // undocumented, and a rule that drifts would silently return "no sessions"
 // rather than fail loudly. Instead each directory is asked what cwd it holds by
-// reading the `cwd` field off its first transcript — 0.15s for 200 directories,
-// and correct whatever the slug rule does next.
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+// reading the `cwd` field off the FIRST BYTES of its first transcript, and the
+// answer is remembered: a directory's cwd is what its name was derived from, so
+// it cannot change under us.
+import { readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { pushPrompt } from "../digest";
 import type { SessionDigest, TranscriptSource } from "../types";
+import { fileMemo, mtimeOf, readHead } from "./files";
 
 const ROOT = () => join(homedir(), ".claude", "projects");
 
+/** How much of a transcript is read to find its `cwd`. The field is on the
+ *  session's first events; reading the whole file to reach them cost a
+ *  gigabyte of I/O across 229 directories (1.3s) instead of 14MB (0.1s). */
+const HEAD_BYTES = 64_000;
+
+/** dir → cwd, for the life of the process. Misses are NOT remembered: a
+ *  directory that is empty now holds the session you start next. */
+const dirCwds = new Map<string, string>();
+
 /** Read the `cwd` a project directory belongs to, from its first transcript. */
-function dirCwd(dir: string): string | null {
+async function dirCwd(dir: string): Promise<string | null> {
+	const known = dirCwds.get(dir);
+	if (known) return known;
 	let files: string[];
 	try {
-		files = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+		files = (await readdir(dir)).filter((f) => f.endsWith(".jsonl"));
 	} catch {
 		return null;
 	}
 	for (const f of files.slice(0, 2)) {
 		let head: string;
 		try {
-			head = readFileSync(join(dir, f), "utf8").slice(0, 64_000);
+			head = await readHead(join(dir, f), HEAD_BYTES);
 		} catch {
 			continue;
 		}
@@ -33,7 +46,10 @@ function dirCwd(dir: string): string | null {
 			if (!line.includes('"cwd"')) continue;
 			try {
 				const cwd = (JSON.parse(line) as { cwd?: unknown }).cwd;
-				if (typeof cwd === "string" && cwd) return cwd;
+				if (typeof cwd === "string" && cwd) {
+					dirCwds.set(dir, cwd);
+					return cwd;
+				}
 			} catch {
 				/* a truncated last line — keep looking */
 			}
@@ -43,12 +59,13 @@ function dirCwd(dir: string): string | null {
 }
 
 /** Parse one transcript into a digest, or null if it holds no real prompts. */
-export function readClaudeTranscript(path: string): SessionDigest | null {
+export async function readClaudeTranscript(
+	path: string,
+	mtimeMs: number,
+): Promise<SessionDigest | null> {
 	let raw: string;
-	let mtimeMs: number;
 	try {
-		raw = readFileSync(path, "utf8");
-		mtimeMs = statSync(path).mtimeMs;
+		raw = await readFile(path, "utf8");
 	} catch {
 		return null;
 	}
@@ -95,26 +112,38 @@ export function readClaudeTranscript(path: string): SessionDigest | null {
 }
 
 export function claudeSource(): TranscriptSource {
+	const digests = fileMemo<SessionDigest | null>();
 	return {
 		agentId: "claude",
-		digestsFor(cwds) {
+		async digestsFor(cwds) {
 			const root = ROOT();
-			if (!existsSync(root)) return [];
 			const wanted = new Set(cwds);
 			const out: SessionDigest[] = [];
 			let dirs: string[];
 			try {
-				dirs = readdirSync(root);
+				dirs = await readdir(root);
 			} catch {
 				return [];
 			}
 			for (const name of dirs) {
 				const dir = join(root, name);
-				const cwd = dirCwd(dir);
+				const cwd = await dirCwd(dir);
 				if (!cwd || !wanted.has(cwd)) continue;
-				for (const f of readdirSync(dir)) {
+				let files: string[];
+				try {
+					files = await readdir(dir);
+				} catch {
+					continue;
+				}
+				// One file at a time on purpose: a transcript can be tens of MB, and
+				// reading a directory's worth in parallel would spike memory for no
+				// gain — the awaits already keep the process responsive.
+				for (const f of files) {
 					if (!f.endsWith(".jsonl")) continue;
-					const digest = readClaudeTranscript(join(dir, f));
+					const path = join(dir, f);
+					const mtimeMs = await mtimeOf(path);
+					if (mtimeMs === null) continue;
+					const digest = await digests(path, mtimeMs, () => readClaudeTranscript(path, mtimeMs));
 					// The directory maps to one cwd, but trust the transcript's own.
 					if (digest && wanted.has(digest.cwd || cwd)) {
 						out.push({ ...digest, cwd: digest.cwd || cwd });

--- a/packages/server/src/session-search/sources/codex.ts
+++ b/packages/server/src/session-search/sources/codex.ts
@@ -1,63 +1,68 @@
 // Codex's transcript store: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl.
 //
 // Sharded by DATE, not by cwd, so there is no directory to look up: the session
-// header (`session_meta`, always the first line) carries the cwd. Reading one
-// line per file is what keeps a whole-history scan cheap.
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+// header (`session_meta`, always the first line) carries the cwd. Reading that
+// line ALONE is what keeps a whole-history scan cheap — a rollout that ran in
+// some other repo must never cost more than the one line that says so, rather
+// than the megabytes behind it.
+import { readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { pushPrompt } from "../digest";
 import type { SessionDigest, TranscriptSource } from "../types";
+import { fileMemo, mtimeOf, readFirstLine } from "./files";
 
 const ROOT = () => join(homedir(), ".codex", "sessions");
 
+interface Header {
+	sessionId: string;
+	cwd: string;
+}
+
 /** Every rollout file under the date-sharded tree. */
-function rolloutFiles(root: string): string[] {
+async function rolloutFiles(root: string): Promise<string[]> {
 	const out: string[] = [];
-	const walk = (dir: string, depth: number) => {
+	const walk = async (dir: string, depth: number) => {
 		let entries: import("node:fs").Dirent[];
 		try {
-			entries = readdirSync(dir, { withFileTypes: true });
+			entries = await readdir(dir, { withFileTypes: true });
 		} catch {
 			return;
 		}
 		for (const e of entries) {
 			const p = join(dir, e.name);
 			// YYYY/MM/DD — three levels of directories, then the files.
-			if (e.isDirectory() && depth < 3) walk(p, depth + 1);
+			if (e.isDirectory() && depth < 3) await walk(p, depth + 1);
 			else if (e.isFile() && e.name.endsWith(".jsonl")) out.push(p);
 		}
 	};
-	walk(root, 0);
+	await walk(root, 0);
 	return out;
 }
 
 /** The cwd a rollout ran in, from its `session_meta` header line. */
-function headerCwd(path: string, head: string): { sessionId: string; cwd: string } | null {
-	for (const line of head.split("\n")) {
-		if (!line.includes('"session_meta"')) continue;
-		try {
-			const payload = (JSON.parse(line) as { payload?: { id?: string; cwd?: string } }).payload;
-			if (payload?.cwd) return { sessionId: payload.id ?? path, cwd: payload.cwd };
-		} catch {
-			return null;
-		}
+function parseHeader(path: string, line: string): Header | null {
+	if (!line.includes('"session_meta"')) return null;
+	try {
+		const payload = (JSON.parse(line) as { payload?: { id?: string; cwd?: string } }).payload;
+		if (payload?.cwd) return { sessionId: payload.id ?? path, cwd: payload.cwd };
+	} catch {
+		/* not a header we can read — the rollout is skipped */
 	}
 	return null;
 }
 
-export function readCodexRollout(path: string, wanted: Set<string>): SessionDigest | null {
+export async function readCodexRollout(
+	path: string,
+	mtimeMs: number,
+	header: Header,
+): Promise<SessionDigest | null> {
 	let raw: string;
-	let mtimeMs: number;
 	try {
-		// The header is the first line; read it before paying for the whole file.
-		raw = readFileSync(path, "utf8");
-		mtimeMs = statSync(path).mtimeMs;
+		raw = await readFile(path, "utf8");
 	} catch {
 		return null;
 	}
-	const header = headerCwd(path, raw.slice(0, 8_000));
-	if (!header || !wanted.has(header.cwd)) return null;
 	const prompts: string[] = [];
 	let startedAt: number | null = null;
 	let endedAt: number | null = null;
@@ -92,17 +97,30 @@ export function readCodexRollout(path: string, wanted: Set<string>): SessionDige
 	};
 }
 
-export function codexSource(): TranscriptSource {
+/** `root` exists so the tests can point at a fixture store: Bun's `os.homedir()`
+ *  ignores `$HOME`, so there is no other seam to stand a fake rollout in. */
+export function codexSource(root = ROOT()): TranscriptSource {
+	// Two memos, because they answer different questions at different prices:
+	// which repo a rollout belongs to (one line), and what it said (the whole
+	// file, up to 7.6MB on this machine).
+	// Neither depends on which project is searching, so both are safe to share
+	// across projects.
+	const headers = fileMemo<Header | null>();
+	const digests = fileMemo<SessionDigest | null>();
 	return {
 		agentId: "codex",
-		digestsFor(cwds) {
-			const root = ROOT();
-			if (!existsSync(root)) return [];
+		async digestsFor(cwds) {
 			const wanted = new Set(cwds);
 			const out: SessionDigest[] = [];
-			for (const f of rolloutFiles(root)) {
-				const d = readCodexRollout(f, wanted);
-				if (d) out.push(d);
+			for (const path of await rolloutFiles(root)) {
+				const mtimeMs = await mtimeOf(path);
+				if (mtimeMs === null) continue;
+				const header = await headers(path, mtimeMs, async () =>
+					parseHeader(path, await readFirstLine(path).catch(() => "")),
+				);
+				if (!header || !wanted.has(header.cwd)) continue;
+				const digest = await digests(path, mtimeMs, () => readCodexRollout(path, mtimeMs, header));
+				if (digest) out.push(digest);
 			}
 			return out;
 		},

--- a/packages/server/src/session-search/sources/files.ts
+++ b/packages/server/src/session-search/sources/files.ts
@@ -1,0 +1,98 @@
+/**
+ * Filesystem helpers shared by the transcript sources.
+ *
+ * Both exist for the same reason: a transcript store is large (1GB+ on the
+ * machine this was measured on) and almost entirely unchanged between searches.
+ * So the two things worth never doing twice are reading a whole file to look at
+ * its first lines, and parsing a file that has not moved since we last parsed
+ * it. Everything is async: the engine shares a process with the window, and a
+ * synchronous gigabyte of I/O is a frozen app.
+ */
+import { open, stat } from "node:fs/promises";
+
+/** The first `bytes` of a file, as text. A tail cut mid-character, or a partial
+ *  last line, is the caller's to tolerate — both only ever end a JSON line that
+ *  fails to parse. */
+export async function readHead(path: string, bytes: number): Promise<string> {
+	const handle = await open(path, "r");
+	try {
+		const buf = Buffer.allocUnsafe(bytes);
+		const { bytesRead } = await handle.read(buf, 0, bytes, 0);
+		return buf.toString("utf8", 0, bytesRead);
+	} finally {
+		await handle.close();
+	}
+}
+
+/**
+ * The whole first line of a file, however long it is: read in chunks, stopping
+ * at the first newline so a multi-megabyte body is never touched.
+ *
+ * A fixed byte budget is the wrong shape for a header line whose length is set
+ * by someone else's format. Codex embeds its entire system prompt in that line
+ * (~19KB today, and it grows with every release of Codex), so a budget that
+ * fits today truncates later — and a truncated JSON line does not raise, it
+ * just stops parsing, which surfaces as "that agent has no sessions at all".
+ * The ceiling below only bounds a file that contains no newline whatsoever.
+ */
+const LINE_CEILING = 1_000_000;
+const LINE_CHUNK = 64_000;
+
+export async function readFirstLine(path: string): Promise<string> {
+	const handle = await open(path, "r");
+	try {
+		const chunks: Buffer[] = [];
+		let offset = 0;
+		while (offset < LINE_CEILING) {
+			const buf = Buffer.allocUnsafe(LINE_CHUNK);
+			const { bytesRead } = await handle.read(buf, 0, LINE_CHUNK, offset);
+			if (bytesRead === 0) break;
+			offset += bytesRead;
+			const read = buf.subarray(0, bytesRead);
+			// Split on the byte, and decode only once at the end: a chunk boundary
+			// lands mid-character often enough that per-chunk decoding corrupts it.
+			const nl = read.indexOf(0x0a);
+			if (nl !== -1) {
+				chunks.push(read.subarray(0, nl));
+				break;
+			}
+			chunks.push(read);
+		}
+		return Buffer.concat(chunks).toString("utf8");
+	} finally {
+		await handle.close();
+	}
+}
+
+/** mtime of `path`, or null when it cannot be read. */
+export async function mtimeOf(path: string): Promise<number | null> {
+	try {
+		return (await stat(path)).mtimeMs;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * A per-file memo, invalidated by mtime. Transcripts are append-only, so a file
+ * whose mtime has not moved parses to exactly what it parsed to last time: this
+ * turns a rebuild from "re-read the whole history" into "re-read the session
+ * you are still sitting in".
+ *
+ * Entries are bounded by the number of transcript files that belong to a task,
+ * and each holds one digest — at most ~24KB, see the caps in digest.ts.
+ */
+export function fileMemo<T>(): (
+	path: string,
+	mtimeMs: number,
+	compute: () => Promise<T>,
+) => Promise<T> {
+	const cache = new Map<string, { mtimeMs: number; value: T }>();
+	return async (path, mtimeMs, compute) => {
+		const hit = cache.get(path);
+		if (hit && hit.mtimeMs === mtimeMs) return hit.value;
+		const value = await compute();
+		cache.set(path, { mtimeMs, value });
+		return value;
+	};
+}

--- a/packages/server/src/session-search/sources/opencode.ts
+++ b/packages/server/src/session-search/sources/opencode.ts
@@ -37,7 +37,7 @@ interface SessionRow {
 export function opencodeSource(): TranscriptSource {
 	return {
 		agentId: "opencode",
-		digestsFor(cwds) {
+		async digestsFor(cwds) {
 			const path = DB_PATH();
 			if (!existsSync(path) || cwds.length === 0) return [];
 			// Required lazily: the driver is a native module that loads under

--- a/packages/server/src/session-search/types.ts
+++ b/packages/server/src/session-search/types.ts
@@ -38,8 +38,10 @@ export interface SessionDigest {
 export interface TranscriptSource {
 	agentId: string;
 	/** Digests for sessions whose cwd is one of `cwds`. Never throws: a missing
-	 *  or unreadable store is simply an agent with no history to search. */
-	digestsFor(cwds: string[]): SessionDigest[];
+	 *  or unreadable store is simply an agent with no history to search.
+	 *  Async because the engine shares a process with the window — a store this
+	 *  size read synchronously freezes the app for the length of the read. */
+	digestsFor(cwds: string[]): Promise<SessionDigest[]>;
 }
 
 /** A ranked match, before it is joined back to a task for the UI. */

--- a/packages/server/test/session-search.test.ts
+++ b/packages/server/test/session-search.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { cleanPrompt, contentText, pushPrompt } from "../src/session-search/digest";
 import { rank, terms } from "../src/session-search/rank";
 import { extractJson, parseVerdicts } from "../src/session-search/rerank";
+import { codexSource } from "../src/session-search/sources/codex";
+import { readFirstLine } from "../src/session-search/sources/files";
 import type { SessionDigest } from "../src/session-search/types";
 
 function digest(id: string, prompts: string[], endedAt = 0): SessionDigest {
@@ -163,5 +168,76 @@ describe("verdicts", () => {
 		expect(parseVerdicts(reply, new Set(["a"]))).toEqual([
 			{ sessionId: "a", why: "w", confidence: "low" },
 		]);
+	});
+});
+
+describe("readFirstLine", () => {
+	async function withFile<T>(body: string, fn: (path: string) => Promise<T>): Promise<T> {
+		const path = join(await mkdtemp(join(tmpdir(), "ateam-search-")), "f.jsonl");
+		await writeFile(path, body);
+		try {
+			return await fn(path);
+		} finally {
+			await rm(dirname(path), { recursive: true, force: true });
+		}
+	}
+
+	test("returns a header line far longer than one read chunk", async () => {
+		// The bug this guards: Codex writes its whole system prompt into the
+		// session_meta line (~19KB and growing), so any fixed head budget
+		// truncates it — and a truncated JSON line does not raise, it silently
+		// parses to nothing and every Codex session disappears from search.
+		const header = `{"pad":"${"x".repeat(300_000)}","cwd":"/w"}`;
+		const line = await withFile(`${header}\n{"body":1}\n`, readFirstLine);
+		expect(line).toBe(header);
+		expect(JSON.parse(line).cwd).toBe("/w");
+	});
+
+	test("stops at the newline instead of reading the body", async () => {
+		const line = await withFile(`{"a":1}\n${"y".repeat(500_000)}\n`, readFirstLine);
+		expect(line).toBe('{"a":1}');
+	});
+
+	test("decodes a multi-byte character that straddles a chunk boundary", async () => {
+		// 64_000 is the chunk size, and "€" is 3 bytes: pad so one lands across
+		// the seam. Decoding per chunk instead of once at the end mangles it.
+		const line = `${"a".repeat(63_999)}€tail`;
+		expect(await withFile(`${line}\n`, readFirstLine)).toBe(line);
+	});
+
+	test("a file with no newline at all still returns its content", async () => {
+		expect(await withFile('{"a":1}', readFirstLine)).toBe('{"a":1}');
+	});
+});
+
+describe("codexSource", () => {
+	test("indexes a rollout whose header line exceeds any fixed budget", async () => {
+		const root = await mkdtemp(join(tmpdir(), "ateam-codex-"));
+		const store = join(root, ".codex", "sessions");
+		const day = join(store, "2026", "09", "01");
+		await mkdir(day, { recursive: true });
+		const cwd = join(root, "worktrees", "a-task");
+		// Same shape as a real rollout: an oversized session_meta, then the turns.
+		const meta = JSON.stringify({
+			timestamp: "2026-09-01T10:00:00.000Z",
+			type: "session_meta",
+			payload: { id: "sess-1", cwd, base_instructions: { text: "z".repeat(200_000) } },
+		});
+		const turn = JSON.stringify({
+			timestamp: "2026-09-01T10:01:00.000Z",
+			payload: { role: "user", content: [{ type: "input_text", text: "make the search cheap" }] },
+		});
+		await writeFile(join(day, "rollout-2026-09-01T10-00-00-sess-1.jsonl"), `${meta}\n${turn}\n`);
+
+		try {
+			const digests = await codexSource(store).digestsFor([cwd]);
+			expect(digests.map((d) => d.sessionId)).toEqual(["sess-1"]);
+			expect(digests[0]?.cwd).toBe(cwd);
+			expect(digests[0]?.prompts).toEqual(["make the search cheap"]);
+			// A rollout from some other repo is skipped without reading its body.
+			expect(await codexSource(store).digestsFor(["/somewhere/else"])).toEqual([]);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
 	});
 });


### PR DESCRIPTION
The search box read the session transcripts on every keystroke. Each debounced call rebuilt the whole index, and the index was built by reading every transcript on the machine **in full**, just to answer "which repo does this directory belong to". 1080 MB of I/O, 1558 ms of it synchronous, in the same process as the window. Typing froze the app.

Typing now matches only the tasks already in the window (name, branch, description). Transcripts are read when you click the AI row, which is the one place their cost buys something.

### The index build, measured on this machine

| | before | after |
|---|---|---|
| index build, 53 worktrees | 1558 ms, synchronous | **507 ms**, async |
| rebuild after the 60s TTL | full price, every time | **5 ms** |
| dir to cwd resolution | 1080 MB read | 14 MB |
| cold scan of a 15 MB Codex store, nothing matching | whole store | **5 ms**, 12 MB peak RSS |

Three changes behind that:

- `dirCwd` did `readFileSync(path).slice(0, 64_000)`, loading each whole file to look at its first 64 KB. Now a real 64 KB `pread`, and the answer is memoized: a directory's cwd is what its name was derived from, so it cannot change.
- Digests are memoized by path + mtime. Transcripts are append-only, so a rebuild now re-parses only the session you are still sitting in. The `mtimeMs` field was already documented as "the cache invalidation key" and nothing used it.
- Codex read every rollout on the machine in full just to check a header.

All three sources are now async, because the engine shares a process with the window.

### A trap in that last one

Codex writes its **entire system prompt** into the `session_meta` line, so that line is ~19 KB on this machine and grows with every Codex release. A fixed head budget truncates it, and a truncated JSON line does not raise: it parses to nothing, and every Codex session silently disappears from search. I shipped this bug at 8 KB and only caught it by running the source against the real `~/.codex/sessions` and getting zero digests for cwds I could see in the files. Typecheck and the suite were green at the time.

It now reads the whole first line, stopping at the newline so the 7.6 MB body behind it is never touched. Tests cover the oversized header, a multi-byte character straddling a chunk boundary, and the source end to end; all three fail against the old fixed budget.

### The render loop

`TaskSearch` reset its state from an effect keyed on `projectIds`, which `App.tsx` rebuilds every render (`activeMembers = activeCard?.members ?? []` feeds a `useMemo` whose deps therefore always change). Fresh array, effect re-runs, effect sets state, state re-renders the parent.

The answer, the request in flight, the dismissal and the highlighted row are now each stamped with the question they belong to and read back only when that stamp still matches. Nothing needs resetting, so the loop cannot form. Two effects deleted.

### Verification

- `bun run typecheck` clean across 8 projects
- `bun test` 358 pass, 0 fail
- biome clean on all changed files
- index build re-measured against the real transcript store after merging `main`

Not done: I have not clicked the search box in a running app. The engine is verified against real transcripts; the React changes are verified by typecheck, lint, and the new tests only.