### PR TITLE
chore: release 0.1.53

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "private": true,
   "main": "./out/main/bootstrap.js",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/desktop": {
       "name": "@ateam/desktop",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "dependencies": {
         "better-sqlite3": "^11.8.1",
         "electron-updater": "^6.8.3",


### PR DESCRIPTION
Three changes have landed on `main` since `v0.1.52`:

- **#203** Loops: every tick is handed the loop's own notes — each tick now leads with a pointer to `.ateam/loop-state.md`, so what a run learns survives into the next one on any agent, not just Claude
- **#202** Agent sessions no longer break when the login-shell PATH probe misses
- **#201** A scheduled loop tick now pushes its own update

Version bumped in `apps/desktop/package.json`, `bun.lock` restaged alongside it.