### PR TITLE
CLI: attach says so before it starts a daemon behind your back

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -32,6 +32,9 @@ import { socketServerTransport } from "./transport/socket";
 import { wsServerTransport } from "./transport/ws";
 
 const SOCK = process.env.ATEAM_RPC_SOCK ?? join(homedir(), ".ateam", "rpc.sock");
+// Where a daemon started from here keeps its state. Shared with the notice
+// `attach` prints before auto-spawning, so the two can never disagree.
+const DATA_DIR = process.env.ATEAM_DATA_DIR ?? join(homedir(), ".ateam");
 
 // Absolute path to THIS running cli.js. Do NOT use import.meta.url: the bundler
 // inlines it to the BUILD-TIME source path (the build host's filesystem), so the
@@ -52,12 +55,15 @@ async function runDaemon(): Promise<void> {
 		return;
 	}
 
-	const dataDir = process.env.ATEAM_DATA_DIR ?? join(homedir(), ".ateam");
 	// The PTY daemon bundle (node-pty + xterm). Shipped beside the ateam bin on
 	// the server; overridable for dev.
 	const ptyDaemon = process.env.ATEAM_PTY_DAEMON ?? join(dirname(SELF), "daemon.js");
 
-	const engine = await createEngine({ dataDir, daemonPath: ptyDaemon, execPath: process.execPath });
+	const engine = await createEngine({
+		dataDir: DATA_DIR,
+		daemonPath: ptyDaemon,
+		execPath: process.execPath,
+	});
 	engine.startLoops();
 	const dispatcher = createDispatcher(engine);
 
@@ -195,9 +201,15 @@ function runAttach(): void {
 					// Route its output to a log file: a detached daemon with no logs is
 					// undebuggable on a remote box (and this is where its startup errors
 					// surface).
-					const dataDir = dirname(SOCK);
-					if (!existsSync(dataDir)) mkdirSync(dataDir, { recursive: true });
-					const log = openSync(join(dataDir, "daemon.log"), "a");
+					const sockDir = dirname(SOCK);
+					if (!existsSync(sockDir)) mkdirSync(sockDir, { recursive: true });
+					const log = openSync(join(sockDir, "daemon.log"), "a");
+					// Say so, on STDERR — stdout is the RPC wire (piped above). A daemon
+					// started here owns DATA_DIR, and on a desktop machine that is NOT
+					// where the app keeps its database (Electron uses its own userData
+					// dir), so starting one silently would serve an empty board from a
+					// second engine with no hint that it had happened.
+					console.error(`[ateam] no daemon at ${SOCK}; starting one (data dir ${DATA_DIR})`);
 					spawn(process.execPath, [SELF, "daemon"], {
 						detached: true,
 						stdio: ["ignore", log, log],


### PR DESCRIPTION
`attach` treats `ECONNREFUSED`/`ENOENT` as "no daemon here" and spawns one detached (`cli.ts:188-207`), with its output going to `daemon.log` and **nothing** printed to the caller. On a box that is the documented on-demand start (`docs/online-ateam.md:29-34`) and it is correct.

On a desktop machine it is a trap. The engine splits its state across two roots:

| | |
|---|---|
| `~/.ateam/` | `pty-daemon.sock` — `engine.ts:152` |
| `~/Library/Application Support/Ateam/` | `ateam.sqlite` — `apps/desktop/src/main/index.ts:342` |

The CLI assumes both live under `~/.ateam` (`cli.ts:34`, `cli.ts:55`), and the desktop binds no `rpc.sock` at all (nothing in `apps/desktop/src` calls `serveRpc`). So an `ateam` command run beside a running app finds no socket, silently starts a second engine, and that engine creates an empty `~/.ateam/ateam.sqlite` the app never reads — a phantom board, with no hint anything happened.

This prints one line naming the socket and the data dir before spawning. It does **not** prevent the phantom: nothing local can drive that daemon until the CLI grows a verb, so visibility is the whole of today's harm. Latent today — `ateam` is not on a desktop's PATH — and live the moment anyone runs the published installer on their Mac.

**On stderr, never stdout**, because stdout is the RPC wire. Verified against every consumer of `attach`'s output:

- `transport/ssh.ts:41-47` — `stdio: ["pipe","pipe","inherit"]`, transport built from stdout only
- `install.sh:60` — handshake pipes stdout to `head -1` with `2>/dev/null`
- `sshExec` merges stdout+stderr, but no call site runs `attach`

Two consequential tidies: `DATA_DIR` is hoisted to module scope so the message and the daemon cannot disagree about where state went, and `runAttach`'s local `dataDir` becomes `sockDir` (it always meant `dirname(SOCK)`; leaving both names in scope would be a new trap).

Exercised against the real command with a temp socket and temp data dir: the notice fires, the failure path still reports, `ateam` with no args still prints usage and exits 2. `bun test` 342 pass / 0 fail, typecheck and biome clean.