### PR TITLE
Agent sessions no longer break when the login-shell PATH probe misses

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { createEngine, type Engine } from "@ateam/server";
@@ -27,36 +26,6 @@ function broadcast(channel: string, ...args: unknown[]): void {
 }
 
 const SMOKE = process.env.ATEAM_SMOKE === "1";
-
-/**
- * GUI apps on macOS launch with a minimal PATH (/usr/bin:/bin:…), so agent
- * binaries in ~/.local/bin or /opt/homebrew/bin look "not installed" and
- * can't be spawned. Resolve the user's real login-shell PATH once at startup
- * and adopt it — the availability probe, PTY env, and the daemon all inherit
- * process.env.
- *
- * Same for the locale: GUI apps also launch with no LANG/LC_*, and `pbcopy`
- * then interprets UTF-8 input as Mac OS Roman — copying from a terminal turns
- * "→ — €" into ",Üí ,Äî ,Ç¨". Adopt the login shell's LANG, falling back to a
- * UTF-8 locale.
- */
-function adoptLoginShellPath(): void {
-	if (process.platform !== "darwin") return;
-	try {
-		const shell = process.env.SHELL || "/bin/zsh";
-		const out = execFileSync(
-			shell,
-			["-ilc", 'printf "__ATEAM_PATH__%s__SEP__%s__END__" "$PATH" "${LANG:-}"'],
-			{ encoding: "utf8", timeout: 8000 },
-		);
-		const m = out.match(/__ATEAM_PATH__([\s\S]*?)__SEP__([\s\S]*?)__END__/);
-		if (m?.[1]) process.env.PATH = m[1];
-		if (!process.env.LANG) process.env.LANG = m?.[2] || "en_US.UTF-8";
-	} catch (err) {
-		console.warn("[ateam] could not resolve login-shell PATH:", err);
-		process.env.LANG ??= "en_US.UTF-8";
-	}
-}
 
 // Triggers a manual update check (with "you're up to date" feedback). Wired by
 // setupAutoUpdate() once auto-update is active; null in dev / unpackaged builds.
@@ -320,7 +289,6 @@ app
 	.whenReady()
 	.then(async () => {
 		app.setName(APP_NAME);
-		adoptLoginShellPath();
 
 		// Show the app icon in the macOS dock during dev (packaged builds use the
 		// .icns in build/). Best-effort: the icon lives at build/icon.png.

--- a/packages/db/src/bootstrap.ts
+++ b/packages/db/src/bootstrap.ts
@@ -166,6 +166,8 @@ export function bootstrap(db: SqliteExecutor): void {
 		// history is never mistaken for tabs that were open at shutdown.
 		"ALTER TABLE agent_sessions ADD COLUMN agent_session_id TEXT",
 		"ALTER TABLE agent_sessions ADD COLUMN exit_reason TEXT",
+		// Null until the first login-shell probe succeeds on this machine.
+		"ALTER TABLE settings ADD COLUMN login_path TEXT",
 	]) {
 		try {
 			db.exec(sql);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -193,6 +193,13 @@ export const settings = sqliteTable("settings", {
 	terminalFontFamily: text("terminal_font_family"),
 	terminalFontSize: integer("terminal_font_size"),
 	notificationsMuted: integer("notifications_muted", { mode: "boolean" }),
+	/**
+	 * The last PATH successfully resolved from this machine's login shell.
+	 * A GUI launch inherits launchd's PATH, and when the startup probe that
+	 * repairs that misses, this is what the engine falls back to instead of
+	 * leaving every agent CLI and `gh` unreachable (see login-env.ts).
+	 */
+	loginPath: text("login_path"),
 });
 
 /**

--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -21,6 +21,7 @@ import type {
 import { ensureGhShim, ensureNotifyScript } from "./agent-setup";
 import { FollowUps } from "./follow-ups";
 import { type HookEvent, HookServer, type MergeRequestEvent } from "./hooks/hook-server";
+import { ensureLoginEnv } from "./login-env";
 import { applySetStatus, buildBoardView } from "./loops/board-signals";
 import { LoopRunner } from "./loops/runner";
 import { MergeQueue } from "./merge-queue";
@@ -129,6 +130,11 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 		}
 	}
 	const db = createDb(dbPath);
+
+	// Before anything is spawned: a GUI launch inherits launchd's PATH, so the
+	// agent CLIs, `gh` and every headless turn would look uninstalled. Awaited
+	// because agent detection runs seconds from here.
+	await ensureLoginEnv({ db, log: opts.log ?? ((line) => console.log(line)) });
 
 	// Prune stale image attachments (written by util:writeImageBytes to the OS temp dir
 	// when a client attaches an image) older than a week, so temp files never accumulate

--- a/packages/server/src/login-env.ts
+++ b/packages/server/src/login-env.ts
@@ -1,0 +1,203 @@
+// Resolving the user's real login environment.
+//
+// A macOS app launched from Finder (or relaunched by the updater) inherits
+// launchd's PATH — `/usr/bin:/bin:/usr/sbin:/sbin` — not the user's. Nearly
+// everything this engine shells out to lives outside it: the agent CLIs
+// (`claude`, `codex`, `opencode`), `gh` for every GitHub operation, and the
+// headless turns behind task tagging and AI search. So the engine resolves the
+// login shell's PATH once at startup and adopts it into `process.env`, which
+// every child then inherits.
+//
+// The hard part is not the probe, it is what happens when the probe MISSES.
+// One silent miss used to break agent launch, agent detection, tagging, AI
+// search and every `gh` call for the whole life of the app, with no recovery
+// but a restart (VS Code carries the same single-shot design, which is why its
+// failure dialog offers a "Restart" button). Three layers make a miss
+// survivable here: a background retry, the last PATH that resolved on this
+// machine, and finally the dirs agent CLIs are actually installed into.
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { type AteamDb, repo } from "@ateam/db";
+
+const pexec = promisify(execFile);
+
+/** VS Code's default, and its FAQ's answer to "why did resolution time out". */
+export const PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Backoff for re-probing after a miss. A miss is nearly always contention at
+ * login (a cold disk, an rc file loading nvm/rvm while the rest of the machine
+ * also starts), so the retries walk out to ~6 minutes and stop: past that the
+ * shell genuinely cannot answer, and the fallbacks stand.
+ */
+export const RETRY_DELAYS_MS = [5_000, 20_000, 60_000, 300_000];
+
+/**
+ * Defuses the two documented ways an interactive shell hangs a probe forever:
+ * oh-my-zsh's update prompt (shell-env#19) and its tmux plugin exec'ing tmux
+ * (shell-env#4). ATEAM_RESOLVING_ENVIRONMENT mirrors VS Code's
+ * VSCODE_RESOLVING_ENVIRONMENT, so a slow rc file can skip its own init.
+ */
+const PROBE_ENV = {
+	ATEAM_RESOLVING_ENVIRONMENT: "1",
+	DISABLE_AUTO_UPDATE: "true",
+	ZSH_TMUX_AUTOSTART: "false",
+	ZSH_TMUX_AUTOSTARTED: "true",
+};
+
+const MARKER = /__ATEAM_PATH__([\s\S]*?)__SEP__([\s\S]*?)__END__/;
+const PROBE_CMD = 'printf "__ATEAM_PATH__%s__SEP__%s__END__" "$PATH" "${LANG:-}"';
+
+export interface LoginEnv {
+	path: string;
+	lang: string;
+}
+
+/**
+ * Where agent CLIs and `gh` land when nothing else can be resolved. Deliberately
+ * not `fix-path`'s list, which predates Apple Silicon and names neither
+ * `/opt/homebrew/bin` nor `~/.local/bin` — the two that matter most here, the
+ * second being what `claude`'s own installer targets. Version-managed dirs (nvm,
+ * rbenv) cannot be named statically; the remembered PATH covers those.
+ */
+export function fallbackBinDirs(home: string = homedir()): string[] {
+	return [
+		join(home, ".local", "bin"),
+		join(home, ".bun", "bin"),
+		join(home, ".cargo", "bin"),
+		"/opt/homebrew/bin",
+		"/opt/homebrew/sbin",
+		"/usr/local/bin",
+	];
+}
+
+/**
+ * This PATH is adopted into every child process the app spawns, so it is a
+ * trust boundary: reject anything that doesn't look like one. Control
+ * characters genuinely arrive here — a TERM-driven reset sequence leaking into
+ * captured output is a known failure of this technique (fix-path#6) — and a
+ * PATH naming no directory that exists is a parse that went wrong rather than
+ * an answer from the shell.
+ */
+export function sanitizeLoginPath(raw: string): string | null {
+	const clean = raw
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the point
+		.replace(/\u001B\[[0-9;?]*[\u0020-\u002F]*[@-~]/g, "")
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the point
+		.replace(/[\u0000-\u001F\u007F]/g, "");
+	const dirs = clean.split(":").filter(Boolean);
+	if (!dirs.some((d) => d.startsWith("/") && existsSync(d))) return null;
+	return dirs.join(":");
+}
+
+/** Append the dirs a PATH doesn't already have, preserving its own order. */
+export function appendMissingDirs(path: string, dirs: string[]): string {
+	const own = path.split(":").filter(Boolean);
+	const have = new Set(own);
+	return [...own, ...dirs.filter((d) => !have.has(d))].join(":");
+}
+
+/** One probe of the login shell. Null on any failure — timeout, junk, non-zero exit. */
+export async function probeLoginEnv(
+	shell = process.env.SHELL || "/bin/zsh",
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<LoginEnv | null> {
+	try {
+		// Interactive AND login: PATH is very often exported from ~/.zshrc, which a
+		// non-interactive shell never reads, rather than from ~/.zprofile. Same
+		// flags VS Code and shell-env use.
+		const { stdout } = await pexec(shell, ["-ilc", PROBE_CMD], {
+			encoding: "utf8",
+			timeout: PROBE_TIMEOUT_MS,
+			env: { ...env, ...PROBE_ENV },
+		});
+		const m = stdout.match(MARKER);
+		if (!m?.[1]) return null;
+		const path = sanitizeLoginPath(m[1]);
+		return path ? { path, lang: m[2] ?? "" } : null;
+	} catch {
+		return null;
+	}
+}
+
+export interface EnsureLoginEnvOptions {
+	db: AteamDb;
+	log: (line: string) => void;
+	/** The env to mutate. Injectable for tests; the engine mutates process.env. */
+	env?: NodeJS.ProcessEnv;
+	probe?: () => Promise<LoginEnv | null>;
+	platform?: NodeJS.Platform;
+	home?: string;
+	retryDelaysMs?: number[];
+}
+
+/**
+ * Adopt the login shell's PATH (and LANG) into `env`, then keep trying in the
+ * background until one probe succeeds. Awaiting the first attempt is
+ * deliberate: agent detection and `gh` run within a second of the engine coming
+ * up, and a wrong answer there is what the user sees.
+ */
+export async function ensureLoginEnv(opts: EnsureLoginEnvOptions): Promise<void> {
+	const {
+		db,
+		log,
+		env = process.env,
+		probe = () => probeLoginEnv(),
+		platform = process.platform,
+		home = homedir(),
+		retryDelaysMs = RETRY_DELAYS_MS,
+	} = opts;
+	// Only a GUI launch loses the environment; a Linux box runs the daemon from
+	// the login shell that started it.
+	if (platform !== "darwin") return;
+
+	const adopt = (resolved: LoginEnv): void => {
+		env.PATH = resolved.path;
+		// GUI apps also launch with no LANG, and pbcopy then reads UTF-8 as Mac OS
+		// Roman — copying "→ — €" out of a terminal yields mojibake.
+		if (!env.LANG) env.LANG = resolved.lang || "en_US.UTF-8";
+		repo.updateSettings(db, { loginPath: resolved.path });
+	};
+
+	const resolved = await probe();
+	if (resolved) {
+		adopt(resolved);
+		return;
+	}
+
+	// Fall back, best first: the last PATH that worked on this machine, then the
+	// dirs agent CLIs install into. Both only ever ADD to what launchd gave us,
+	// and both are replaced the moment a retry succeeds.
+	const remembered = repo.getSettings(db).loginPath;
+	if (remembered) {
+		log("[ateam] login-shell probe failed; using the PATH last resolved on this machine");
+		env.PATH = remembered;
+	} else {
+		log("[ateam] login-shell probe failed and none is remembered; using known agent CLI dirs");
+		env.PATH = appendMissingDirs(env.PATH ?? "", fallbackBinDirs(home));
+	}
+	if (!env.LANG) env.LANG = "en_US.UTF-8";
+
+	// Re-probe on a backoff until one lands; each success replaces the fallback.
+	let attempt = 0;
+	const retry = (): void => {
+		const delay = retryDelaysMs[attempt];
+		if (delay === undefined) {
+			log("[ateam] login-shell PATH never resolved; agent CLIs outside the known dirs won't run");
+			return;
+		}
+		attempt++;
+		// Unref'd: a pending retry must never be the reason the process stays up.
+		setTimeout(() => {
+			void probe().then((late) => {
+				if (!late) return retry();
+				log(`[ateam] login-shell PATH resolved on retry ${attempt}`);
+				adopt(late);
+			});
+		}, delay).unref();
+	};
+	retry();
+}

--- a/packages/server/test/login-env.test.ts
+++ b/packages/server/test/login-env.test.ts
@@ -1,0 +1,115 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { type AteamDb, bootstrap, repo } from "@ateam/db";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import * as schema from "../../db/src/schema";
+import {
+	appendMissingDirs,
+	ensureLoginEnv,
+	fallbackBinDirs,
+	type LoginEnv,
+	sanitizeLoginPath,
+} from "../src/login-env";
+
+function createTestDb(): AteamDb {
+	const sqlite = new Database(":memory:");
+	bootstrap(sqlite);
+	return drizzle(sqlite, { schema }) as unknown as AteamDb;
+}
+
+const BARE = "/usr/bin:/bin:/usr/sbin:/sbin";
+const REAL = "/opt/homebrew/bin:/usr/bin:/bin";
+const silent = () => {};
+
+describe("sanitizeLoginPath", () => {
+	test("keeps a real PATH intact", () => {
+		expect(sanitizeLoginPath(REAL)).toBe(REAL);
+	});
+
+	test("strips escape sequences a shell leaked into the capture", () => {
+		expect(sanitizeLoginPath("\u001B[0m/usr/bin:/bin\u001B[m")).toBe("/usr/bin:/bin");
+	});
+
+	test("rejects a capture naming no directory that exists", () => {
+		expect(sanitizeLoginPath("/nope/not/here:/also/missing")).toBeNull();
+		expect(sanitizeLoginPath("")).toBeNull();
+	});
+});
+
+describe("appendMissingDirs", () => {
+	test("adds only what the PATH lacks, keeping its order", () => {
+		expect(appendMissingDirs("/usr/bin:/bin", ["/bin", "/opt/homebrew/bin"])).toBe(
+			"/usr/bin:/bin:/opt/homebrew/bin",
+		);
+	});
+});
+
+describe("fallbackBinDirs", () => {
+	test("names the two dirs fix-path's list misses", () => {
+		const dirs = fallbackBinDirs("/Users/x");
+		expect(dirs).toContain("/Users/x/.local/bin");
+		expect(dirs).toContain("/opt/homebrew/bin");
+	});
+});
+
+describe("ensureLoginEnv", () => {
+	const opts = (db: AteamDb, env: NodeJS.ProcessEnv, probe: () => Promise<LoginEnv | null>) => ({
+		db,
+		env,
+		probe,
+		log: silent,
+		platform: "darwin" as NodeJS.Platform,
+		home: "/Users/x",
+		retryDelaysMs: [] as number[],
+	});
+
+	test("adopts and remembers a resolved PATH", async () => {
+		const db = createTestDb();
+		const env: NodeJS.ProcessEnv = { PATH: BARE };
+		await ensureLoginEnv(opts(db, env, async () => ({ path: REAL, lang: "en_GB.UTF-8" })));
+		expect(env.PATH).toBe(REAL);
+		expect(env.LANG).toBe("en_GB.UTF-8");
+		expect(repo.getSettings(db).loginPath).toBe(REAL);
+	});
+
+	test("a miss falls back to the PATH last resolved on this machine", async () => {
+		const db = createTestDb();
+		repo.updateSettings(db, { loginPath: REAL });
+		const env: NodeJS.ProcessEnv = { PATH: BARE };
+		await ensureLoginEnv(opts(db, env, async () => null));
+		expect(env.PATH).toBe(REAL);
+		expect(env.LANG).toBe("en_US.UTF-8");
+	});
+
+	test("a miss with nothing remembered still reaches the agent CLI dirs", async () => {
+		const db = createTestDb();
+		const env: NodeJS.ProcessEnv = { PATH: BARE };
+		await ensureLoginEnv(opts(db, env, async () => null));
+		expect(env.PATH).toStartWith(BARE);
+		expect(env.PATH).toContain("/Users/x/.local/bin");
+		// A failed probe must never be remembered as a good answer.
+		expect(repo.getSettings(db).loginPath).toBeNull();
+	});
+
+	test("a retry that lands replaces the fallback", async () => {
+		const db = createTestDb();
+		const env: NodeJS.ProcessEnv = { PATH: BARE };
+		let calls = 0;
+		const probe = async () => (++calls === 1 ? null : { path: REAL, lang: "" });
+		await ensureLoginEnv({ ...opts(db, env, probe), retryDelaysMs: [1] });
+		expect(env.PATH).not.toBe(REAL); // the first attempt missed
+		await new Promise((r) => setTimeout(r, 20));
+		expect(env.PATH).toBe(REAL);
+		expect(repo.getSettings(db).loginPath).toBe(REAL);
+	});
+
+	test("does nothing off macOS, where the daemon starts from a login shell", async () => {
+		const db = createTestDb();
+		const env: NodeJS.ProcessEnv = { PATH: BARE };
+		await ensureLoginEnv({
+			...opts(db, env, async () => ({ path: REAL, lang: "" })),
+			platform: "linux",
+		});
+		expect(env.PATH).toBe(BARE);
+	});
+});


### PR DESCRIPTION
## The bug

Creating a task printed `zsh:1: command not found: claude` into the agent pane, with a healthy shell prompt underneath it.

A macOS GUI launch inherits launchd's PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), so the app resolves the login shell's PATH once at startup and adopts it into `process.env`. In the broken session that probe missed, and the evidence was still on the machine: the PTY daemon's environment carried the bare PATH together with `LANG=en_US.UTF-8`, a pair only the catch branch of `adoptLoginShellPath()` produces. The agent then launched through `zsh -l -c`, which never sources `.zshrc` (where `~/.local/bin` comes from), while the `exec zsh -l` after it is interactive and does, which is exactly the failed command over a working prompt.

The probe was single-shot, un-persisted and silent, and eight subsystems depend on the PATH it adopts. A miss broke agent launch, agent detection, task tagging, AI search, and every `gh` call (repo view, clone, PR create, merge, board signals) for the life of the app. `PromptComposer` then hid the one honest signal by defaulting to `claude` when no agent reports available.

## The fix

Resolution moves into the engine, so every consumer inherits it rather than only the desktop's children, and a miss becomes survivable:

- **Validate before adopting.** The captured PATH is injected into every child process, so it is a trust boundary: strip escape sequences (a documented failure of this technique, `fix-path#6`) and reject a capture that names no directory that exists.
- **Remember the last good PATH** in `settings.login_path`, used only when a probe fails.
- **Fall back to the dirs agent CLIs install into** when nothing is remembered, including `~/.local/bin` and `/opt/homebrew/bin` (`fix-path`'s own list has neither).
- **Re-probe on a backoff** at 5s/20s/60s/300s until one lands, each success replacing the fallback. VS Code carries the same single-shot design, which is why its failure dialog offers a Restart button; retrying is what makes that unnecessary.
- Adopt `shell-env`'s two hang-defusers (oh-my-zsh's update prompt and its tmux plugin) and VS Code's `*_RESOLVING_ENVIRONMENT` flag, so a slow rc file can skip its own init. Timeout raised 8s to 10s, matching VS Code's default.

Behaviour off macOS is unchanged: a box runs its daemon from the login shell that started it.

## Verification

`bun test` 388 pass (10 new), typecheck clean. Against the real shell, using the exact `zsh -l -c` shape `sessions.ts` launches agents with:

```
baseline (launchd PATH)                 → FAILED: command not found: claude
real probe from a bare env              → 2.1.259 (Claude Code), remembered
probe fails, nothing remembered         → 2.1.259 (Claude Code)
probe fails, previous PATH remembered   → 2.1.259 (Claude Code)
gh: launchd PATH → not found            repaired PATH → found
```

The built Electron main, launched with a launchd-style bare PATH against a throwaway user-data dir, reaches `ATEAM_READY` and writes the resolved PATH into its database.

## Follow-ups, not in this PR

- `PromptComposer.tsx:95` / `App.tsx:1665` fall back to `"claude"` when no agent is available, hiding a real "not installed" state.
- The desktop passes no `log` to `createEngine`, so the new failure line lands in a console a packaged build discards. Routing engine logs to a rotating file would have answered this in seconds.