### PR TITLE
New worktrees inherit installed dependencies, and an empty terminal offers to resume

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1767,6 +1767,20 @@ function TaskPanel({
 		[task.id, run, setTerminal, refreshSessions],
 	);
 
+	/**
+	 * "Resume last conversation": the newest tab a restart stranded, brought back
+	 * by id, and failing that the newest conversation in the worktree. Same choice
+	 * the tab-fallback effect makes below — this is the button for when that
+	 * effect has already had its one go, or the task's column rules it out.
+	 * Leaves the editor, like every other user gesture that shows a terminal.
+	 */
+	const resumeLast = useCallback(() => {
+		setEditorOpen(false);
+		const newest = [...restorable].reverse().find((s) => s.agentId !== "shell");
+		if (newest) void restoreTab(newest);
+		else void launch(false, true);
+	}, [restorable, restoreTab, launch]);
+
 	// Keep the active tab pointed at something real. Covers (re)opening a task
 	// with surviving daemon sessions, and a session ending — its tab disappears
 	// and the newest survivor takes focus. With nothing left, resume the agent's
@@ -1995,16 +2009,7 @@ function TaskPanel({
 								onClick: () => setSessionComposerOpen(true),
 							},
 							{ label: "Terminal", icon: SquareTerminal, onClick: shell },
-							{
-								label: "Resume last conversation",
-								icon: History,
-								// launch() is also driven by the tab-fallback effect, which must
-								// NOT yank you out of the editor — so only this user gesture does.
-								onClick: () => {
-									setEditorOpen(false);
-									launch(false, true);
-								},
-							},
+							{ label: "Resume last conversation", icon: History, onClick: resumeLast },
 						]}
 					/>
 				</div>
@@ -2169,8 +2174,12 @@ function TaskPanel({
 							}
 						/>
 					) : (
-						<div className="term" style={{ display: "grid", placeItems: "center" }}>
-							<span className="muted">Open a tab with + to start a terminal</span>
+						<div className="term term-empty">
+							<button type="button" onClick={resumeLast}>
+								<History size={13} />
+								Resume last conversation
+							</button>
+							<span className="muted">or open a tab with + to start a terminal</span>
 						</div>
 					)}
 				</div>

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -916,6 +916,22 @@ input {
 	background: #000;
 	padding: 6px;
 }
+/* No terminal on this task yet: the way back into the last conversation, and
+   the hint for starting a fresh one. */
+.term-empty {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+}
+.term-empty button {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12.5px;
+}
+
 /* Self-contained terminal: a single flex:1 box (drop-in for the old lone .term)
    that splits into the xterm area + the bottom toolbar. Parents (.term-wrap,
    .tile) keep treating the terminal as one fill child. */

--- a/packages/git-core/src/task.ts
+++ b/packages/git-core/src/task.ts
@@ -1,12 +1,16 @@
+import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { cp, mkdir, readdir, stat } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
+import { promisify } from "node:util";
 import type { SimpleGit } from "simple-git";
 import { gitFor, refExists } from "./git-client";
 import { GitCoreError } from "./errors";
 import { detectDefaultBranch, ensureWorktreesIgnored } from "./project";
 import { slugify } from "./util";
 import { safeResolveWorktreePath, worktreesRootFor } from "./worktree-paths";
+
+const pexec = promisify(execFile);
 
 export interface CreateTaskInput {
 	repoPath: string;
@@ -212,6 +216,75 @@ async function copyEnvFiles(
 }
 
 /**
+ * Copy-on-write copy: share blocks with the source instead of duplicating them.
+ * macOS `cp -c` is clonefile(2); GNU `cp --reflink=auto` reflinks on btrfs/XFS
+ * and silently falls back to a full copy elsewhere rather than failing.
+ */
+const CLONE_CP = process.platform === "darwin" ? "/bin/cp" : "cp";
+const CLONE_ARGS = process.platform === "darwin" ? ["-c", "-R"] : ["--reflink=auto", "-R"];
+
+/** Every `node_modules` in the repo, without descending into them. */
+async function findNodeModules(repoPath: string, worktreesRoot?: string | null): Promise<string[]> {
+	const root = worktreesRootFor(repoPath, worktreesRoot);
+	const found: string[] = [];
+
+	async function walk(dir: string): Promise<void> {
+		const entries = await readdir(dir, { withFileTypes: true }).catch(() => null);
+		if (!entries) return;
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue;
+			const abs = join(dir, entry.name);
+			if (abs === root) continue; // don't descend into other worktrees
+			if (entry.name === "node_modules") {
+				found.push(abs); // a tree to clone, not a tree to walk
+				continue;
+			}
+			if (entry.name === ".git") continue;
+			await walk(abs);
+		}
+	}
+
+	await walk(repoPath);
+	return found;
+}
+
+/**
+ * Dependencies are gitignored, so a fresh worktree cannot typecheck, lint or run
+ * until something installs them — and nothing does. Clone the source repo's
+ * `node_modules` across instead, which on a copy-on-write filesystem shares the
+ * blocks rather than duplicating them.
+ *
+ * Measured on this repo: 23k files that `du` reports as 807 MB clone in ~5s for
+ * ~9 MB of real disk. `fs.cp` is not a substitute — even with COPYFILE_FICLONE
+ * it wrote 819 MB for the same tree — hence shelling out. `verbatim` symlink
+ * behaviour matters too: `cp -R` preserves the relative links a bun/pnpm store
+ * depends on, while `fs.cp` rewrites them to absolute paths into the SOURCE.
+ *
+ * The seed also removes the expensive half of any later install: Electron's
+ * postinstall exits early once `dist/version` matches, so its 244 MB download
+ * and extract never runs in this worktree.
+ *
+ * Monorepos keep a `node_modules` per package, so every tree is cloned, not just
+ * the root one. Best-effort: a repo with no deps installed, a filesystem without
+ * reflinks, or a copy error must never fail task creation.
+ */
+async function seedNodeModules(
+	repoPath: string,
+	worktreePath: string,
+	worktreesRoot?: string | null,
+): Promise<void> {
+	for (const src of await findNodeModules(repoPath, worktreesRoot)) {
+		const dest = join(worktreePath, relative(repoPath, src));
+		try {
+			await mkdir(dirname(dest), { recursive: true });
+			await pexec(CLONE_CP, [...CLONE_ARGS, src, dest]);
+		} catch {
+			/* best-effort — the worktree just needs its own install */
+		}
+	}
+}
+
+/**
  * Create a task = a new branch checked out into its own co-located worktree.
  *
  * Safety: `git worktree add -b` creates the branch and checks it out into the
@@ -264,6 +337,11 @@ export async function createTask(input: CreateTaskInput): Promise<TaskInfo> {
 	// Carry gitignored env files (.env*, .dev.vars*) over, including nested ones,
 	// so the worktree can run the app without re-creating its local secrets.
 	await copyEnvFiles(input.repoPath, worktreePath, input.worktreesRoot);
+
+	// Carry the installed dependencies over as a copy-on-write clone, so the
+	// worktree can typecheck and run immediately instead of paying a full
+	// install (and Electron's 244 MB extract) per task.
+	await seedNodeModules(input.repoPath, worktreePath, input.worktreesRoot);
 
 	return { slug, branch, baseBranch, worktreePath };
 }

--- a/packages/git-core/test/git-core.test.ts
+++ b/packages/git-core/test/git-core.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import {
+	chmod,
+	mkdir,
+	mkdtemp,
+	readlink,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
 import simpleGit from "simple-git";
 import {
@@ -187,6 +195,57 @@ describe("createTask isolation", () => {
 			).text(),
 		).toBe("API=2\n");
 		expect(existsSync(join(task.worktreePath, ".env.example"))).toBe(false);
+	});
+
+	it("seeds every node_modules into the new worktree, symlinks verbatim", async () => {
+		// A monorepo keeps a tree per package, and package stores link between
+		// them RELATIVELY. A copy that rewrites those links to absolute paths
+		// would point the new worktree back at the source repo.
+		await mkdir(join(repo.work, "node_modules", ".store", "dep"), {
+			recursive: true,
+		});
+		await writeFile(
+			join(repo.work, "node_modules", ".store", "dep", "index.js"),
+			"module.exports = 1;\n",
+		);
+		await symlink(
+			join(".store", "dep"),
+			join(repo.work, "node_modules", "dep"),
+		);
+		await mkdir(join(repo.work, "apps", "web", "node_modules"), {
+			recursive: true,
+		});
+		await symlink(
+			join("..", "..", "..", "node_modules", ".store", "dep"),
+			join(repo.work, "apps", "web", "node_modules", "dep"),
+		);
+
+		const task = await createTask({ repoPath: repo.work, name: "seeded" });
+
+		expect(
+			await Bun.file(
+				join(task.worktreePath, "node_modules", ".store", "dep", "index.js"),
+			).text(),
+		).toBe("module.exports = 1;\n");
+		// The nested tree is cloned too, not just the root one.
+		expect(
+			existsSync(join(task.worktreePath, "apps", "web", "node_modules")),
+		).toBe(true);
+		// And both links still point where they did, relatively.
+		expect(
+			await readlink(join(task.worktreePath, "node_modules", "dep")),
+		).toBe(join(".store", "dep"));
+		expect(
+			await readlink(
+				join(task.worktreePath, "apps", "web", "node_modules", "dep"),
+			),
+		).toBe(join("..", "..", "..", "node_modules", ".store", "dep"));
+	});
+
+	it("creates the worktree fine when nothing is installed", async () => {
+		const task = await createTask({ repoPath: repo.work, name: "no-deps" });
+		expect(existsSync(task.worktreePath)).toBe(true);
+		expect(existsSync(join(task.worktreePath, "node_modules"))).toBe(false);
 	});
 
 	it("creates the worktree fine when there are no env files", async () => {


### PR DESCRIPTION
## Worktree dependency seeding

`createTask` already carried the Supabase link (`task.ts:262`) and the env files (`task.ts:266`) across, but stopped short of `node_modules`, so every new worktree paid a full install. The expensive half of that install is Electron's postinstall re-extracting 244 MB of `dist` per worktree, because nothing seeded a `dist/version` for its own `isInstalled()` check (`electron/install.js:20`) to find.

`seedNodeModules` clones every `node_modules` in the repo (root plus one per package, since a monorepo keeps a tree per package) using `cp -c` on macOS and `cp --reflink=auto` on Linux. Best-effort, like both neighbours: no deps installed, no reflink support, or a copy error must never fail task creation.

Measured on this repo:

| | real disk | time |
|---|---|---|
| `du` reports | 807 MB | |
| `/bin/cp -c -R` | **8.8 MB** | 4.8s |
| `fs.cp` + `COPYFILE_FICLONE` | 819 MB | 11.8s |

Two reasons this shells out instead of using `fs.cp`:

1. **`COPYFILE_FICLONE` does not actually clone** through `fs.cp`. 819 MB versus 8.8 MB for the identical tree.
2. **`fs.cp` rewrites relative symlinks into absolute paths pointing back at the source repo.** With 23k symlinks in a bun store, every worktree would have depended on one directory. `cp -R` preserves them verbatim.

Both are covered by tests, so neither can regress silently.

Adds ~5s to task creation, awaited rather than backgrounded so an agent can never start against a half-copied tree.

## Resume button

The empty terminal pane offered only a hint at the `+` menu. It now offers **Resume last conversation**: it restores the newest stranded tab by id when there is one, and falls back to `--continue` otherwise, which is the same choice the tab-fallback effect already makes. The `+` menu item now shares that handler, so it no longer ignores a stranded tab sitting in the strip.

## Verification

- 33/33 `git-core` tests pass, including two new cases (nested trees cloned, relative symlinks verbatim)
- `tsc --noEmit` clean on `git-core` and the desktop renderer
- Biome: same 3 pre-existing diagnostics as `main`, none added
- Desktop app launched from this worktree and the empty-state button rendered