### PR TITLE
Resuming a stopped task no longer counts as activity

### DIFF
--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -302,6 +302,12 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 				rawAgentSessionId: e.sessionId ?? null,
 			});
 		}
+		// A Start is the process coming up, not the conversation doing anything:
+		// it fires on `--resume` (and on compaction) exactly as on a fresh launch.
+		// A fresh launch already filed the card as running when it spawned, and
+		// its first Working follows within seconds; a resume sits idle at the
+		// prompt and must not move the card or refresh its "last activity".
+		if (e.eventType === "Start") return;
 		const task = repo.getTask(db, session.taskId);
 		if (task) {
 			const column = mapEventToColumn(e.eventType);

--- a/packages/server/src/sessions.ts
+++ b/packages/server/src/sessions.ts
@@ -163,9 +163,15 @@ export async function spawnAgentInTask(
 	// turn-end hook, or dropped if the pane dies first.
 	services.followUps.arm(terminalId, input.followUp);
 
+	// A resume is not activity. It brings a conversation back to an idle
+	// prompt: nothing runs until the user types (UserPromptSubmit → UserReply
+	// moves the card then). Opening a stopped task auto-resumes it, so writing
+	// "running" here would file every task you merely looked at as in-flight,
+	// and the stall rule would later demote it as silent work. Leave the card
+	// where it was; only a launch that carries a prompt is work starting.
+	const isResume = Boolean(input.resume || input.resumeSessionId);
 	repo.updateTask(services.db, task.id, {
-		column: "running",
-		agentStatus: "running",
+		...(isResume ? {} : { column: "running", agentStatus: "running" }),
 		agentId: agent.id,
 	});
 	notifyTaskUpdated(task.id);

--- a/packages/server/test/spawn-resume.test.ts
+++ b/packages/server/test/spawn-resume.test.ts
@@ -1,0 +1,101 @@
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AteamDb } from "@ateam/db";
+import { bootstrap, repo } from "@ateam/db";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import * as schema from "../../db/src/schema";
+import { FollowUps } from "../src/follow-ups";
+import type { Services } from "../src/services";
+import { spawnAgentInTask } from "../src/sessions";
+
+// Opening a stopped task auto-resumes its conversation, so a resume must be
+// side-effect free on the board: the card keeps its column, status and "last
+// activity" until the user actually types. Driven through the real spawn path
+// with a PTY client that records instead of forking.
+
+function createTestDb(): AteamDb {
+	const sqlite = new Database(":memory:");
+	sqlite.exec("PRAGMA foreign_keys = ON;");
+	bootstrap(sqlite);
+	return drizzle(sqlite, { schema }) as unknown as AteamDb;
+}
+
+let db: AteamDb;
+let services: Services;
+let taskId: string;
+const T0 = 1_700_000_000_000;
+
+beforeEach(() => {
+	db = createTestDb();
+	const scratch = mkdtempSync(join(tmpdir(), "ateam-spawn-"));
+	services = {
+		db,
+		pty: { spawn: () => "pty", has: () => false },
+		hooksDir: scratch,
+		notifyScriptPath: join(scratch, "notify.sh"),
+		hookPort: 0,
+		followUps: new FollowUps(),
+	} as unknown as Services;
+	const project = repo.upsertProject(db, {
+		repoPath: "/tmp/repo",
+		name: "Repo",
+		defaultBranch: "main",
+	});
+	if (!project) throw new Error("failed to seed project");
+	const task = repo.createTask(db, {
+		projectId: project.id,
+		name: "stopped task",
+		slug: "stopped-task",
+		branch: "feat/stopped",
+		baseBranch: "main",
+		worktreePath: scratch,
+	});
+	// The card as a stopped agent leaves it: parked on a question, last heard
+	// from at T0.
+	repo.updateTask(db, task.id, {
+		column: "needs_attention",
+		agentStatus: "stopped",
+		lastEventAt: T0,
+	});
+	taskId = task.id;
+});
+
+describe("spawnAgentInTask on resume", () => {
+	it("`--continue` leaves column, status and last activity untouched", async () => {
+		await spawnAgentInTask(services, () => {}, { taskId, agentId: "claude", resume: true });
+		const task = repo.getTask(db, taskId);
+		expect(task).toMatchObject({
+			column: "needs_attention",
+			agentStatus: "stopped",
+			lastEventAt: T0,
+			agentId: "claude",
+		});
+	});
+
+	it("resuming a specific conversation leaves the card where it was too", async () => {
+		await spawnAgentInTask(services, () => {}, {
+			taskId,
+			agentId: "claude",
+			resumeSessionId: "11111111-1111-4111-8111-111111111111",
+		});
+		const task = repo.getTask(db, taskId);
+		expect(task).toMatchObject({
+			column: "needs_attention",
+			agentStatus: "stopped",
+			lastEventAt: T0,
+		});
+	});
+
+	it("a launch that carries a prompt still files the card as running", async () => {
+		await spawnAgentInTask(services, () => {}, {
+			taskId,
+			agentId: "claude",
+			prompt: "fix the bug",
+		});
+		const task = repo.getTask(db, taskId);
+		expect(task).toMatchObject({ column: "running", agentStatus: "running", lastEventAt: T0 });
+	});
+});


### PR DESCRIPTION
Opening a stopped task auto-resumes its conversation, and that resume was indistinguishable from work starting: the spawn path filed the card as running, and the SessionStart hook (which fires on `--resume` exactly as on a fresh launch) moved the column again and stamped the task's last activity. So merely inspecting an old task bumped it to the top of "Last updated first", parked it in Running with an idle agent behind it, and left the stall rule to demote it hours later as silent work.

A resume brings a conversation back to an idle prompt; nothing runs until the user types.

- `sessions.ts`: the spawn path leaves column and agent status alone when the launch is a resume (`--continue` or by conversation id). It still records the owning agent.
- `engine.ts`: a `Start` hook event updates only the session row and returns before touching the task. Fresh launches are already filed as running when they spawn, and their first `Working` follows within seconds.
- New test drives the real spawn path with a recording PTY: both resume forms leave column, status and timestamp untouched; a prompted launch still lands in Running.

The first keystroke in a resumed session (`UserReply`) moves the card as before. Compaction restarts no longer refresh the timestamp either.