### PR TITLE
chore: release 0.1.51

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "private": true,
   "main": "./out/main/bootstrap.js",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/desktop": {
       "name": "@ateam/desktop",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "dependencies": {
         "better-sqlite3": "^11.8.1",
         "electron-updater": "^6.8.3",


### PR DESCRIPTION
Two changes have landed on `main` since `v0.1.50`:

- **#197** Loops: a tick that skips can no longer skip forever — the guard could latch permanently, and had wedged 8 of 10 loops for ~20 hours
- **#196** Confirm dialog: wrap long task names and size buttons to the dialog text

Version bumped in `apps/desktop/package.json`, `bun.lock` restaged alongside it.