### PR TITLE
Terminal sidebar: keep the agent in view beside the editor, and stop Copilot Chat popping open

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -32,6 +32,7 @@ import {
 	Minimize2,
 	Monitor,
 	PanelLeft,
+	PanelRight,
 	Play,
 	Plus,
 	Repeat,
@@ -1682,6 +1683,15 @@ function TaskPanel({
 	const [editorSrc, setEditorSrc] = useState<string | null>(null);
 	const [editorOpen, setEditorOpen] = useState(false);
 	const [editorBusy, setEditorBusy] = useState<string | null>(null);
+	// Dock the agent terminal as a right sidebar while the editor or the changes
+	// view owns the main area — the agent keeps working in view instead of
+	// vanishing behind it. Default on; the left-sidebar variant was left out.
+	const [termSide, setTermSide] = useState(() => localStorage.getItem("ateam.termSide") !== "0");
+	const toggleTermSide = () =>
+		setTermSide((s) => {
+			localStorage.setItem("ateam.termSide", s ? "0" : "1");
+			return !s;
+		});
 	const [viewFile, setViewFile] = useState<string | null>(null);
 	// This task's live PTY sessions — agents and shells alike. They ARE the tabs:
 	// the daemon already owns as many per task as you like, so there is nothing
@@ -1914,6 +1924,11 @@ function TaskPanel({
 
 	const tabs = sessionTabs(sessions ?? [], agents, restorable);
 
+	// Whether a view covers the terminal, and whether the terminal instead docks
+	// beside it (both open at once). Only when the toggle wants it.
+	const mainViewOpen = editorOpen || changesOpen;
+	const termDocked = termSide && mainViewOpen;
+
 	// Closing a tab kills its PTY — tabs are exactly the live sessions, so there
 	// is no "closed but still running" state to explain. Confirm first when the
 	// agent is mid-turn or holding a permission prompt, where a stray click would
@@ -2074,6 +2089,12 @@ function TaskPanel({
 					}}
 				/>
 				<IconButton
+					icon={PanelRight}
+					active={termSide}
+					label={termSide ? "Hide terminal sidebar" : "Show terminal sidebar"}
+					onClick={toggleTermSide}
+				/>
+				<IconButton
 					icon={ExternalLink}
 					label={
 						alias === null
@@ -2167,10 +2188,14 @@ function TaskPanel({
 				</button>
 			</div>
 
-			<div className="panel-body">
+			<div className={`panel-body${termDocked ? " docked-term" : ""}`}>
 				{/* Keep the terminal mounted (xterm state survives) while the
-				    changes view is open — just hide it. */}
-				<div className="term-wrap" style={{ display: changesOpen || editorOpen ? "none" : "flex" }}>
+				    changes view is open — just hide it, or dock it beside the
+				    view when the sidebar toggle is on. */}
+				<div
+					className="term-wrap"
+					style={{ display: termDocked || !mainViewOpen ? "flex" : "none" }}
+				>
 					{terminalId ? (
 						<TerminalView
 							terminalId={terminalId}

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -1110,6 +1110,17 @@ input {
 	background: #1e1e1e;
 }
 
+/* Terminal docked as a right sidebar: while the editor (or changes view) owns
+   the main area, the agent terminal stays visible beside it. Same node as
+   always — `order` moves it right in the flex row, because re-placing it in
+   JSX would remount it and drop the xterm. Fixed 40% dock; a drag-resizable
+   width is the upgrade if this ever feels wrong. */
+.panel-body.docked-term .term-wrap {
+	order: 2;
+	flex: 0 0 40%;
+	border-left: 1px solid var(--border);
+}
+
 .changes-view {
 	flex: 1;
 	min-width: 0;

--- a/packages/server/src/editor.ts
+++ b/packages/server/src/editor.ts
@@ -89,6 +89,9 @@ export function preseedUserSettings(dataDir = join(homedir(), ".local", "share",
 			{
 				"workbench.colorTheme": "Default Dark Modern",
 				"security.workspace.trust.enabled": false,
+				// Copilot Chat opens itself in the secondary side bar on first run;
+				// this is what its "Show View by Default" toggle writes.
+				"workbench.secondarySideBar.defaultVisibility": "hidden",
 			},
 			null,
 			2,

--- a/packages/server/test/editor.test.ts
+++ b/packages/server/test/editor.test.ts
@@ -45,6 +45,7 @@ describe("editor: preseedUserSettings", () => {
 		const seeded = JSON.parse(readFileSync(file, "utf8"));
 		expect(seeded["workbench.colorTheme"]).toBe("Default Dark Modern");
 		expect(seeded["security.workspace.trust.enabled"]).toBe(false);
+		expect(seeded["workbench.secondarySideBar.defaultVisibility"]).toBe("hidden");
 
 		writeFileSync(file, '{"workbench.colorTheme":"Mine"}');
 		preseedUserSettings(dataDir);


### PR DESCRIPTION
A PanelRight toggle between the VS Code and open-worktree buttons docks the agent terminal as a right sidebar while the editor or changes view owns the main area — default on, remembered across panels. Docking re-orders the terminal with CSS `order` instead of moving it in JSX, so the xterm scrollback survives. No left-sidebar variant for now.

The seeded code-server settings also set `workbench.secondarySideBar.defaultVisibility: hidden` (what Copilot Chat's "Show View by Default" toggle writes), so fresh installs no longer open the chat sidebar unprompted. Existing installs keep their settings file — click the toggle once there, or delete the seed to re-seed.