### PR TITLE
Task creation: a repeated name takes the next free branch instead of failing

### DIFF
--- a/packages/git-core/src/task.ts
+++ b/packages/git-core/src/task.ts
@@ -1,5 +1,7 @@
+import { existsSync } from "node:fs";
 import { cp, mkdir, readdir, stat } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
+import type { SimpleGit } from "simple-git";
 import { gitFor, refExists } from "./git-client";
 import { GitCoreError } from "./errors";
 import { detectDefaultBranch, ensureWorktreesIgnored } from "./project";
@@ -84,6 +86,45 @@ async function resolveStartPoint(
 		return baseBranch;
 	}
 	return "HEAD";
+}
+
+/** Give up after this many suffixed variants (guards against a pathological repo). */
+const MAX_NAME_ATTEMPTS = 100;
+
+/**
+ * Pick the first free `slug`/`branch`/worktree triple: `slug`, then `slug-2`,
+ * `slug-3`, ... A repeated task name is normal (two prompts that summarize to
+ * the same title, or a branch that outlived a removed task), so it must never
+ * surface `git worktree add -b` refusing an existing branch. "Free" means no
+ * directory at the worktree path, no local branch, and no `origin/` branch.
+ */
+async function allocateNames(
+	git: SimpleGit,
+	repoPath: string,
+	slug: string,
+	branch: string,
+	worktreesRoot: string | null | undefined,
+): Promise<{ slug: string; branch: string; worktreePath: string }> {
+	for (let n = 1; n <= MAX_NAME_ATTEMPTS; n++) {
+		const suffix = n === 1 ? "" : `-${n}`;
+		const candidate = {
+			slug: slug + suffix,
+			branch: branch + suffix,
+			worktreePath: safeResolveWorktreePath(
+				repoPath,
+				slug + suffix,
+				worktreesRoot,
+			),
+		};
+		if (existsSync(candidate.worktreePath)) continue;
+		if (await refExists(git, `refs/heads/${candidate.branch}`)) continue;
+		if (await refExists(git, `refs/remotes/origin/${candidate.branch}`)) continue;
+		return candidate;
+	}
+	throw new GitCoreError(
+		"INVALID_NAME",
+		`Could not find a free branch/worktree name for "${slug}" after ${MAX_NAME_ATTEMPTS} attempts`,
+	);
 }
 
 /**
@@ -178,23 +219,25 @@ async function copyEnvFiles(
  * and we never `checkout` a different branch inside an existing worktree.
  */
 export async function createTask(input: CreateTaskInput): Promise<TaskInfo> {
-	const slug = slugify(input.name);
-	if (!slug) {
+	const baseSlug = slugify(input.name);
+	if (!baseSlug) {
 		throw new GitCoreError(
 			"INVALID_NAME",
 			`Task name produced an empty slug: "${input.name}"`,
 		);
 	}
-	const branch = input.branch ?? slug;
 	const baseBranch =
 		input.baseBranch ?? (await detectDefaultBranch(input.repoPath));
-	const worktreePath = safeResolveWorktreePath(
-		input.repoPath,
-		slug,
-		input.worktreesRoot,
-	);
 
 	const git = gitFor(input.repoPath);
+	// A repeated name is normal, not an error: take the next free variant.
+	const { slug, branch, worktreePath } = await allocateNames(
+		git,
+		input.repoPath,
+		baseSlug,
+		input.branch ?? baseSlug,
+		input.worktreesRoot,
+	);
 	const startPoint = await resolveStartPoint(input.repoPath, baseBranch);
 
 	// Keep co-located worktrees out of the project's own `git status`, even if

--- a/packages/git-core/test/git-core.test.ts
+++ b/packages/git-core/test/git-core.test.ts
@@ -194,6 +194,49 @@ describe("createTask isolation", () => {
 		expect(existsSync(task.worktreePath)).toBe(true);
 		expect(existsSync(join(task.worktreePath, ".env"))).toBe(false);
 	});
+	it("allows several tasks with the same name", async () => {
+		const a = await createTask({ repoPath: repo.work, name: "same name" });
+		const b = await createTask({ repoPath: repo.work, name: "same name" });
+		const c = await createTask({ repoPath: repo.work, name: "Same Name!" });
+
+		expect([a.branch, b.branch, c.branch]).toEqual([
+			"same-name",
+			"same-name-2",
+			"same-name-3",
+		]);
+		expect([a.slug, b.slug, c.slug]).toEqual([
+			"same-name",
+			"same-name-2",
+			"same-name-3",
+		]);
+		for (const t of [a, b, c]) expect(existsSync(t.worktreePath)).toBe(true);
+	});
+
+	it("skips a name whose branch survived an earlier task", async () => {
+		// Task removed, branch kept (deleteBranch not requested) — the classic
+		// "a branch named X already exists" failure.
+		const first = await createTask({ repoPath: repo.work, name: "leftover" });
+		await removeTask({
+			repoPath: repo.work,
+			worktreePath: first.worktreePath,
+			branch: first.branch,
+		});
+
+		const second = await createTask({ repoPath: repo.work, name: "leftover" });
+		expect(second.branch).toBe("leftover-2");
+		expect(existsSync(second.worktreePath)).toBe(true);
+	});
+
+	it("skips a name already taken by a remote branch", async () => {
+		await simpleGit(repo.work).raw([
+			"update-ref",
+			"refs/remotes/origin/taken",
+			"HEAD",
+		]);
+
+		const task = await createTask({ repoPath: repo.work, name: "taken" });
+		expect(task.branch).toBe("taken-2");
+	});
 });
 
 describe("updateFromBase", () => {


### PR DESCRIPTION
## What broke
Creating a task whose AI-derived title matched an existing task (or a branch that outlived a removed task) failed with the raw git error:

    Error invoking remote method 'tasks:create': ... fatal: a branch named 'what-do-you-think-about-this' already exists

`createTask` used the name's slug verbatim as both the branch and the worktree directory, so `git worktree add -b` refused the second one.

## Fix
`allocateNames` walks `slug`, `slug-2`, `slug-3`... and takes the first variant free on all three fronts: no worktree directory, no local branch, no `origin/` branch.

An earlier session (worktree `error-invoking-remote-method-tasks-create-error`) wrote this same fix but never committed it, which is why the error kept showing up. This PR lands it.

## Tests
Three new git-core tests: repeated names, a branch surviving a removed task, a name taken by a remote branch. All 36 git-core tests pass; `tsc --noEmit` clean.