### PR TITLE
Reclaim idle agent sessions instead of holding them forever

### DIFF
--- a/docs/online-ateam.md
+++ b/docs/online-ateam.md
@@ -55,8 +55,9 @@ Skip this if you already have a box you work on. Starting from a provider's
 **Size it for agents, not for the app.** A recent Ubuntu LTS with **4 GB RAM, 2 vCPU,
 40 GB disk** is a comfortable starting point — a Hetzner **CX23** (x86) or **CAX11**
 (Arm64), or the equivalent elsewhere. Each concurrent agent session wants roughly a
-gigabyte, plus whatever your project's own dev server and test runs need. x86_64 and
-arm64 both work.
+gigabyte, plus whatever your project's own dev server and test runs need. Size for
+agents *active* rather than agents *started* — a finished one is reclaimed after two
+hours and costs nothing until you open it again. x86_64 and arm64 both work.
 
 **Create a non-root user.** Agents run as this user, in its login shell, with its
 git and `gh` credentials — don't give them root.
@@ -372,7 +373,11 @@ The connection menu surfaces the real error inline. Common ones:
 - **The same box also backs the iOS app** — see step 5. Same daemon, agents, and
   worktrees; a WebSocket instead of SSH, both riding Tailscale.
 - **Sessions persist.** The daemon keeps agents and PTYs alive across disconnects;
-  reconnecting re-attaches to the exact running sessions.
+  reconnecting re-attaches to the exact running sessions. The one exception is an
+  agent that finished its turn and has been untouched for two hours: the app
+  reclaims its process and leaves the tab on the strip, and bringing it back
+  resumes the same conversation. Agents mid-turn or holding a question are never
+  reclaimed.
 - **A box that drops mid-session shows as disconnected too.** Sleep the Mac, flip
   networks, or let the box go away and Ateam drops that box rather than leaving a dead
   link on the board — the rest of the board keeps working, and reconnecting from the

--- a/packages/db/src/repo.ts
+++ b/packages/db/src/repo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import {
 	agentEvents,
 	agentSessions,
@@ -127,15 +127,21 @@ export const repo = {
 	 *
 	 * Deliberately NOT "every session that never got closed". A task in this db
 	 * has held as many as 28 sessions over its life, and a strip of 28 dead tabs
-	 * is not a restore, it is a history browser nobody asked for. `stranded` is
-	 * kept to one app run by `demoteStrandedSessions`, so this list can never be
-	 * longer than the number of tabs actually open at shutdown.
+	 * is not a restore, it is a history browser nobody asked for. Both sources
+	 * are bounded to keep it that way: `stranded` is kept to one app run by
+	 * `demoteStrandedSessions`, and `reaped` to one per task by
+	 * `demoteReapedSessions`.
 	 */
 	listRestorableSessions(db: AteamDb, taskId: string) {
 		return db
 			.select()
 			.from(agentSessions)
-			.where(and(eq(agentSessions.taskId, taskId), eq(agentSessions.exitReason, "stranded")))
+			.where(
+				and(
+					eq(agentSessions.taskId, taskId),
+					inArray(agentSessions.exitReason, ["stranded", "reaped"]),
+				),
+			)
 			.orderBy(desc(agentSessions.startedAt))
 			.all();
 	},
@@ -150,6 +156,19 @@ export const repo = {
 		db.update(agentSessions)
 			.set({ exitReason: "exited" })
 			.where(eq(agentSessions.exitReason, "stranded"))
+			.run();
+	},
+
+	/**
+	 * Retire a task's previously reaped tabs to plain history. A task holds one
+	 * live session at a time, so a fresh reap supersedes any earlier one. Without
+	 * this, a task the user never brings back would collect a dead tab per reap —
+	 * the same history-browser strip `listRestorableSessions` exists to avoid.
+	 */
+	demoteReapedSessions(db: AteamDb, taskId: string) {
+		db.update(agentSessions)
+			.set({ exitReason: "exited" })
+			.where(and(eq(agentSessions.taskId, taskId), eq(agentSessions.exitReason, "reaped")))
 			.run();
 	},
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -21,16 +21,20 @@ export type PrState = "open" | "merged" | "closed";
 
 /**
  * How a terminal session ended. The distinction exists for exactly one reason:
- * only `stranded` sessions are offered back as restorable tabs.
+ * only `stranded` and `reaped` sessions are offered back as restorable tabs.
  *
  * - `closed`   — you closed the tab (its PTY was killed on purpose).
  * - `exited`   — the shell behind it ended on its own while the app watched.
  * - `stranded` — it was still open when the app or the machine went down, and
  *                the PTY daemon had forgotten it by the time we reconnected.
- * - `restored` — a stranded session whose conversation has since been picked
- *                back up in a new tab, so it is no longer offered.
+ * - `reaped`   — it finished its turn and sat idle long enough that the app
+ *                reclaimed the process (see pty/reap.ts). Unlike `stranded`,
+ *                this survives a restart: the ending was deliberate, so the tab
+ *                stays on offer until the user brings it back or supersedes it.
+ * - `restored` — a stranded or reaped session whose conversation has since been
+ *                picked back up in a new tab, so it is no longer offered.
  */
-export type SessionExitReason = "closed" | "exited" | "stranded" | "restored";
+export type SessionExitReason = "closed" | "exited" | "stranded" | "reaped" | "restored";
 
 /**
  * Where a task sits in the merge queue. `null` = not queued. The queue is

--- a/packages/db/test/repo.test.ts
+++ b/packages/db/test/repo.test.ts
@@ -215,6 +215,51 @@ describe("restorable sessions", () => {
 		expect(repo.listRestorableSessions(db, t.id)).toEqual([]);
 	});
 
+	// A reap is deliberate, so unlike a strand it survives the once-per-run
+	// retirement: the app took the process on purpose and owes the tab back.
+	it("offers a reaped tab, and still offers it after the next app run", () => {
+		const t = task();
+		const s = repo.createSession(db, {
+			taskId: t.id,
+			agentId: "claude",
+			terminalId: "term-reaped",
+			agentSessionId: "conv-1",
+			cwd: "/wt/t",
+		});
+		repo.updateSession(db, s.id, { exitedAt: 1, exitReason: "reaped" });
+
+		expect(repo.listRestorableSessions(db, t.id).map((x) => x.id)).toEqual([s.id]);
+
+		repo.demoteStrandedSessions(db);
+
+		expect(repo.listRestorableSessions(db, t.id).map((x) => x.id)).toEqual([s.id]);
+	});
+
+	// A task holds one live session at a time, so reap after reap on a task the
+	// user never comes back to must not grow a strip of dead tabs.
+	it("supersedes a task's earlier reaped tab with the newest one", () => {
+		const t = task();
+		const mk = (terminalId: string) => {
+			const s = repo.createSession(db, {
+				taskId: t.id,
+				agentId: "claude",
+				terminalId,
+				agentSessionId: terminalId,
+				cwd: "/wt/t",
+			});
+			repo.updateSession(db, s.id, { exitedAt: 1, exitReason: "reaped" });
+			return s;
+		};
+		const first = mk("term-1");
+
+		repo.demoteReapedSessions(db, t.id);
+		const second = mk("term-2");
+
+		expect(repo.listRestorableSessions(db, t.id).map((x) => x.id)).toEqual([second.id]);
+		expect(repo.getSessionByTerminal(db, "term-1")?.exitReason).toBe("exited");
+		expect(first.id).not.toBe(second.id);
+	});
+
 	// Without this, every run of the app would leave its own layer of tabs behind.
 	it("retires the previous run's stranded tabs to plain history", () => {
 		const t = task();

--- a/packages/server/src/dispatcher.ts
+++ b/packages/server/src/dispatcher.ts
@@ -663,7 +663,11 @@ export function createDispatcher(engine: Engine): Dispatcher {
 					.find((s) => s.agentSessionId === dead.agentSessionId && services.pty.has(s.terminalId));
 				if (open) return { terminalId: open.terminalId };
 			}
-			if (dead.exitReason !== "stranded") throw new Error("That session is not restorable");
+			// Both endings mean "this tab is coming back if you ask": the app went
+			// down under it, or the app reclaimed its idle process.
+			if (dead.exitReason !== "stranded" && dead.exitReason !== "reaped") {
+				throw new Error("That session is not restorable");
+			}
 			// A shell holds no conversation — restoring one means opening a fresh
 			// shell where it stood, which is all it ever was.
 			if (dead.agentId === "shell") {

--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -25,6 +25,7 @@ import { applySetStatus, buildBoardView } from "./loops/board-signals";
 import { LoopRunner } from "./loops/runner";
 import { MergeQueue } from "./merge-queue";
 import { PtyClient } from "./pty/pty-client";
+import { reapableSessions } from "./pty/reap";
 import { makeStrandReconciler } from "./pty/reconcile";
 import { type Services, toTaskDTO } from "./services";
 import { createTaskInProject, spawnAgentInTask } from "./sessions";
@@ -73,6 +74,11 @@ export interface Engine {
 	/** Stop just the hook server (used by the headless smoke check). */
 	stopHooks(): void;
 }
+
+/** How long an agent sits finished before the app reclaims its process. */
+const REAP_IDLE_MS = 2 * 60 * 60 * 1000;
+/** How often to look for reapable sessions. One indexed read over open rows. */
+const REAP_SWEEP_MS = 5 * 60 * 1000;
 
 function mapEventToStatus(eventType: string): AgentStatus {
 	if (eventType === "PermissionRequest") return "awaiting_input";
@@ -253,7 +259,16 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 		// else reaching here ended on its own. Either way the tab is not coming
 		// back on its own, so neither is offered as restorable.
 		if (session.exitedAt == null) {
-			applyAgentExit(session.id, session.taskId, Date.now(), true, session.exitReason ?? "exited");
+			// A reap is the app reclaiming an idle process, not news: the card must
+			// not claim the user has something new to look at because a timer fired.
+			const reaped = session.exitReason === "reaped";
+			applyAgentExit(
+				session.id,
+				session.taskId,
+				Date.now(),
+				!reaped,
+				session.exitReason ?? "exited",
+			);
 		}
 	});
 
@@ -337,6 +352,28 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 		}
 	});
 
+	// Reclaim agents that finished their turn and went quiet (see pty/reap.ts).
+	// Stamp the ending BEFORE the kill, exactly as the close-tab handler does:
+	// the exit handler above reads it back, and `reaped` is what puts the tab on
+	// the restorable strip instead of retiring it to history.
+	let reapTimer: ReturnType<typeof setInterval> | null = null;
+	const reapIdleSessions = (): void => {
+		const due = reapableSessions(repo.listOpenSessions(db), Date.now(), REAP_IDLE_MS);
+		let count = 0;
+		for (const s of due) {
+			// Already gone: its exit is the live path's to record, not ours.
+			if (!pty.has(s.terminalId)) continue;
+			repo.demoteReapedSessions(db, s.taskId);
+			repo.updateSession(db, s.id, { exitReason: "reaped" });
+			pty.kill(s.terminalId);
+			count += 1;
+		}
+		if (count > 0) {
+			const log = opts.log ?? ((line: string) => console.log(line));
+			log(`[ateam] reaped ${count} idle session(s) — restorable from their tabs`);
+		}
+	};
+
 	// Agent ran `gh pr merge` in its terminal → the gh shim routed it here.
 	// Resolve the task from the terminal and enqueue, so terminal merges and the
 	// in-app Merge button share one serialized queue per base branch.
@@ -381,11 +418,16 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 		},
 		startLoops() {
 			loopRunner.start();
+			reapTimer ??= setInterval(reapIdleSessions, REAP_SWEEP_MS);
 		},
 		stop() {
 			pty.disconnect();
 			hooks.stop();
 			loopRunner.stop();
+			if (reapTimer) {
+				clearInterval(reapTimer);
+				reapTimer = null;
+			}
 		},
 		stopHooks() {
 			hooks.stop();

--- a/packages/server/src/pty/reap.ts
+++ b/packages/server/src/pty/reap.ts
@@ -1,0 +1,60 @@
+/**
+ * Which idle agent sessions the app reclaims.
+ *
+ * A finished agent is not free. It sits at its prompt holding a full harness
+ * heap — hundreds of MB for Claude Code — and producing nothing, and nothing
+ * ever closes it: a PTY dies only when you close its tab (dispatcher's
+ * `ptyKill`) or delete the task. Over a few days of work that is dozens of
+ * processes and gigabytes of RAM held for conversations nobody is having, with
+ * no ceiling other than how many tasks you have started.
+ *
+ * Reclaiming one costs little, because the process is not where the
+ * conversation lives: the harness writes its transcript to disk as it works and
+ * resumes from there. So a reaped session becomes a restorable tab — the same
+ * affordance the app already offers for sessions stranded by a crash — and
+ * bringing it back resumes THAT conversation (see dispatcher's
+ * `ptyRestoreSession`).
+ *
+ * What is deliberately never reaped:
+ *
+ *  - Anything but `idle`. `idle` is set by a Stop event, i.e. the turn is
+ *    complete and nothing is in flight. `running` may be mid-tool-call and
+ *    `awaiting_input` is holding a question; killing either throws away work in
+ *    progress, which is exactly what closing such a tab warns about first.
+ *  - A session that has never reported an event. Rows are created with the
+ *    default `idle` status BEFORE the agent starts (sessions.ts), so a null
+ *    `lastEventAt` means "not started yet", not "finished long ago". Without
+ *    this guard the sweep would kill every agent it just launched.
+ *  - Shells. A shell holds state that exists nowhere else — its cwd, its env, a
+ *    half-typed command — and has no transcript to resume from.
+ *
+ * Pure module: no db, no I/O, no clock. Unit-tested in test/reap.test.ts.
+ */
+
+/** The fields of an open `agent_sessions` row this decision needs. */
+export interface ReapableSession {
+	id: string;
+	taskId: string;
+	terminalId: string;
+	agentId: string;
+	status: string;
+	lastEventAt: number | null;
+}
+
+/**
+ * Open sessions that finished their turn and have been quiet for at least
+ * `idleMs`. Caller stamps the ending and kills the PTY.
+ */
+export function reapableSessions<T extends ReapableSession>(
+	open: readonly T[],
+	now: number,
+	idleMs: number,
+): T[] {
+	return open.filter(
+		(s) =>
+			s.status === "idle" &&
+			s.agentId !== "shell" &&
+			s.lastEventAt != null &&
+			now - s.lastEventAt >= idleMs,
+	);
+}

--- a/packages/server/test/dispatcher.test.ts
+++ b/packages/server/test/dispatcher.test.ts
@@ -135,6 +135,51 @@ describe("createDispatcher", () => {
 		}
 	});
 
+	// The other ending that owes the tab back: the app reclaimed an idle agent's
+	// process to free memory. The user must not be able to tell the difference —
+	// the same strip, the same conversation, resumed by id.
+	it("restores a reaped tab into a new terminal on the same conversation", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "ateam-reaped-"));
+		try {
+			const db = createTestDb();
+			const { engine, spawned } = makeEngine(db);
+			const d = createDispatcher(engine);
+			const project = repo.upsertProject(db, { repoPath: dir, name: "R", defaultBranch: "main" });
+			const task = repo.createTask(db, {
+				projectId: project!.id,
+				name: "reap me",
+				slug: "reap-me",
+				branch: "reap-me",
+				baseBranch: "main",
+				worktreePath: dir,
+			});
+			const reaped = repo.createSession(db, {
+				taskId: task.id,
+				agentId: "claude",
+				terminalId: "term-reaped",
+				agentSessionId: "conv-9",
+				cwd: dir,
+			});
+			repo.updateSession(db, reaped.id, { exitedAt: 1, exitReason: "reaped" });
+
+			const listed = (await d.handle(CH.ptyListRestorable, [task.id])) as Array<{
+				terminalId: string;
+			}>;
+			expect(listed.map((x) => x.terminalId)).toEqual(["term-reaped"]);
+
+			const back = (await d.handle(CH.ptyRestoreSession, [
+				{ taskId: task.id, terminalId: "term-reaped" },
+			])) as { terminalId: string };
+
+			expect(back.terminalId).not.toBe("term-reaped");
+			expect(spawned.at(-1)?.args?.join(" ")).toContain("claude --resume 'conv-9'");
+			expect(await d.handle(CH.ptyListRestorable, [task.id])).toEqual([]);
+			expect(repo.getSessionByTerminal(db, "term-reaped")?.exitReason).toBe("restored");
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
 	// Two windows on the same task both auto-restore, or you double-click: the
 	// conversation is already back, so hand over the tab it is in.
 	it("hands back the existing tab when the conversation is already restored", async () => {

--- a/packages/server/test/reap.test.ts
+++ b/packages/server/test/reap.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { type ReapableSession, reapableSessions } from "../src/pty/reap";
+
+const NOW = 1_000_000;
+const IDLE = 2 * 60 * 60 * 1000;
+
+function session(id: string, over: Partial<ReapableSession> = {}): ReapableSession {
+	return {
+		id,
+		taskId: `task-${id}`,
+		terminalId: `term-${id}`,
+		agentId: "claude",
+		status: "idle",
+		lastEventAt: NOW - IDLE - 1,
+		...over,
+	};
+}
+
+describe("reapableSessions", () => {
+	it("reclaims an agent that finished its turn and went quiet", () => {
+		expect(reapableSessions([session("a")], NOW, IDLE).map((s) => s.id)).toEqual(["a"]);
+	});
+
+	it("leaves an agent that finished recently", () => {
+		const fresh = session("a", { lastEventAt: NOW - IDLE + 1 });
+		expect(reapableSessions([fresh], NOW, IDLE)).toEqual([]);
+	});
+
+	it("treats the threshold itself as due", () => {
+		const exact = session("a", { lastEventAt: NOW - IDLE });
+		expect(reapableSessions([exact], NOW, IDLE).map((s) => s.id)).toEqual(["a"]);
+	});
+
+	// The two endings that mean work is in flight. Killing either throws away
+	// what the agent is mid-way through, which is what closing such a tab warns
+	// about before it does anything.
+	it("never reclaims a running agent, however long it has been quiet", () => {
+		const busy = session("a", { status: "running", lastEventAt: 0 });
+		expect(reapableSessions([busy], NOW, IDLE)).toEqual([]);
+	});
+
+	it("never reclaims an agent holding a question for the user", () => {
+		const blocked = session("a", { status: "awaiting_input", lastEventAt: 0 });
+		expect(reapableSessions([blocked], NOW, IDLE)).toEqual([]);
+	});
+
+	// Rows are born `idle` with no lastEventAt, BEFORE the agent starts. Without
+	// this guard the first sweep after a launch would kill everything it found.
+	it("never reclaims a session that has not reported an event yet", () => {
+		const starting = session("a", { lastEventAt: null });
+		expect(reapableSessions([starting], NOW, IDLE)).toEqual([]);
+	});
+
+	// A shell's state lives nowhere else and there is no transcript to resume.
+	it("never reclaims a shell", () => {
+		const shell = session("a", { agentId: "shell" });
+		expect(reapableSessions([shell], NOW, IDLE)).toEqual([]);
+	});
+
+	it("separates due from live and in-flight in one pass", () => {
+		const open = [
+			session("due"),
+			session("fresh", { lastEventAt: NOW - 60_000 }),
+			session("busy", { status: "running" }),
+			session("shell", { agentId: "shell" }),
+			session("starting", { lastEventAt: null }),
+		];
+		expect(reapableSessions(open, NOW, IDLE).map((s) => s.id)).toEqual(["due"]);
+	});
+});


### PR DESCRIPTION
## The problem

A finished agent was never closed. A PTY died only when you closed its tab (`ptyKill`) or deleted the task, so every session ever launched stayed resident at its prompt holding a full harness heap.

Measured on a working board: **43 `claude` processes, 10.9 GB resident (30% of a 36 GB machine)**, 14 of them over a day old. A 20-second sample of the daemon's broadcast showed **41 of 46 live sessions emitting zero bytes** while holding roughly 250 MB each. 1.4 GB of it belonged to tasks already **merged**. There was no ceiling other than how many tasks you had started.

## The change

Sweep every five minutes for agents that finished their turn and have been quiet for two hours, and reclaim them.

The process is not where the conversation lives — the harness writes its transcript to disk as it works — so a reaped session becomes a **restorable tab**, the same affordance already offered for sessions stranded by a crash, and bringing it back resumes that exact conversation.

**Never reclaimed:**
- Anything but `idle`. `idle` is set by a Stop event, so the turn is complete and nothing is in flight. `running` may be mid-tool-call and `awaiting_input` is holding a question; killing either throws away work, which is exactly what closing such a tab warns about first.
- A session that has not reported an event. Rows are created `idle` *before* the agent starts, so this guard is what stops the sweep killing what it just launched. It fired on real data.
- Shells. State that exists nowhere else, no transcript to resume from.

A reap also does not mark the card unread — a timer firing is not news.

## Why a new exit reason

`reaped` rather than reusing `stranded`: `demoteStrandedSessions` retires stranded rows once per app run, which would make a reaped tab unrestorable after the next restart. Bounded to one per task via `demoteReapedSessions`, so a task the user never returns to cannot grow a strip of dead tabs. No migration — `exit_reason` is untyped TEXT.

## Verification

- 8 unit tests on the pure selector, 2 repo tests, 1 dispatcher round-trip proving a reaped tab resumes as `claude --resume 'conv-9'`. Full suite: 378 pass.
- **The real selector against a real board** (read-only copy): picks 11 of 42 open sessions; keeps 11 `awaiting_input`, 11 `running`, 8 under threshold, and 1 that had never reported an event.
- **A live end-to-end reap** through the built daemon under Electron-as-node, asserting a real OS process existed before the kill and was gone after.

Threshold is a constant (`REAP_IDLE_MS = 2h`), deliberately conservative: comparable idle-culling defaults are 10–30 minutes (JupyterHub idle-culler, Codespaces, Gitpod), and dropping from 2h to 1h would have reclaimed only 0.4 GB more.

## Known limit

Sessions blocked on `awaiting_input` are untouched by design and still accumulate. Their fix is board archiving, not a killer.