### PR TITLE
Confirm dialog: wrap long task names and size buttons to the dialog text

### DIFF
--- a/apps/desktop/src/renderer/src/components/usePrompt.tsx
+++ b/apps/desktop/src/renderer/src/components/usePrompt.tsx
@@ -46,9 +46,7 @@ export function usePrompt(): {
 			<div className="dialog" onMouseDown={(e) => e.stopPropagation()}>
 				<div className="dtitle">{state.title}</div>
 				{state.body && (
-					<div className="muted" style={{ fontSize: 12, marginBottom: 8 }}>
-						{state.body}
-					</div>
+					<div className="dbody muted">{state.body}</div>
 				)}
 				{state.kind === "input" && (
 					// biome-ignore lint/a11y/noAutofocus: modal input should focus

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -1516,11 +1516,25 @@ input {
 	font-size: 13px;
 	margin-bottom: 10px;
 }
+/* Task names can be one long unbreakable word (a pasted URL), so let the
+   body break anywhere rather than run past the dialog's edge. */
+.dbody {
+	font-size: 12px;
+	line-height: 1.45;
+	margin-bottom: 8px;
+	overflow-wrap: anywhere;
+}
 .drow {
 	display: flex;
 	justify-content: flex-end;
 	gap: 8px;
 	margin-top: 12px;
+}
+/* Nothing sets a body font size, so buttons and inputs here would inherit
+   the browser's 16px default and dwarf the 12-13px dialog text. */
+.dialog .drow button,
+.dialog > input {
+	font-size: 13px;
 }
 
 /* ---- error toast ---- */


### PR DESCRIPTION
The in-app confirm dialog (delete task, force delete) had two visual bugs, visible when a task is named after a pasted URL:

- **Overflow:** the task name is one unbreakable word, so it ran past the right edge of the 360px dialog. The body now uses a `dbody` class with `overflow-wrap: anywhere` instead of an inline style.
- **Oversized buttons:** nothing sets a body font size, so Cancel/Confirm inherited the browser's 16px default while the dialog title and body are 13px/12px. The dialog's buttons and text input now use 13px, matching the app's other dialogs.

Scoped to the prompt dialog only; buttons elsewhere are untouched.