### PR TITLE
Loops: a tick that skips can no longer skip forever

### DIFF
--- a/packages/server/src/loops/runner.ts
+++ b/packages/server/src/loops/runner.ts
@@ -241,15 +241,19 @@ export class LoopRunner {
 		}
 	}
 
-	/** Run an instance now, even if disabled (manual trigger from the UI). */
-	async runNow(loopId: string): Promise<void> {
+	/**
+	 * Run an instance now, even if disabled (manual trigger from the UI). The run
+	 * is marked `manual` so it can override the guards a scheduled tick honours;
+	 * tests pass `{ manual: false }` to exercise the scheduled path synchronously.
+	 */
+	async runNow(loopId: string, opts: { manual?: boolean } = {}): Promise<void> {
 		const inst = this.instances.get(loopId);
 		if (!inst) return;
 		if (inst.timer) {
 			clearTimeout(inst.timer);
 			inst.timer = null;
 		}
-		await this.fire(inst, true);
+		await this.fire(inst, true, opts.manual ?? true);
 	}
 
 	list(): Loop[] {
@@ -336,7 +340,7 @@ export class LoopRunner {
 		}, delayMs);
 	}
 
-	private async fire(inst: Instance, force: boolean): Promise<void> {
+	private async fire(inst: Instance, force: boolean, manual = false): Promise<void> {
 		if (inst.running) return; // never overlap a loop with itself
 		const row = repo.getLoop(this.deps.db, inst.loopId);
 		if (!row) return;
@@ -344,6 +348,7 @@ export class LoopRunner {
 		inst.running = true;
 		const ctx: LoopContext = {
 			db: this.deps.db,
+			manual,
 			log: (m) => this.deps.log?.(`[loop ${inst.loopId}] ${m}`),
 			...this.deps.sessions,
 		};

--- a/packages/server/src/loops/templates.ts
+++ b/packages/server/src/loops/templates.ts
@@ -29,6 +29,23 @@ function str(v: unknown): string | undefined {
 }
 
 /**
+ * How long a session may go silent before a tick stops treating its agent as
+ * working.
+ *
+ * Deliberately generous, because the two failure costs are lopsided: too short
+ * kills real work (a single long tool call — a build, a test suite — emits no
+ * hook event while it runs), while too long only delays a latched loop's
+ * self-healing, which Run now already cuts through instantly.
+ *
+ * The honest caveat: this cannot be measured from what we store. `Working` is
+ * the event a busy agent emits, and it is deliberately excluded from the
+ * `agent_events` log (see the hook handler), while `agent_sessions.lastEventAt`
+ * is overwritten in place — so no history of the working cadence exists. Two
+ * hours is chosen to sit beyond any plausible single tool call, not from data.
+ */
+const AGENT_SILENT_MS = 2 * 60 * 60 * 1000;
+
+/**
  * Agent session — the one loop kind, with cron semantics: the loop owns ONE
  * persistent task (branch + worktree, created lazily on the first run), and
  * every tick starts a FRESH agent session in it with the same prompt — a fixed
@@ -75,14 +92,37 @@ const agentSession: LoopTemplate = {
 		const linkedId = str(row?.config?.taskId) ?? str(row?.config?.lastTaskId);
 		let task = linkedId ? repo.getTask(ctx.db, linkedId) : undefined;
 
-		// Never overlap runs: while the previous run's agent is still working
-		// (or waiting on the user), skip this tick. Require a LIVE PTY, not
-		// just the persisted status — agentStatus can strand at "running" when
-		// the exit happened while the app was closed, and a status-only check
-		// would wedge the loop forever.
-		if (task) {
-			const activeStatus = task.agentStatus === "running" || task.agentStatus === "awaiting_input";
-			if (activeStatus && ctx.isTaskAgentLive(task.id)) {
+		// Don't cut off an agent that is genuinely mid-flight. The branch below
+		// kills the previous pane before spawning, so this is not about overlap:
+		// it is only about not interrupting real work.
+		//
+		// Status and a live PTY are both necessary and neither is sufficient, which
+		// is why the old two-condition version latched every long-lived loop:
+		//   * a live PTY is not a live agent — a pane runs `<agent>; exec $SHELL -l`
+		//     (see spawnAgentInTask), so it outlives the agent by design;
+		//   * and a status can strand when the exit went unobserved.
+		// With only those two, the guard is self-perpetuating: a skipped tick
+		// spawns nothing, so no hook fires, so the status that caused the skip can
+		// never change. Every loop here sat wedged for ~20 hours that way.
+		//
+		// Recency is what bounds it. `updateSession` stamps the SESSION row on
+		// every hook event, including the per-tool-use `Working` that the task row
+		// skips for no-op updates, so a working agent keeps this fresh while a
+		// stranded one goes quiet. `awaiting_input` stays in scope on purpose: a
+		// prompt you are about to answer deserves the same protection as a running
+		// turn, and a day-old one gets none because it is no longer recent.
+		//
+		// A manual Run now overrides all of it — the user asked, and can see what
+		// it replaced.
+		if (task && !ctx.manual) {
+			const active = task.agentStatus === "running" || task.agentStatus === "awaiting_input";
+			const working = active && ctx.isTaskAgentLive(task.id);
+			const lastHeard = Math.max(
+				0,
+				// A session that just spawned has no hook event yet; its start counts.
+				...repo.listSessionsByTask(ctx.db, task.id).map((s) => s.lastEventAt ?? s.startedAt ?? 0),
+			);
+			if (working && Date.now() - lastHeard < AGENT_SILENT_MS) {
 				return { skipped: true, summary: `previous run still active (${task.name}) — skipped` };
 			}
 		}

--- a/packages/server/src/loops/types.ts
+++ b/packages/server/src/loops/types.ts
@@ -38,6 +38,12 @@ export interface LoopSessionOps {
 /** Services and helpers handed to a loop on each run. */
 export interface LoopContext extends LoopSessionOps {
 	db: AteamDb;
+	/**
+	 * A human pressed Run now, rather than the schedule firing. A run may then
+	 * override guards that exist to protect an unattended tick from itself —
+	 * the user asked for this one, and can see what it interrupts.
+	 */
+	manual: boolean;
 	/** Emit a diagnostic line (prefixed with the loop id by the runner). */
 	log: (message: string) => void;
 }

--- a/packages/server/test/loops-runner.test.ts
+++ b/packages/server/test/loops-runner.test.ts
@@ -64,7 +64,16 @@ function makeRunner(log: SessionLog = makeLog()): LoopRunner {
 			},
 			spawnAgent: async (input) => {
 				log.spawned.push(input);
-				return { terminalId: `term-${log.spawned.length}` };
+				const terminalId = `term-${log.spawned.length}`;
+				// Mirror spawnAgentInTask: a launch records a session row, which is
+				// what the template's liveness check reads.
+				repo.createSession(db, {
+					taskId: input.taskId,
+					agentId: input.agentId,
+					terminalId,
+					cwd: `/tmp/${input.taskId}`,
+				});
+				return { terminalId };
 			},
 			stopTaskSessions: (taskId) => {
 				log.stopped.push(taskId);
@@ -400,7 +409,8 @@ describe("LoopRunner", () => {
 			const taskId = repo.getLoop(db, id)?.config?.taskId as string;
 			repo.updateTask(db, taskId, { agentStatus: "running" });
 			log.liveTasks.add(taskId);
-			await runner.runNow(id);
+			// A SCHEDULED tick, not a manual one: the guard only binds the schedule.
+			await runner.runNow(id, { manual: false });
 			expect(log.spawned).toHaveLength(1);
 			expect(log.stopped).toHaveLength(0); // a live pane is never killed
 			expect(repo.getLoop(db, id)?.lastSummary).toContain("skipped");
@@ -426,6 +436,75 @@ describe("LoopRunner", () => {
 			runner.stop();
 		});
 
+		it("protects a FRESH prompt: a recent awaiting_input still blocks a tick", async () => {
+			// A question you are seconds from answering deserves the same protection as
+			// a running turn — the tick would otherwise kill the pane under you.
+			const projectId = seedProject();
+			const log = makeLog();
+			const runner = makeRunner(log);
+			runner.start();
+			const id = seedLoop(runner, projectId);
+
+			await runner.runNow(id);
+			const taskId = repo.getLoop(db, id)?.config?.taskId as string;
+			repo.updateTask(db, taskId, { agentStatus: "awaiting_input" });
+			log.liveTasks.add(taskId);
+
+			await runner.runNow(id, { manual: false });
+			expect(log.spawned).toHaveLength(1);
+			runner.stop();
+		});
+
+		it("breaks the latch: a long-silent session never blocks a tick", async () => {
+			// The wedge that stopped every long-lived loop. Both statuses latched the
+			// same way — the skip spawned nothing, so no hook fired, so the status that
+			// caused the skip could never change. Recency is what bounds it.
+			const stale = Date.now() - 3 * 60 * 60 * 1000;
+			for (const status of ["running", "awaiting_input"] as const) {
+				db = createTestDb();
+				const projectId = seedProject();
+				const log = makeLog();
+				const runner = makeRunner(log);
+				runner.start();
+				const id = seedLoop(runner, projectId);
+
+				await runner.runNow(id);
+				const taskId = repo.getLoop(db, id)?.config?.taskId as string;
+				repo.updateTask(db, taskId, { agentStatus: status });
+				log.liveTasks.add(taskId);
+				for (const sess of repo.listSessionsByTask(db, taskId)) {
+					repo.updateSession(db, sess.id, { lastEventAt: stale });
+				}
+
+				await runner.runNow(id, { manual: false });
+				expect(log.spawned).toHaveLength(2);
+				runner.stop();
+			}
+		});
+
+		it("Run now overrides the guard even while the agent is working", async () => {
+			// The scheduled tick protects real work; a human pressing the button is
+			// asking for a run and can see what it replaces.
+			const projectId = seedProject();
+			const log = makeLog();
+			const runner = makeRunner(log);
+			runner.start();
+			const id = seedLoop(runner, projectId);
+
+			await runner.runNow(id);
+			const taskId = repo.getLoop(db, id)?.config?.taskId as string;
+			repo.updateTask(db, taskId, { agentStatus: "running" });
+			log.liveTasks.add(taskId);
+
+			await runner.runNow(id, { manual: false });
+			expect(log.spawned).toHaveLength(1); // schedule defers to live work
+
+			await runner.runNow(id); // manual by default
+			expect(log.spawned).toHaveLength(2);
+			expect(log.stopped).toContain(taskId); // the old pane is replaced
+			runner.stop();
+		});
+
 		it("does not count a skipped tick as a run", async () => {
 			// `lastRunAt` is what a restart computes the next due time from, so a
 			// skip that stamped it would silently push the schedule forward.
@@ -442,7 +521,7 @@ describe("LoopRunner", () => {
 			const taskId = afterRun?.config?.taskId as string;
 			repo.updateTask(db, taskId, { agentStatus: "running" });
 			log.liveTasks.add(taskId);
-			await runner.runNow(id);
+			await runner.runNow(id, { manual: false });
 
 			const afterSkip = repo.getLoop(db, id);
 			expect(log.spawned).toHaveLength(1);


### PR DESCRIPTION
Eight of the ten loops on my machine had been wedged for ~20 hours, each reporting `previous run still active — skipped` with an agent that had not spoken since the previous afternoon. Run counts frozen at 14, 13, 13, 12, 8, 4, 4, 3. Run now could not break it either.

| loop | status | session last heard |
|---|---|---|
| Linkedin Clawnify posts | `awaiting_input` | 18.9h ago |
| Clay alternative | `awaiting_input` | 19.4h ago |
| Clawnify Article write | `awaiting_input` | 20.6h ago |
| Check Google oauth | `running` | 21.4h ago |
| *(and four more)* | | |

### Why

The guard skipped when the task's status was `running` or `awaiting_input` **and** a PTY was live. Neither half proves an agent is working:

- a pane runs `<agent>; exec $SHELL -l` (`sessions.ts`), so it outlives the agent by design — exactly what `isTaskAgentLive` (`engine.ts:182`) was meant to rule out;
- a status strands when an exit goes unobserved.

And the pair is **self-perpetuating**: a skipped tick spawns nothing, so no hook fires, so the status that caused the skip can never change. Only closing the pane by hand recovered it. `pty/reconcile.ts` can't help — it retires sessions the daemon no longer knows about, and here the PTY is present.

### The fix

Bound it with recency. `updateSession` (`engine.ts:291-294`) stamps the session row on every hook event, including the per-tool-use `Working` that the task row skips for no-op updates, so a working agent keeps it fresh while a stranded one goes quiet.

`awaiting_input` stays in scope on purpose: a prompt you are seconds from answering deserves the same protection as a running turn, and a day-old one no longer qualifies as recent.

The 2h window is deliberately generous and is **not** derived from data — it can't be, because `Working` is the one event never written to `agent_events` (`engine.ts:295-297`) and `agent_sessions.lastEventAt` is overwritten in place. Killing real work costs more than a delayed recovery, and no value of the constant can reintroduce the latch, which is the property that matters.

`Run now` overrides the guard outright. A scheduled tick still defers to live work — which `loops-runner.test.ts:390` deliberately protects — while a human pressing the button is asking for a run and can see what it replaces. `runNow` already passed `force`, but `fire()` consumed it only for the `enabled` check, so the template never learned the run was manual.

### Effect

The wedged loops heal on their next tick. No reconcile, no manual pane-closing, no migration.

Tests: +3 net (367 pass, 0 fail). Two existing tests now pass `{ manual: false }` — they used `runNow` to stand in for a scheduled tick, which is no longer the same thing.