### PR TITLE
chore: release 0.1.50

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "private": true,
   "main": "./out/main/bootstrap.js",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/desktop": {
       "name": "@ateam/desktop",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "dependencies": {
         "better-sqlite3": "^11.8.1",
         "electron-updater": "^6.8.3",


### PR DESCRIPTION
Five changes have landed on `main` since `v0.1.49`:

- **#188** A task opens over the view you're in, not always the Board
- **#189** Loops: run on the schedule they were given, and stop reading "idle" as "blocked"
- **#190** Search: typing costs a pass over an array, not a gigabyte off disk
- **#191** CLI: `attach` says so before it starts a daemon behind your back
- **#194** Resuming a stopped task no longer counts as activity

Version bumped in `apps/desktop/package.json`, with `bun.lock` restaged alongside it so later `bun install` runs don't dirty the tree. Re-synced with `main` after #194 landed, so this branch is `main` plus the bump and nothing else.

Merge this and I'll build, notarize and publish `v0.1.50`.