### PR TITLE
Install hook re-execs natively: an Intel bash was the real cause of x64 rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,16 @@ Identity and all GitHub operations come from the `gh` CLI.
 > own, via a `postinstall` hook in `apps/desktop`. You do not need a second
 > command, and a fresh task worktree is runnable straight after installing.
 >
-> The hook is not optional bookkeeping. Everything Bun's script runner spawns on
-> macOS runs translated, picking the x86_64 slice of a universal `node`, so
-> `prebuild-install` resolves `process.arch` as x64 and fetches a `darwin-x64`
-> better-sqlite3 that Electron cannot load. The rebuild replaces it with the
-> arm64 Electron-ABI build.
+> The hook is not optional bookkeeping. `bun install` fetches better-sqlite3 built
+> for the host's Node ABI, which Electron cannot load; the rebuild replaces it with
+> the arm64 Electron-ABI build.
+>
+> On Apple Silicon the hook also re-execs itself natively first. Bun runs lifecycle
+> scripts with the first `bash` on `PATH`, and an x86_64-only bash (an Intel Homebrew
+> in `/usr/local` is the usual source) makes the script and everything under it run
+> under Rosetta, so `prebuild-install` resolves `process.arch` as x64 and fetches a
+> `darwin-x64` binary. Worth fixing at the source too: macOS blames the app that owns
+> the terminal for translated child processes, and Rosetta ends after macOS 27.
 
 ## Layout
 

--- a/apps/desktop/scripts/rebuild-natives.sh
+++ b/apps/desktop/scripts/rebuild-natives.sh
@@ -17,12 +17,22 @@ set -euo pipefail
 # CI installs the workspace on Linux to typecheck and test; no Electron there.
 [ "$(uname -s)" = Darwin ] || exit 0
 
-# Everything bun's script runner spawns runs TRANSLATED: it picks the x86_64
-# slice of universal binaries, so inside this script `uname -m` reports x86_64
-# and `arch` reports i386 even on an M-series Mac. That is also why bun's install
-# leaves a darwin-x64 better-sqlite3 behind: prebuild-install sees process.arch
-# as x64. `sysctl hw.optional.arm64` describes the HARDWARE, not the calling
-# process, so it survives the translation and is the one honest probe here.
+# `bun run` executes lifecycle scripts with the first `bash` on PATH. When that is
+# an x86_64-only bash (an Intel Homebrew under /usr/local is the usual source), this
+# script and every child it spawns run TRANSLATED: `uname -m` reports x86_64 on an
+# M-series Mac and prebuild-install sees process.arch as x64, which is how a
+# darwin-x64 better-sqlite3 lands in the worktree. macOS also attributes translated
+# processes to the app that owns the terminal, which is what raises "Support Ending
+# for Intel-Based Apps" against Ateam. Re-exec natively so node-gyp, python3 and cc
+# below all run arm64; after the re-exec proc_translated is 0, so this runs once.
+if [ "$(sysctl -n sysctl.proc_translated 2>/dev/null || echo 0)" = 1 ] &&
+	[ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" = 1 ] &&
+	[ -x /usr/bin/arch ] && [ -x /bin/bash ]; then
+	exec /usr/bin/arch -arm64 /bin/bash "$0" "$@"
+fi
+
+# `sysctl hw.optional.arm64` describes the HARDWARE, not the calling process, so it
+# stays honest even on a machine where the re-exec above could not run.
 if [ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" = 1 ]; then
 	ARCH=arm64
 else


### PR DESCRIPTION
## What

`apps/desktop/scripts/rebuild-natives.sh` now re-execs itself natively before rebuilding, and the stale root-cause comment (plus the matching README passage) is corrected.

## Why

The script and README claimed "everything Bun's script runner spawns runs translated". That is wrong. `bun run` executes lifecycle scripts with the first `bash` on `PATH`; on a machine with an x86_64-only bash (an Intel Homebrew under `/usr/local`) the script and every child it spawns run under Rosetta, which is why `prebuild-install` resolved `process.arch` as x64 and fetched a `darwin-x64` better-sqlite3.

Measured both ways on the same machine:

```
bun run py                            -> python-machine x86_64
PATH=<arm64 bash first> bun run py    -> python-machine arm64
```

## The guard

```bash
if [ "$(sysctl -n sysctl.proc_translated ...)" = 1 ] && [ "$(sysctl -n hw.optional.arm64 ...)" = 1 ] && ...; then
	exec /usr/bin/arch -arm64 /bin/bash "$0" "$@"
fi
```

Verified through a real `bun install` with an Intel bash first on `PATH`: entry `uname=x86_64 translated=1`, after the guard `uname=arm64 translated=0`, child python and node both arm64, `electron-rebuild` completed. The `hw.optional.arm64` probe stays as the fallback for machines where the re-exec cannot run.

## Side effect worth knowing

macOS attributes Rosetta-translated processes to the **responsible app bundle**, so installs and agent commands running translated inside Ateam terminals are blamed on Ateam. `ecosystemd` posted "Support Ending for Intel-Based Apps" naming Ateam, even though the shipped 0.1.54 bundle contains zero x86_64 Mach-O. Rosetta ends after macOS 27, so this is worth fixing at the source rather than ignoring.