### PR TITLE
New tasks appear immediately, and stop copying other checkouts' dependencies and secrets

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -60,9 +60,9 @@ import { LoopsPanel } from "./components/LoopsPanel";
 import { Menu } from "./components/Menu";
 import { PromptComposer } from "./components/PromptComposer";
 import { TaskSearch } from "./components/TaskSearch";
-import { VscodeLogo } from "./components/VscodeLogo";
 import { TerminalView } from "./components/Terminal";
 import { usePrompt } from "./components/usePrompt";
+import { VscodeLogo } from "./components/VscodeLogo";
 import { activeTerminal, sessionTabs } from "./session-tabs";
 import { matchesTagQuery, tagsFor, taskIcon } from "./task-tags";
 import { byWhatsNext, relativeAge } from "./triage-order";
@@ -814,13 +814,24 @@ export function App() {
 			// Loops shows only loop-owned tasks, so a new task would land
 			// somewhere it can't be seen; every other view keeps its place.
 			if (view === "loops") setView("board");
-			const { terminalId } = await window.ateam.pty.spawnAgent({
-				taskId: task.id,
-				agentId: input.agentId,
-				yolo: input.yolo,
-				prompt: input.prompt || undefined,
-				files: input.files.length ? input.files : undefined,
-			});
+			// The card is on the board already — the engine creates the row as soon
+			// as the worktree exists. What this awaits is the worktree's gitignored
+			// state (dependencies, env files) finishing its copy, which the engine
+			// makes the agent launch wait for. Without a word here, that gap reads
+			// as another dead click, which is the whole bug this path had.
+			setInfo("Preparing worktree…");
+			let terminalId: string;
+			try {
+				({ terminalId } = await window.ateam.pty.spawnAgent({
+					taskId: task.id,
+					agentId: input.agentId,
+					yolo: input.yolo,
+					prompt: input.prompt || undefined,
+					files: input.files.length ? input.files : undefined,
+				}));
+			} finally {
+				setInfo(null);
+			}
 			setTermByTask((m) => ({ ...m, [task.id]: terminalId }));
 		});
 
@@ -2159,10 +2170,7 @@ function TaskPanel({
 			<div className="panel-body">
 				{/* Keep the terminal mounted (xterm state survives) while the
 				    changes view is open — just hide it. */}
-				<div
-					className="term-wrap"
-					style={{ display: changesOpen || editorOpen ? "none" : "flex" }}
-				>
+				<div className="term-wrap" style={{ display: changesOpen || editorOpen ? "none" : "flex" }}>
 					{terminalId ? (
 						<TerminalView
 							terminalId={terminalId}

--- a/packages/git-core/src/index.ts
+++ b/packages/git-core/src/index.ts
@@ -35,9 +35,10 @@ export type {
 	CreateTaskInput,
 	RemoveTaskInput,
 	RemoveTaskResult,
+	SeedWorktreeInput,
 	TaskInfo,
 } from "./task";
-export { createTask, removeTask } from "./task";
+export { createTask, removeTask, seedWorktree } from "./task";
 export type { GitClient } from "./types";
 export { slugify } from "./util";
 export type { WorktreeRecord } from "./worktree-list";

--- a/packages/git-core/src/task.ts
+++ b/packages/git-core/src/task.ts
@@ -1,14 +1,14 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { cp, mkdir, readdir, stat } from "node:fs/promises";
-import { dirname, join, relative } from "node:path";
+import { cp, mkdir, rm, stat } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import type { SimpleGit } from "simple-git";
-import { gitFor, refExists } from "./git-client";
 import { GitCoreError } from "./errors";
+import { gitFor, refExists, safeRaw } from "./git-client";
 import { detectDefaultBranch, ensureWorktreesIgnored } from "./project";
 import { slugify } from "./util";
-import { safeResolveWorktreePath, worktreesRootFor } from "./worktree-paths";
+import { safeResolveWorktreePath } from "./worktree-paths";
 
 const pexec = promisify(execFile);
 
@@ -77,10 +77,7 @@ async function fetchBase(repoPath: string, baseBranch: string): Promise<void> {
 }
 
 /** Resolve the start point for a new task branch: prefer the pushed base. */
-async function resolveStartPoint(
-	repoPath: string,
-	baseBranch: string,
-): Promise<string> {
+async function resolveStartPoint(repoPath: string, baseBranch: string): Promise<string> {
 	const git = gitFor(repoPath);
 	await fetchBase(repoPath, baseBranch);
 	if (await refExists(git, `refs/remotes/origin/${baseBranch}`)) {
@@ -114,11 +111,7 @@ async function allocateNames(
 		const candidate = {
 			slug: slug + suffix,
 			branch: branch + suffix,
-			worktreePath: safeResolveWorktreePath(
-				repoPath,
-				slug + suffix,
-				worktreesRoot,
-			),
+			worktreePath: safeResolveWorktreePath(repoPath, slug + suffix, worktreesRoot),
 		};
 		if (existsSync(candidate.worktreePath)) continue;
 		if (await refExists(git, `refs/heads/${candidate.branch}`)) continue;
@@ -139,10 +132,7 @@ async function allocateNames(
  * CLI in the new worktree is already linked. Best-effort: a missing source dir,
  * a non-Supabase repo, or a copy error must never fail task creation.
  */
-async function copySupabaseLink(
-	repoPath: string,
-	worktreePath: string,
-): Promise<void> {
+async function copySupabaseLink(repoPath: string, worktreePath: string): Promise<void> {
 	const src = join(repoPath, "supabase", ".temp");
 	try {
 		if (!(await stat(src)).isDirectory()) return;
@@ -158,17 +148,57 @@ async function copySupabaseLink(
 	}
 }
 
-/** Directories never worth descending into when hunting for env files. */
-const SKIP_DIRS = new Set([".git", "node_modules"]);
+/**
+ * What is in this working tree but NOT on the branch: its ignored and untracked
+ * entries. Everything the seed carries across is one of these by definition —
+ * git refuses to put them on the branch, which is precisely why a fresh worktree
+ * cannot run until something copies them.
+ *
+ * `git ls-files` rather than a hand-rolled directory walk, for two properties a
+ * walk cannot reproduce:
+ *
+ *  - It never crosses a repository boundary. A nested checkout — another tool's
+ *    worktrees (`.claude/worktrees`), a vendored clone, a submodule — is
+ *    reported as a single entry whose contents are never listed, whether or not
+ *    it is gitignored. A walk has no idea it has left this repo, so it descends
+ *    and copies that repo's dependencies and secrets into the new worktree:
+ *    measured on one monorepo, 370 `node_modules` trees instead of 11, and 28
+ *    `.env`/`.dev.vars` files belonging to six unrelated checkouts.
+ *  - It owns ignore semantics — `.gitignore` at every level, `.git/info/exclude`
+ *    (where ensureWorktreesIgnored puts our own worktrees root), the user's
+ *    global excludes — so the worktrees root needs no special-casing here.
+ *
+ * Two invocations, answering different questions:
+ *  - ignored, WITH `--directory`: collapses a wholly-ignored tree to one entry,
+ *    so `node_modules/` arrives as a single path instead of 114k files.
+ *  - untracked-but-not-ignored, WITHOUT `--directory`: a repo that does not
+ *    gitignore its `.env` still needs it carried, and there the individual files
+ *    are what we want. Nested repos stay collapsed either way.
+ *
+ * Tracked files appear in neither, which is correct: they ride the branch, and
+ * copying them would clobber the checkout with the source worktree's version.
+ *
+ * `-z` because `ls-files` otherwise C-quotes any path with non-ASCII bytes.
+ */
+async function listUnversionedEntries(repoPath: string): Promise<string[]> {
+	const git = gitFor(repoPath);
+	const [ignored, untracked] = await Promise.all([
+		safeRaw(git, ["ls-files", "-z", "-o", "-i", "--exclude-standard", "--directory"]),
+		safeRaw(git, ["ls-files", "-z", "-o", "--exclude-standard"]),
+	]);
+	const entries = new Set<string>();
+	for (const raw of `${ignored}\0${untracked}`.split("\0")) {
+		const entry = raw.replace(/\/$/, "").trim();
+		if (entry) entries.add(entry);
+	}
+	return [...entries];
+}
 
 /**
- * Local secrets/config live in gitignored env files — `.env` (and variants like
+ * Local secrets/config live in env files — `.env` (and variants like
  * `.env.local`) and Cloudflare's `.dev.vars` — that don't ride along on the
- * branch, so a fresh worktree can't run the app until they're present. Copy them
- * across, including nested ones (e.g. `apps/api/.dev.vars`), preserving their
- * relative location. Template files (`.env.example` & co.) are tracked already,
- * so we skip them. Best-effort: any walk/copy error must never fail task
- * creation.
+ * branch, so a fresh worktree can't run the app until they're present. Template
+ * files (`.env.example` & co.) are tracked already, so we skip them.
  */
 function isEnvFile(name: string): boolean {
 	if (/\.(example|sample|template)$/.test(name)) return false;
@@ -180,73 +210,38 @@ function isEnvFile(name: string): boolean {
 	);
 }
 
+/** Copy this repo's own env files across, preserving their relative location. */
 async function copyEnvFiles(
 	repoPath: string,
 	worktreePath: string,
-	worktreesRoot?: string | null,
+	entries: string[],
 ): Promise<void> {
-	const root = worktreesRootFor(repoPath, worktreesRoot);
-
-	async function walk(dir: string): Promise<void> {
-		let entries;
+	for (const rel of entries) {
+		if (!isEnvFile(basename(rel))) continue;
 		try {
-			entries = await readdir(dir, { withFileTypes: true });
+			if (!(await stat(join(repoPath, rel))).isFile()) continue;
+			const dest = join(worktreePath, rel);
+			await mkdir(dirname(dest), { recursive: true });
+			await cp(join(repoPath, rel), dest);
 		} catch {
-			return;
-		}
-		for (const entry of entries) {
-			const abs = join(dir, entry.name);
-			if (abs === root) continue; // don't descend into other worktrees
-			if (entry.isDirectory()) {
-				if (SKIP_DIRS.has(entry.name)) continue;
-				await walk(abs);
-			} else if (entry.isFile() && isEnvFile(entry.name)) {
-				const dest = join(worktreePath, relative(repoPath, abs));
-				try {
-					await mkdir(dirname(dest), { recursive: true });
-					await cp(abs, dest);
-				} catch {
-					/* best-effort — skip this file */
-				}
-			}
+			/* best-effort — skip this file */
 		}
 	}
-
-	await walk(repoPath);
 }
 
 /**
  * Copy-on-write copy: share blocks with the source instead of duplicating them.
  * macOS `cp -c` is clonefile(2); GNU `cp --reflink=auto` reflinks on btrfs/XFS
  * and silently falls back to a full copy elsewhere rather than failing.
+ *
+ * Measured ceiling: this is per-file, so a 1.3 GB / 114k-file `node_modules`
+ * costs ~35s. Darwin's clonefile(2) applied to the DIRECTORY does the same work
+ * in ~3.7s, but it has no Node binding and no Linux equivalent, and the engine
+ * also runs on Linux boxes. Revisit only if seeding ever blocks task creation
+ * again — today it does not, seedWorktree runs after the task row exists.
  */
 const CLONE_CP = process.platform === "darwin" ? "/bin/cp" : "cp";
 const CLONE_ARGS = process.platform === "darwin" ? ["-c", "-R"] : ["--reflink=auto", "-R"];
-
-/** Every `node_modules` in the repo, without descending into them. */
-async function findNodeModules(repoPath: string, worktreesRoot?: string | null): Promise<string[]> {
-	const root = worktreesRootFor(repoPath, worktreesRoot);
-	const found: string[] = [];
-
-	async function walk(dir: string): Promise<void> {
-		const entries = await readdir(dir, { withFileTypes: true }).catch(() => null);
-		if (!entries) return;
-		for (const entry of entries) {
-			if (!entry.isDirectory()) continue;
-			const abs = join(dir, entry.name);
-			if (abs === root) continue; // don't descend into other worktrees
-			if (entry.name === "node_modules") {
-				found.push(abs); // a tree to clone, not a tree to walk
-				continue;
-			}
-			if (entry.name === ".git") continue;
-			await walk(abs);
-		}
-	}
-
-	await walk(repoPath);
-	return found;
-}
 
 /**
  * Dependencies are gitignored, so a fresh worktree cannot typecheck, lint or run
@@ -254,30 +249,30 @@ async function findNodeModules(repoPath: string, worktreesRoot?: string | null):
  * `node_modules` across instead, which on a copy-on-write filesystem shares the
  * blocks rather than duplicating them.
  *
- * Measured on this repo: 23k files that `du` reports as 807 MB clone in ~5s for
- * ~9 MB of real disk. `fs.cp` is not a substitute — even with COPYFILE_FICLONE
- * it wrote 819 MB for the same tree — hence shelling out. `verbatim` symlink
- * behaviour matters too: `cp -R` preserves the relative links a bun/pnpm store
- * depends on, while `fs.cp` rewrites them to absolute paths into the SOURCE.
+ * `fs.cp` is not a substitute — even with COPYFILE_FICLONE it wrote 819 MB for a
+ * tree that clones for ~9 MB of real disk — hence shelling out. `verbatim`
+ * symlink behaviour matters too: `cp -R` preserves the relative links a bun/pnpm
+ * store depends on, while `fs.cp` rewrites them to absolute paths into the
+ * SOURCE.
  *
  * The seed also removes the expensive half of any later install: Electron's
  * postinstall exits early once `dist/version` matches, so its 244 MB download
  * and extract never runs in this worktree.
  *
- * Monorepos keep a `node_modules` per package, so every tree is cloned, not just
- * the root one. Best-effort: a repo with no deps installed, a filesystem without
- * reflinks, or a copy error must never fail task creation.
+ * Monorepos keep a `node_modules` per package, so every tree THIS repo owns is
+ * cloned, not just the root one.
  */
 async function seedNodeModules(
 	repoPath: string,
 	worktreePath: string,
-	worktreesRoot?: string | null,
+	entries: string[],
 ): Promise<void> {
-	for (const src of await findNodeModules(repoPath, worktreesRoot)) {
-		const dest = join(worktreePath, relative(repoPath, src));
+	for (const rel of entries) {
+		if (basename(rel) !== "node_modules") continue;
+		const dest = join(worktreePath, rel);
 		try {
 			await mkdir(dirname(dest), { recursive: true });
-			await pexec(CLONE_CP, [...CLONE_ARGS, src, dest]);
+			await pexec(CLONE_CP, [...CLONE_ARGS, join(repoPath, rel), dest]);
 		} catch {
 			/* best-effort — the worktree just needs its own install */
 		}
@@ -294,13 +289,9 @@ async function seedNodeModules(
 export async function createTask(input: CreateTaskInput): Promise<TaskInfo> {
 	const baseSlug = slugify(input.name);
 	if (!baseSlug) {
-		throw new GitCoreError(
-			"INVALID_NAME",
-			`Task name produced an empty slug: "${input.name}"`,
-		);
+		throw new GitCoreError("INVALID_NAME", `Task name produced an empty slug: "${input.name}"`);
 	}
-	const baseBranch =
-		input.baseBranch ?? (await detectDefaultBranch(input.repoPath));
+	const baseBranch = input.baseBranch ?? (await detectDefaultBranch(input.repoPath));
 
 	const git = gitFor(input.repoPath);
 	// A repeated name is normal, not an error: take the next free variant.
@@ -318,32 +309,46 @@ export async function createTask(input: CreateTaskInput): Promise<TaskInfo> {
 	await ensureWorktreesIgnored(input.repoPath, input.worktreesRoot);
 
 	await mkdir(dirname(worktreePath), { recursive: true });
-	await git.raw([
-		"worktree",
-		"add",
-		"--no-track",
-		"-b",
-		branch,
-		worktreePath,
-		startPoint,
-	]);
+	await git.raw(["worktree", "add", "--no-track", "-b", branch, worktreePath, startPoint]);
 
 	// Record the base branch so update/merge know what to diff/merge against.
 	await gitFor(worktreePath).raw(["config", `branch.${branch}.base`, baseBranch]);
 
+	return { slug, branch, baseBranch, worktreePath };
+}
+
+export interface SeedWorktreeInput {
+	repoPath: string;
+	worktreePath: string;
+}
+
+/**
+ * Carry over the gitignored working-tree state a fresh worktree needs in order
+ * to RUN: the Supabase link, env files, and installed dependencies.
+ *
+ * Deliberately NOT part of createTask, and deliberately not awaited by it. This
+ * is the overwhelming majority of the cost — measured on one monorepo, `git
+ * worktree add` is ~2s and this is ~52s for 161k files — so gating the task's
+ * existence on it means the board shows nothing for a minute, and the user
+ * reasonably concludes the click did not register and clicks New task again.
+ * The caller creates the row first, announces it, and runs this after; anything
+ * that needs the dependencies (launching an agent) awaits it by task id.
+ *
+ * Every step is best-effort by design: a repo with nothing installed, a
+ * filesystem without reflinks, or a copy error leaves a worktree that needs its
+ * own install — never a task that failed to be created.
+ */
+export async function seedWorktree(input: SeedWorktreeInput): Promise<void> {
+	const entries = await listUnversionedEntries(input.repoPath);
 	// Carry the Supabase link over so the worktree's CLI is already linked.
-	await copySupabaseLink(input.repoPath, worktreePath);
-
-	// Carry gitignored env files (.env*, .dev.vars*) over, including nested ones,
-	// so the worktree can run the app without re-creating its local secrets.
-	await copyEnvFiles(input.repoPath, worktreePath, input.worktreesRoot);
-
+	await copySupabaseLink(input.repoPath, input.worktreePath);
+	// Carry env files (.env*, .dev.vars*) over, including nested ones, so the
+	// worktree can run the app without re-creating its local secrets.
+	await copyEnvFiles(input.repoPath, input.worktreePath, entries);
 	// Carry the installed dependencies over as a copy-on-write clone, so the
 	// worktree can typecheck and run immediately instead of paying a full
 	// install (and Electron's 244 MB extract) per task.
-	await seedNodeModules(input.repoPath, worktreePath, input.worktreesRoot);
-
-	return { slug, branch, baseBranch, worktreePath };
+	await seedNodeModules(input.repoPath, input.worktreePath, entries);
 }
 
 export interface RemoveTaskInput {
@@ -361,9 +366,42 @@ export interface RemoveTaskResult {
 	warnings: string[];
 }
 
-export async function removeTask(
-	input: RemoveTaskInput,
-): Promise<RemoveTaskResult> {
+/**
+ * Delete a worktree's directory ourselves, returning whether it is now gone.
+ *
+ * `rm -rf` driven by a path out of the database needs a stronger guarantee than
+ * "it looks like a worktree path", so the only paths eligible are the ones git
+ * itself reports as worktrees of THIS repo, minus the main worktree. That is one
+ * command, and it is git's own record rather than our inference from a string.
+ */
+async function removeWorktreeDirectory(
+	git: SimpleGit,
+	repoPath: string,
+	worktreePath: string,
+): Promise<boolean> {
+	const target = resolve(worktreePath);
+	if (target === resolve(repoPath)) return false;
+	const listed = await safeRaw(git, ["worktree", "list", "--porcelain"]);
+	const known = listed
+		.split("\n")
+		.filter((line) => line.startsWith("worktree "))
+		.some((line) => resolve(line.slice("worktree ".length).trim()) === target);
+	if (!known) return false;
+	try {
+		await rm(target, { recursive: true, force: true });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * simple-git's inactivity killer, verbatim from its timeout plugin. Matching the
+ * message is what separates "git was killed mid-removal" from "git refused".
+ */
+const TIMEOUT_KILL = /block timeout reached/i;
+
+export async function removeTask(input: RemoveTaskInput): Promise<RemoveTaskResult> {
 	const git = gitFor(input.repoPath);
 	const warnings: string[] = [];
 
@@ -378,12 +416,33 @@ export async function removeTask(
 		// the tree is already gone. Prune the stale admin entry below and carry
 		// on to branch deletion instead of surfacing the error to the user.
 		const message = err instanceof Error ? err.message : String(err);
-		if (!/is not a working tree|No such file or directory/i.test(message)) {
+		if (/is not a working tree|No such file or directory/i.test(message)) {
+			warnings.push(`Worktree "${input.worktreePath}" was already gone; pruned its stale entry.`);
+		} else if (
+			TIMEOUT_KILL.test(message) &&
+			(await removeWorktreeDirectory(git, input.repoPath, input.worktreePath))
+		) {
+			// git was KILLED here, it did not refuse: simple-git's `timeout.block`
+			// is an INACTIVITY timer, and `worktree remove` prints nothing at all
+			// while it unlinks, so a worktree with seeded dependencies (~161k files)
+			// trips it at five minutes with the tree half-deleted. Rethrowing then
+			// strands the task — the caller never deletes its row, the card stays on
+			// the board pointing at a broken worktree, and every retry dies exactly
+			// the same way. Finishing the removal ourselves is what makes a delete
+			// the user asked for actually complete.
+			//
+			// Narrow to that one signature ON PURPOSE. `worktree remove` validates
+			// BEFORE it unlinks, so a timeout means the checks already passed and
+			// the deletion was underway — safe to finish. Every other failure is git
+			// REFUSING (a dirty worktree without --force, a main working tree), and
+			// deleting the directory there would silently turn a guarded removal
+			// into a forced one and destroy uncommitted work. Those still throw.
+			warnings.push(
+				`Worktree "${input.worktreePath}" did not remove cleanly (${message}); removed its directory directly.`,
+			);
+		} else {
 			throw err;
 		}
-		warnings.push(
-			`Worktree "${input.worktreePath}" was already gone; pruned its stale entry.`,
-		);
 	}
 
 	// Prune before deleting the branch: if the worktree dir vanished, git still

--- a/packages/git-core/test/git-core.test.ts
+++ b/packages/git-core/test/git-core.test.ts
@@ -1,16 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
-import {
-	chmod,
-	mkdir,
-	mkdtemp,
-	readlink,
-	rm,
-	symlink,
-	writeFile,
-} from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readlink, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import simpleGit from "simple-git";
+import { GitCoreError } from "../src/errors";
 import {
 	cloneRepo,
 	commit,
@@ -19,22 +12,17 @@ import {
 	detectMerged,
 	diff,
 	initRepository,
-	push,
 	parseWorktreeList,
+	push,
 	registerProject,
 	removeTask,
 	safeResolveWorktreePath,
+	seedWorktree,
 	slugify,
 	updateFromBase,
 	updateLocalMain,
 } from "../src/index";
-import { GitCoreError } from "../src/errors";
-import {
-	advanceOrigin,
-	commitFile,
-	makeTempRepoPair,
-	type TempRepo,
-} from "./helpers/temp-repo";
+import { advanceOrigin, commitFile, makeTempRepoPair, type TempRepo } from "./helpers/temp-repo";
 
 let repo: TempRepo;
 
@@ -68,9 +56,7 @@ describe("project", () => {
 
 	it("adds /.ateam/ to .git/info/exclude", async () => {
 		await registerProject(repo.work);
-		const exclude = await Bun.file(
-			join(repo.work, ".git", "info", "exclude"),
-		).text();
+		const exclude = await Bun.file(join(repo.work, ".git", "info", "exclude")).text();
 		expect(exclude).toContain("/.ateam/");
 	});
 
@@ -86,9 +72,7 @@ describe("createTask freshness", () => {
 		// The clone's refs/remotes/origin/main is now behind the real remote --
 		// exactly the state a repo sits in between merges.
 		const advanced = await advanceOrigin(repo);
-		expect(await branchSha(repo.work, "refs/remotes/origin/main")).not.toBe(
-			advanced,
-		);
+		expect(await branchSha(repo.work, "refs/remotes/origin/main")).not.toBe(advanced);
 
 		const task = await createTask({ repoPath: repo.work, name: "fresh" });
 
@@ -115,11 +99,22 @@ describe("createTask freshness", () => {
 });
 
 describe("createTask isolation", () => {
+	/**
+	 * A real "create a task" is both calls: createTask makes the worktree, and
+	 * seedWorktree carries the gitignored state it needs to RUN. They are split
+	 * so the task's row (and its card) can exist before the slow half finishes.
+	 */
+	async function createAndSeed(name: string) {
+		const task = await createTask({ repoPath: repo.work, name });
+		await seedWorktree({
+			repoPath: repo.work,
+			worktreePath: task.worktreePath,
+		});
+		return task;
+	}
+
 	it("creates a co-located worktree without disturbing the main worktree", async () => {
-		const headBefore = await simpleGit(repo.work).raw([
-			"symbolic-ref",
-			"HEAD",
-		]);
+		const headBefore = await simpleGit(repo.work).raw(["symbolic-ref", "HEAD"]);
 		const statusBefore = await porcelainStatus(repo.work);
 
 		const task = await createTask({ repoPath: repo.work, name: "Add auth" });
@@ -127,15 +122,11 @@ describe("createTask isolation", () => {
 		expect(task.slug).toBe("add-auth");
 		expect(task.branch).toBe("add-auth");
 		expect(task.baseBranch).toBe("main");
-		expect(task.worktreePath).toBe(
-			join(repo.work, ".ateam", "worktrees", "add-auth"),
-		);
+		expect(task.worktreePath).toBe(join(repo.work, ".ateam", "worktrees", "add-auth"));
 		expect(existsSync(task.worktreePath)).toBe(true);
 
 		// Main worktree HEAD + working tree byte-for-byte unchanged.
-		expect(await simpleGit(repo.work).raw(["symbolic-ref", "HEAD"])).toBe(
-			headBefore,
-		);
+		expect(await simpleGit(repo.work).raw(["symbolic-ref", "HEAD"])).toBe(headBefore);
 		expect(await porcelainStatus(repo.work)).toBe(statusBefore);
 	});
 
@@ -153,12 +144,9 @@ describe("createTask isolation", () => {
 	it("copies the Supabase link state into the new worktree", async () => {
 		// Simulate `supabase link`: the gitignored link cache in the main repo.
 		await mkdir(join(repo.work, "supabase", ".temp"), { recursive: true });
-		await writeFile(
-			join(repo.work, "supabase", ".temp", "project-ref"),
-			"abcdefghijklmnopqrst",
-		);
+		await writeFile(join(repo.work, "supabase", ".temp", "project-ref"), "abcdefghijklmnopqrst");
 
-		const task = await createTask({ repoPath: repo.work, name: "linked" });
+		const task = await createAndSeed("linked");
 
 		const copied = join(task.worktreePath, "supabase", ".temp", "project-ref");
 		expect(existsSync(copied)).toBe(true);
@@ -167,7 +155,7 @@ describe("createTask isolation", () => {
 
 	it("creates the worktree fine when there is no Supabase link", async () => {
 		// No supabase/.temp in the repo — task creation must still succeed.
-		const task = await createTask({ repoPath: repo.work, name: "unlinked" });
+		const task = await createAndSeed("unlinked");
 		expect(existsSync(task.worktreePath)).toBe(true);
 		expect(existsSync(join(task.worktreePath, "supabase"))).toBe(false);
 	});
@@ -181,19 +169,13 @@ describe("createTask isolation", () => {
 		// Template files are tracked already — must NOT be copied as a secret.
 		await writeFile(join(repo.work, ".env.example"), "ROOT=\n");
 
-		const task = await createTask({ repoPath: repo.work, name: "envy" });
+		const task = await createAndSeed("envy");
 
-		expect(await Bun.file(join(task.worktreePath, ".env")).text()).toBe(
-			"ROOT=1\n",
+		expect(await Bun.file(join(task.worktreePath, ".env")).text()).toBe("ROOT=1\n");
+		expect(await Bun.file(join(task.worktreePath, ".env.local")).text()).toBe("LOCAL=1\n");
+		expect(await Bun.file(join(task.worktreePath, "apps", "api", ".dev.vars")).text()).toBe(
+			"API=2\n",
 		);
-		expect(await Bun.file(join(task.worktreePath, ".env.local")).text()).toBe(
-			"LOCAL=1\n",
-		);
-		expect(
-			await Bun.file(
-				join(task.worktreePath, "apps", "api", ".dev.vars"),
-			).text(),
-		).toBe("API=2\n");
 		expect(existsSync(join(task.worktreePath, ".env.example"))).toBe(false);
 	});
 
@@ -201,6 +183,7 @@ describe("createTask isolation", () => {
 		// A monorepo keeps a tree per package, and package stores link between
 		// them RELATIVELY. A copy that rewrites those links to absolute paths
 		// would point the new worktree back at the source repo.
+		await writeFile(join(repo.work, ".gitignore"), "node_modules/\n");
 		await mkdir(join(repo.work, "node_modules", ".store", "dep"), {
 			recursive: true,
 		});
@@ -208,10 +191,7 @@ describe("createTask isolation", () => {
 			join(repo.work, "node_modules", ".store", "dep", "index.js"),
 			"module.exports = 1;\n",
 		);
-		await symlink(
-			join(".store", "dep"),
-			join(repo.work, "node_modules", "dep"),
-		);
+		await symlink(join(".store", "dep"), join(repo.work, "node_modules", "dep"));
 		await mkdir(join(repo.work, "apps", "web", "node_modules"), {
 			recursive: true,
 		});
@@ -220,36 +200,58 @@ describe("createTask isolation", () => {
 			join(repo.work, "apps", "web", "node_modules", "dep"),
 		);
 
-		const task = await createTask({ repoPath: repo.work, name: "seeded" });
+		const task = await createAndSeed("seeded");
 
 		expect(
-			await Bun.file(
-				join(task.worktreePath, "node_modules", ".store", "dep", "index.js"),
-			).text(),
+			await Bun.file(join(task.worktreePath, "node_modules", ".store", "dep", "index.js")).text(),
 		).toBe("module.exports = 1;\n");
 		// The nested tree is cloned too, not just the root one.
-		expect(
-			existsSync(join(task.worktreePath, "apps", "web", "node_modules")),
-		).toBe(true);
+		expect(existsSync(join(task.worktreePath, "apps", "web", "node_modules"))).toBe(true);
 		// And both links still point where they did, relatively.
-		expect(
-			await readlink(join(task.worktreePath, "node_modules", "dep")),
-		).toBe(join(".store", "dep"));
-		expect(
-			await readlink(
-				join(task.worktreePath, "apps", "web", "node_modules", "dep"),
-			),
-		).toBe(join("..", "..", "..", "node_modules", ".store", "dep"));
+		expect(await readlink(join(task.worktreePath, "node_modules", "dep"))).toBe(
+			join(".store", "dep"),
+		);
+		expect(await readlink(join(task.worktreePath, "apps", "web", "node_modules", "dep"))).toBe(
+			join("..", "..", "..", "node_modules", ".store", "dep"),
+		);
+	});
+
+	it("never descends into a nested checkout when seeding", async () => {
+		// Another tool's worktrees, or a vendored clone, living inside the repo.
+		// Its dependencies and secrets belong to IT, not to this task, and a
+		// directory walk cannot tell it has left the repo — which is how 370
+		// node_modules trees and 28 unrelated .env files ended up in every new
+		// worktree. `git ls-files` stops at the boundary; that is the fix.
+		await writeFile(join(repo.work, ".gitignore"), "node_modules/\n");
+		await mkdir(join(repo.work, "node_modules", "own"), { recursive: true });
+		await writeFile(join(repo.work, "node_modules", "own", "i.js"), "mine\n");
+		await writeFile(join(repo.work, ".env"), "MINE=1\n");
+
+		const nested = join(repo.work, "vendor", "other");
+		await mkdir(nested, { recursive: true });
+		await simpleGit().raw(["init", "-b", "main", nested]);
+		await mkdir(join(nested, "node_modules", "theirs"), { recursive: true });
+		await writeFile(join(nested, "node_modules", "theirs", "i.js"), "theirs\n");
+		await writeFile(join(nested, ".env"), "THEIRS=1\n");
+
+		const task = await createAndSeed("boundary");
+
+		// This repo's own state came across.
+		expect(existsSync(join(task.worktreePath, "node_modules", "own"))).toBe(true);
+		expect(await Bun.file(join(task.worktreePath, ".env")).text()).toBe("MINE=1\n");
+		// The nested checkout's did not — neither its deps nor its secrets.
+		expect(existsSync(join(task.worktreePath, "vendor", "other", "node_modules"))).toBe(false);
+		expect(existsSync(join(task.worktreePath, "vendor", "other", ".env"))).toBe(false);
 	});
 
 	it("creates the worktree fine when nothing is installed", async () => {
-		const task = await createTask({ repoPath: repo.work, name: "no-deps" });
+		const task = await createAndSeed("no-deps");
 		expect(existsSync(task.worktreePath)).toBe(true);
 		expect(existsSync(join(task.worktreePath, "node_modules"))).toBe(false);
 	});
 
 	it("creates the worktree fine when there are no env files", async () => {
-		const task = await createTask({ repoPath: repo.work, name: "no-env" });
+		const task = await createAndSeed("no-env");
 		expect(existsSync(task.worktreePath)).toBe(true);
 		expect(existsSync(join(task.worktreePath, ".env"))).toBe(false);
 	});
@@ -258,16 +260,8 @@ describe("createTask isolation", () => {
 		const b = await createTask({ repoPath: repo.work, name: "same name" });
 		const c = await createTask({ repoPath: repo.work, name: "Same Name!" });
 
-		expect([a.branch, b.branch, c.branch]).toEqual([
-			"same-name",
-			"same-name-2",
-			"same-name-3",
-		]);
-		expect([a.slug, b.slug, c.slug]).toEqual([
-			"same-name",
-			"same-name-2",
-			"same-name-3",
-		]);
+		expect([a.branch, b.branch, c.branch]).toEqual(["same-name", "same-name-2", "same-name-3"]);
+		expect([a.slug, b.slug, c.slug]).toEqual(["same-name", "same-name-2", "same-name-3"]);
 		for (const t of [a, b, c]) expect(existsSync(t.worktreePath)).toBe(true);
 	});
 
@@ -287,11 +281,7 @@ describe("createTask isolation", () => {
 	});
 
 	it("skips a name already taken by a remote branch", async () => {
-		await simpleGit(repo.work).raw([
-			"update-ref",
-			"refs/remotes/origin/taken",
-			"HEAD",
-		]);
+		await simpleGit(repo.work).raw(["update-ref", "refs/remotes/origin/taken", "HEAD"]);
 
 		const task = await createTask({ repoPath: repo.work, name: "taken" });
 		expect(task.branch).toBe("taken-2");
@@ -344,12 +334,7 @@ describe("updateLocalMain — Stage B safety (no GitHub needed)", () => {
 
 	it("aborts cleanly without clobbering when local main has diverged", async () => {
 		// Local divergent commit on work's main.
-		const localSha = await commitFile(
-			repo.work,
-			"local.txt",
-			"local\n",
-			"divergent local commit",
-		);
+		const localSha = await commitFile(repo.work, "local.txt", "local\n", "divergent local commit");
 		// Remote advances on a different line of history.
 		await advanceOrigin(repo, { file: "remote.txt", content: "remote\n" });
 
@@ -454,6 +439,25 @@ describe("detectMerged — external merge detection (no GitHub needed)", () => {
 });
 
 describe("removeTask", () => {
+	it("refuses a dirty worktree instead of deleting it behind git's back", async () => {
+		const task = await createTask({ repoPath: repo.work, name: "dirty" });
+		await writeFile(join(task.worktreePath, "scratch.txt"), "unsaved\n");
+
+		// removeTask has a rescue path that deletes the directory itself, but it
+		// is armed ONLY for git being KILLED mid-removal (the inactivity timeout
+		// on a huge worktree). git REFUSING is a different thing entirely, and
+		// widening the rescue to cover it would turn every guarded removal into a
+		// forced one and destroy uncommitted work.
+		await expect(
+			removeTask({
+				repoPath: repo.work,
+				worktreePath: task.worktreePath,
+				branch: task.branch,
+			}),
+		).rejects.toThrow();
+		expect(existsSync(join(task.worktreePath, "scratch.txt"))).toBe(true);
+	});
+
 	it("removes only the target worktree, leaving siblings intact", async () => {
 		const a = await createTask({ repoPath: repo.work, name: "task a" });
 		const b = await createTask({ repoPath: repo.work, name: "task b" });
@@ -531,9 +535,7 @@ describe("commit & diff", () => {
 
 describe("path safety", () => {
 	it("safeResolveWorktreePath rejects traversal", () => {
-		expect(() => safeResolveWorktreePath("/repo", "../../evil")).toThrow(
-			GitCoreError,
-		);
+		expect(() => safeResolveWorktreePath("/repo", "../../evil")).toThrow(GitCoreError);
 	});
 
 	it("slugify neutralizes traversal characters", () => {
@@ -581,8 +583,8 @@ describe("cloneRepo — gh fallback (no GitHub needed)", () => {
 
 	it("throws GH_FAILED when git fails too", async () => {
 		process.env.GIT_CONFIG_KEY_0 = `url.${join(repo.dir, "nowhere.git")}.insteadOf`;
-		await expect(
-			cloneRepo(GH_URL, join(repo.dir, "cloned")),
-		).rejects.toMatchObject({ code: "GH_FAILED" });
+		await expect(cloneRepo(GH_URL, join(repo.dir, "cloned"))).rejects.toMatchObject({
+			code: "GH_FAILED",
+		});
 	});
 });

--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -222,6 +222,7 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 		mergeQueue,
 		loopRunner,
 		followUps,
+		pendingSeeds: new Map(),
 	};
 
 	// Record an agent's exit: close the session and file its card. Shared by the

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -19,6 +19,14 @@ export interface Services {
 	loopRunner: LoopRunner;
 	/** One-shot follow-up turns, armed at launch and consumed at turn end. */
 	followUps: FollowUps;
+	/**
+	 * In-flight `seedWorktree` calls by task id. A task's row is created (and its
+	 * card announced) as soon as the worktree exists, so its dependencies are
+	 * still landing for up to a minute afterwards; anything that needs them —
+	 * launching an agent — awaits the entry here. Absent means nothing pending,
+	 * so `await map.get(id)` is the whole protocol.
+	 */
+	pendingSeeds: Map<string, Promise<void>>;
 }
 
 export function toProjectDTO(p: Project): ProjectDTO {

--- a/packages/server/src/sessions.ts
+++ b/packages/server/src/sessions.ts
@@ -6,7 +6,7 @@ import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import { agentCommand, generateTaskTags, getAgent } from "@ateam/agents";
 import { repo, type Task } from "@ateam/db";
-import { createTask as gitCreateTask } from "@ateam/git-core";
+import { createTask as gitCreateTask, seedWorktree } from "@ateam/git-core";
 import { buildAgentEnv, ensureClaudeHooks, ensureCodexHooks } from "./agent-setup";
 import type { Services } from "./services";
 
@@ -59,6 +59,20 @@ export async function createTaskInProject(
 	// Broadcast so any other window showing this project gains the new card
 	// (renderers upsert). The caller also gets it — an idempotent upsert.
 	notifyTaskUpdated(row.id);
+	// Only NOW carry the gitignored state across. It is by far the slowest part
+	// of making a task (~52s against ~2s for the worktree itself on a large
+	// monorepo), and nothing above needs it, so blocking the row on it bought
+	// nothing and cost the user every signal that their click had registered.
+	// The promise is parked for `spawnAgentInTask` to await; failures are
+	// already swallowed inside seedWorktree, and the catch here only keeps a
+	// rejection from escaping as unhandled.
+	const seeding = seedWorktree({
+		repoPath: project.repoPath,
+		worktreePath: created.worktreePath,
+	})
+		.catch(() => {})
+		.finally(() => services.pendingSeeds.delete(row.id));
+	services.pendingSeeds.set(row.id, seeding);
 	return row;
 }
 
@@ -72,6 +86,13 @@ export async function spawnAgentInTask(
 	if (!task) throw new Error(`Task not found: ${input.taskId}`);
 	const agent = getAgent(input.agentId);
 	if (!agent) throw new Error(`Unknown agent: ${input.agentId}`);
+
+	// A task's card appears as soon as its worktree exists, so its dependencies
+	// may still be copying. An agent launched into a half-seeded worktree would
+	// fail its first `bun test` / typecheck for reasons that have nothing to do
+	// with the code, so the launch waits here rather than the board waiting
+	// earlier. Undefined (nothing pending) awaits to undefined immediately.
+	await services.pendingSeeds.get(task.id);
 
 	const terminalId = randomUUID();
 	// The conversation this tab holds. On a fresh launch we mint it — the

--- a/packages/server/test/dispatcher.test.ts
+++ b/packages/server/test/dispatcher.test.ts
@@ -30,6 +30,7 @@ function makeEngine(db: AteamDb) {
 				},
 			},
 			followUps: { arm() {}, discard() {} },
+			pendingSeeds: new Map(),
 			hooks: {},
 			mergeQueue: {},
 			loopRunner: { describe: () => [] },

--- a/packages/server/test/spawn-resume.test.ts
+++ b/packages/server/test/spawn-resume.test.ts
@@ -38,6 +38,7 @@ beforeEach(() => {
 		notifyScriptPath: join(scratch, "notify.sh"),
 		hookPort: 0,
 		followUps: new FollowUps(),
+		pendingSeeds: new Map(),
 	} as unknown as Services;
 	const project = repo.upsertProject(db, {
 		repoPath: "/tmp/repo",


### PR DESCRIPTION
## The bug

Creating a task on a large repo appeared to do nothing for about a minute, so the same task got created several times over. Deleting the duplicates then failed with `Error invoking remote method 'tasks:remove': Error: block timeout reached`, leaving cards on the board pointing at half-deleted worktrees.

Three causes, all in the dependency-seeding step shipped in 0.1.54:

**The walk crossed repository boundaries.** `findNodeModules` and `copyEnvFiles` skipped only the project's own worktrees root, so a repo that keeps another tool's worktrees inside it (`.claude/worktrees`) had all of them descended into. Measured on one monorepo: **370 `node_modules` trees instead of 11**, and **28 `.env` / `.dev.vars` files belonging to six unrelated checkouts** copied into every new task worktree. Every agent launched in that task could read six other checkouts' secrets.

**The card waited for the copy.** The task row was written only after all the copying finished. `git worktree add` takes 2.9s; the copy takes ~52s. For that minute there was no card and no spinner, so the click read as a no-op.

**A killed `git` stranded the task.** simple-git's `timeout.block` is an *inactivity* timer, and `git worktree remove` prints nothing while it unlinks. On a 161k-file worktree it was killed at five minutes with the tree half-deleted, `removeTask` threw, and `repo.deleteTask` never ran, so the card survived and every retry died the same way.

## The fix

**Ask git instead of walking.** `git ls-files` never crosses a repository boundary (a nested checkout is one entry whose contents are never listed, whether or not it is gitignored) and it owns ignore semantics, so the worktrees root needs no special-casing. Two invocations: ignored entries with `--directory` so `node_modules/` is a single path rather than 114k files, and untracked-but-not-ignored without it, so a repo that does not gitignore its `.env` still gets it carried. Tracked files appear in neither, which also stops us clobbering a checked-out `.env`.

**Create the row before seeding.** `createTask` now returns once the worktree exists; the copying moved to an exported `seedWorktree`. The row is created and announced immediately, and `spawnAgentInTask` awaits the pending seed through `services.pendingSeeds`, so no agent launches into a worktree whose dependencies are still landing. The renderer shows the existing info toast during that wait.

**Finish a removal git could not.** On the `block timeout reached` signature only, delete the directory ourselves and prune. Narrow on purpose: `worktree remove` validates *before* it unlinks, so a timeout means the checks passed and deletion was underway. Every other failure is git refusing (a dirty worktree without `--force`), where deleting the directory would silently turn a guarded removal into a forced one and destroy uncommitted work. A test covers that.

## Measured, end to end on the repo that broke (433 worktrees)

| | before | after |
|---|---|---|
| card appears after | ~54s | **2.9s** |
| `node_modules` trees copied | 370 | **11** |
| env files copied | 33, **28 from other checkouts** | **5, zero stray** |
| `.claude/worktrees` copied in | yes, 1.2 GB | **no** |
| delete | killed at 5 min, card survived | **10.0s**, clean |

## Testing

40 pass, 0 fail. Two new tests: one plants a nested checkout with its own `node_modules` and `.env` and asserts neither crosses; one asserts a dirty worktree still refuses removal and keeps its uncommitted file. Typecheck clean across all 8 projects. Biome findings in `App.tsx` are 17 before and 17 after, all pre-existing a11y warnings.

Also considered and rejected: Darwin's directory-level `clonefile(2)` copies the same 1.3 GB in 3.7s against `/bin/cp -c -R`'s 35.4s, but it has no Node binding and no Linux equivalent, and the engine also runs on Linux boxes. Noted in a comment with its trigger. Even at 9.6x the seed is not instant, so the row still has to come first.