### PR TITLE
chore: release 0.1.54

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "private": true,
   "main": "./out/main/bootstrap.js",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/desktop": {
       "name": "@ateam/desktop",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "dependencies": {
         "better-sqlite3": "^11.8.1",
         "electron-updater": "^6.8.3",


### PR DESCRIPTION
Two changes have landed on `main` since `v0.1.53`:

- **#206** New worktrees inherit installed dependencies, and an empty terminal offers to resume
- **#205** Loops: the state file is one absolute path, not a phrase to interpret — a follow-up to #203, where "relative to the repository root" was read two ways inside a worktree and one loop wrote its notes to the shared main checkout

Not included: #114, #86 and #20, all reporting `UNKNOWN` merge state — stale branches that need rebasing and re-testing before they belong in a release.