### PR TITLE
Loops: a scheduled tick now pushes its own update, so its task stops showing under TASKS

### DIFF
--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -174,6 +174,10 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 	const loopRunner = new LoopRunner({
 		db,
 		log: opts.log ?? ((line) => console.log(line)),
+		// A scheduled tick has no RPC call to answer, so it pushes its own update
+		// — otherwise the UI keeps the pre-tick DTOs (no taskId, stale telemetry)
+		// until some unrelated event happens to re-list.
+		onChanged: () => emitter.emit("loopsUpdated", loopRunner.describe()),
 		sessions: {
 			createTask: async (input) => {
 				const task = await createTaskInProject(services, sendTaskUpdated, input);

--- a/packages/server/src/loops/runner.ts
+++ b/packages/server/src/loops/runner.ts
@@ -31,6 +31,17 @@ export interface LoopRunnerDeps {
 	log?: (line: string) => void;
 	/** Task/session capabilities handed through to each run (engine-wired). */
 	sessions: LoopSessionOps;
+	/**
+	 * Called after a SCHEDULED tick changed a loop's row, so the UI re-lists.
+	 * The UI-driven mutations (create/update/enable/run now) already push from
+	 * their RPC handler; a timer tick has no request to answer, and its row
+	 * changes are exactly the ones the board depends on — a first run mints the
+	 * loop's persistent task, and a UI holding the pre-run DTO has no `taskId`
+	 * to filter that task out of the sidebar's TASKS list with, so the loop's
+	 * card shows up there as if it were a hand-made task until something else
+	 * happens to re-list.
+	 */
+	onChanged?: () => void;
 }
 
 export interface CreateUserLoopInput {
@@ -376,15 +387,24 @@ export class LoopRunner {
 		});
 		if (status === "done") {
 			this.removeInstance(inst.loopId, { deleteRow: true });
+			this.deps.onChanged?.();
 			return;
 		}
 		// Re-check liveness/enabled — the run may have disabled or removed us, or
 		// an edit may have swapped in a REPLACEMENT instance (updateUserLoop);
 		// identity, not just presence, or both instances would keep timers.
-		if (this.instances.get(inst.loopId) !== inst) return;
+		if (this.instances.get(inst.loopId) !== inst) {
+			this.deps.onChanged?.();
+			return;
+		}
 		const after = repo.getLoop(this.deps.db, inst.loopId);
-		if (!after?.enabled) return;
+		if (!after?.enabled) {
+			this.deps.onChanged?.();
+			return;
+		}
 		this.schedule(inst, this.nextDelay(inst.def, outcome));
+		// After the reschedule, so the pushed DTO carries the new nextRunAt too.
+		this.deps.onChanged?.();
 	}
 
 	private nextDelay(def: LoopDefinition, outcome: LoopOutcome): number {

--- a/packages/server/test/loops-runner.test.ts
+++ b/packages/server/test/loops-runner.test.ts
@@ -45,9 +45,10 @@ function makeLog(): SessionLog {
 
 /** Fake session ops: record calls and create real task rows, so the
  *  agent-session template's liveness/link checks see real state. */
-function makeRunner(log: SessionLog = makeLog()): LoopRunner {
+function makeRunner(log: SessionLog = makeLog(), onChanged?: () => void): LoopRunner {
 	return new LoopRunner({
 		db,
+		onChanged,
 		sessions: {
 			createTask: async (input) => {
 				if (log.failNames.has(input.name)) throw new Error(`branch exists: ${input.name}`);
@@ -348,6 +349,27 @@ describe("LoopRunner", () => {
 			expect(log.stopped).toEqual([taskId]);
 			expect(log.spawned).toHaveLength(2);
 			expect(log.spawned[1]?.taskId).toBe(taskId);
+			runner.stop();
+		});
+
+		it("notifies after a scheduled tick, with the task link already in the DTO", async () => {
+			const projectId = seedProject();
+			const log = makeLog();
+			// What the engine pushes on each notification — the UI filters the
+			// loop's task out of its TASKS list by this taskId, so a notification
+			// that arrives without it would leave the loop's card sitting there.
+			const pushed: (string | null)[] = [];
+			let runner!: LoopRunner;
+			runner = makeRunner(log, () => {
+				pushed.push(runner.describe().find((l) => l.kind === "user")?.taskId ?? null);
+			});
+			runner.start();
+			const id = seedLoop(runner, projectId);
+
+			await runner.runNow(id, { manual: false });
+			const taskId = repo.getLoop(db, id)?.config?.taskId as string;
+			expect(taskId).toBeTruthy();
+			expect(pushed).toEqual([taskId]);
 			runner.stop();
 		});
 


### PR DESCRIPTION
## The report

Loop-owned tasks kept appearing in the sidebar's TASKS list as if they were hand-made tasks (OpenStudio in the screenshot), and "went back to Loops" on their own a while later.

## What is actually wrong

Not a loop minting stray tasks. Checked against the live DB: all 14 loops have a valid `config.taskId` pointing at exactly one task.

The sidebar already filters loop-owned tasks out of TASKS by `loop.taskId` (`App.tsx:521`). That set comes from the renderer's `loops` state, which is only refreshed on a `loopsUpdated` push, and that event was emitted from the five UI-driven RPC handlers only: create, update, setEnabled, runNow, delete.

A **scheduled** tick fires from `LoopRunner`'s own timer and has no request to answer, so it emitted nothing:

1. The run creates the loop's task, `taskUpdated` fires, the card appears.
2. The run writes `taskId` into the loop row, and no push follows.
3. The renderer still holds the pre-tick DTO with no `taskId`, so nothing filters the card out.
4. It sits in TASKS until something unrelated re-lists loops: app restart, a box connecting or dropping (`App.tsx:318`), or touching a loop. That is the "fixed all of a sudden" part.

Trashing the stray card fed the loop back into it: the next tick found no task and minted a fresh one, which is how OpenStudio reached branch `openstudio-3`. Run now never showed the bug because its handler pushes.

## The fix

`LoopRunner` takes an `onChanged` dep and calls it at the end of every tick, after the row update and after the reschedule, so the pushed DTOs carry the new `taskId`, `runs`, `lastSummary` and `nextRunAt` in a single event. The engine wires it to the existing `loopsUpdated` emitter, so it travels the transport the manual paths already use. Stale Loops-panel telemetry between ticks was the same gap and is fixed by the same push.

## Test

A scheduled tick (`manual: false`) must notify exactly once, and the DTO in that notification must already carry the task link. 226/226 server tests pass, typecheck and biome clean.

## Not in this PR

`templates.ts:150` persists the task link *after* `spawnAgent`. If a spawn ever throws, the task exists but is never linked, and the next tick mints another. No loop in the DB shows `last_status = error`, so there is no evidence it is biting, but it is a one-line move worth doing separately.