### PR TITLE
Task dependencies seed atomically, and the card shows the copy in flight

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -819,24 +819,13 @@ export function App() {
 			// Loops shows only loop-owned tasks, so a new task would land
 			// somewhere it can't be seen; every other view keeps its place.
 			if (view === "loops") setView("board");
-			// The card is on the board already — the engine creates the row as soon
-			// as the worktree exists. What this awaits is the worktree's gitignored
-			// state (dependencies, env files) finishing its copy, which the engine
-			// makes the agent launch wait for. Without a word here, that gap reads
-			// as another dead click, which is the whole bug this path had.
-			setInfo("Preparing worktree…");
-			let terminalId: string;
-			try {
-				({ terminalId } = await window.ateam.pty.spawnAgent({
-					taskId: task.id,
-					agentId: input.agentId,
-					yolo: input.yolo,
-					prompt: input.prompt || undefined,
-					files: input.files.length ? input.files : undefined,
-				}));
-			} finally {
-				setInfo(null);
-			}
+			const { terminalId } = await window.ateam.pty.spawnAgent({
+				taskId: task.id,
+				agentId: input.agentId,
+				yolo: input.yolo,
+				prompt: input.prompt || undefined,
+				files: input.files.length ? input.files : undefined,
+			});
 			setTermByTask((m) => ({ ...m, [task.id]: terminalId }));
 		});
 
@@ -925,7 +914,11 @@ export function App() {
 									) : (
 										<Icon size={16} strokeWidth={1.75} />
 									)}
-									{t.agentStatus && <span className={`corner ${t.agentStatus}`} />}
+									{t.preparing ? (
+										<span className="corner preparing" />
+									) : (
+										t.agentStatus && <span className={`corner ${t.agentStatus}`} />
+									)}
 								</button>
 							);
 						})}
@@ -1460,7 +1453,17 @@ function TaskRow({
 				)}
 			</button>
 			<span className="task-trail">
-				{t.agentStatus && <span className={`tstatus ${t.agentStatus}`} />}
+				{/* A task is `preparing` before it has any agentStatus, so this is
+				    the one dot it gets — otherwise the trail is empty for the whole
+				    copy and the card looks idle while it is anything but. */}
+				{t.preparing ? (
+					<span
+						className="tstatus preparing"
+						title="Copying dependencies into the worktree…"
+					/>
+				) : (
+					t.agentStatus && <span className={`tstatus ${t.agentStatus}`} />
+				)}
 				<IconButton
 					icon={Trash2}
 					label="Delete task"

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -439,6 +439,14 @@ input {
 .tstatus.stopped {
 	background: var(--text-dim);
 }
+/* Dependencies still copying in. Dim rather than a status colour — nothing is
+   wrong and nothing is running yet — with the same pulse the rail uses, so it
+   reads as work in progress instead of a fifth agent state. */
+.tstatus.preparing,
+.rail-tile .corner.preparing {
+	background: var(--text-dim);
+	animation: dotpulse 1.4s ease-in-out infinite;
+}
 .tree-empty {
 	color: var(--text-dim);
 	font-size: 12px;

--- a/packages/git-core/src/task.ts
+++ b/packages/git-core/src/task.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { cp, mkdir, rm, stat } from "node:fs/promises";
+import { cp, mkdir, rename, rm, stat } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import type { SimpleGit } from "simple-git";
@@ -267,15 +267,46 @@ async function seedNodeModules(
 	worktreePath: string,
 	entries: string[],
 ): Promise<void> {
-	for (const rel of entries) {
-		if (basename(rel) !== "node_modules") continue;
-		const dest = join(worktreePath, rel);
-		try {
-			await mkdir(dirname(dest), { recursive: true });
-			await pexec(CLONE_CP, [...CLONE_ARGS, join(repoPath, rel), dest]);
-		} catch {
-			/* best-effort — the worktree just needs its own install */
+	// Stage OUTSIDE the worktree, then move each finished tree in. Two reasons,
+	// both learned the hard way:
+	//
+	//  - A copy takes ~25s for a large monorepo, and the agent now launches
+	//    immediately rather than waiting for it. A tree copied in place is
+	//    therefore VISIBLE while half-populated, and a half-populated
+	//    `node_modules` is worse than none at all: an absent one fails with a
+	//    plain "not installed", a partial one fails with a module resolving to
+	//    nothing halfway through a build. `rename(2)` is atomic, so the worktree
+	//    only ever sees absent or complete.
+	//  - Nothing writes inside the worktree while it is being copied, so a
+	//    delete that lands mid-seed is not racing a copy that keeps recreating
+	//    the directory it is trying to remove.
+	//
+	// The staging directory is a sibling of the worktree (same worktrees root,
+	// therefore the same filesystem), which is what makes the rename a metadata
+	// operation rather than a second copy: measured at 0.1ms for a 114k-file
+	// tree, against ~25s to copy it.
+	const staging = join(
+		dirname(worktreePath),
+		`.seeding-${basename(worktreePath)}-${process.pid}`,
+	);
+	try {
+		for (const rel of entries) {
+			if (basename(rel) !== "node_modules") continue;
+			const staged = join(staging, rel);
+			const dest = join(worktreePath, rel);
+			try {
+				await mkdir(dirname(staged), { recursive: true });
+				await pexec(CLONE_CP, [...CLONE_ARGS, join(repoPath, rel), staged]);
+				await mkdir(dirname(dest), { recursive: true });
+				await rename(staged, dest);
+			} catch {
+				/* best-effort — the worktree just needs its own install */
+			}
 		}
+	} finally {
+		// Whatever did not make it across is scrap; never leave it beside the
+		// worktrees, where the next task's walk would have to reason about it.
+		await rm(staging, { recursive: true, force: true }).catch(() => {});
 	}
 }
 

--- a/packages/git-core/test/git-core.test.ts
+++ b/packages/git-core/test/git-core.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
-import { chmod, mkdir, mkdtemp, readlink, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, readlink, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import simpleGit from "simple-git";
 import { GitCoreError } from "../src/errors";
@@ -214,6 +214,30 @@ describe("createTask isolation", () => {
 		expect(await readlink(join(task.worktreePath, "apps", "web", "node_modules", "dep"))).toBe(
 			join("..", "..", "..", "node_modules", ".store", "dep"),
 		);
+	});
+
+	it("stages dependencies outside the worktree and leaves no scrap behind", async () => {
+		// The copy takes ~25s on a real monorepo and the agent no longer waits for
+		// it, so a tree copied in place would be visible half-populated — worse
+		// than absent, because a partial `node_modules` fails in ways that look
+		// like the code's fault. Staging out of tree and renaming in makes the
+		// worktree show absent or complete and nothing else.
+		await writeFile(join(repo.work, ".gitignore"), "node_modules/\n");
+		await mkdir(join(repo.work, "node_modules", "pkg"), { recursive: true });
+		await writeFile(join(repo.work, "node_modules", "pkg", "i.js"), "dep\n");
+
+		const task = await createAndSeed("staged");
+
+		// Landed complete...
+		expect(
+			await Bun.file(join(task.worktreePath, "node_modules", "pkg", "i.js")).text(),
+		).toBe("dep\n");
+		// ...and the staging directory, a sibling of the worktree, is gone.
+		const worktreesRoot = join(repo.work, ".ateam", "worktrees");
+		const leftovers = (await readdir(worktreesRoot)).filter((n) =>
+			n.startsWith(".seeding-"),
+		);
+		expect(leftovers).toEqual([]);
 	});
 
 	it("never descends into a nested checkout when seeding", async () => {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -162,6 +162,12 @@ export interface TaskDTO {
 	/** Last agent/lifecycle activity (falls back to row update time). */
 	lastEventAt: number | null;
 	isUnread: boolean;
+	/**
+	 * The worktree's dependencies are still being copied in. Ephemeral and
+	 * runtime-only — derived from the engine's in-flight seed map, never stored,
+	 * so a crash mid-seed cannot leave a task permanently "preparing".
+	 */
+	preparing: boolean;
 	/** Model-assigned topic tags; null when none were generated (the client
 	 *  falls back to deriving them from the task's text). */
 	tags: string[] | null;

--- a/packages/server/src/dispatcher.ts
+++ b/packages/server/src/dispatcher.ts
@@ -277,7 +277,10 @@ export function createDispatcher(engine: Engine): Dispatcher {
 		},
 
 		// ---- tasks ----
-		[CH.tasksList]: async (projectId: string) => repo.listTasks(db, projectId).map(toTaskDTO),
+		[CH.tasksList]: async (projectId: string) =>
+			repo
+				.listTasks(db, projectId)
+				.map((t) => toTaskDTO(t, services.pendingSeeds.has(t.id))),
 		[CH.tasksCreate]: async (input: {
 			projectId: string;
 			name: string;
@@ -285,7 +288,7 @@ export function createDispatcher(engine: Engine): Dispatcher {
 			agentId?: string;
 		}) => {
 			const row = await createTaskInProject(services, engine.sendTaskUpdated, input);
-			return toTaskDTO(row);
+			return toTaskDTO(row, services.pendingSeeds.has(row.id));
 		},
 		[CH.tasksRemove]: async (input: { id: string; deleteBranch?: boolean; force?: boolean }) => {
 			const task = requireTask(services, input.id);

--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -152,9 +152,14 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 		}
 	}
 
+	// Declared here rather than inline in `services` below because the broadcast
+	// closure needs it: a card's "preparing" state is exactly "is there a seed in
+	// flight for this task", and that answer must ride along on every update.
+	const pendingSeeds = new Map<string, Promise<void>>();
+
 	const sendTaskUpdated = (taskId: string): void => {
 		const task = repo.getTask(db, taskId);
-		if (task) emitter.emit("taskUpdated", toTaskDTO(task));
+		if (task) emitter.emit("taskUpdated", toTaskDTO(task, pendingSeeds.has(taskId)));
 	};
 
 	// The detached PTY daemon survives restarts; daemonPath is run via execPath as
@@ -222,7 +227,7 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 		mergeQueue,
 		loopRunner,
 		followUps,
-		pendingSeeds: new Map(),
+		pendingSeeds,
 	};
 
 	// Record an agent's exit: close the session and file its card. Shared by the

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -41,7 +41,7 @@ export function toProjectDTO(p: Project): ProjectDTO {
 	};
 }
 
-export function toTaskDTO(t: Task): TaskDTO {
+export function toTaskDTO(t: Task, preparing = false): TaskDTO {
 	return {
 		id: t.id,
 		projectId: t.projectId,
@@ -61,6 +61,7 @@ export function toTaskDTO(t: Task): TaskDTO {
 		gitStatus: t.gitStatus ?? null,
 		lastEventAt: t.lastEventAt ?? t.updatedAt ?? null,
 		isUnread: Boolean(t.isUnread),
+		preparing,
 		tags: t.tags ?? null,
 		triage: triageTask(t),
 	};

--- a/packages/server/src/sessions.ts
+++ b/packages/server/src/sessions.ts
@@ -104,12 +104,13 @@ export async function spawnAgentInTask(
 	const agent = getAgent(input.agentId);
 	if (!agent) throw new Error(`Unknown agent: ${input.agentId}`);
 
-	// A task's card appears as soon as its worktree exists, so its dependencies
-	// may still be copying. An agent launched into a half-seeded worktree would
-	// fail its first `bun test` / typecheck for reasons that have nothing to do
-	// with the code, so the launch waits here rather than the board waiting
-	// earlier. Undefined (nothing pending) awaits to undefined immediately.
-	await services.pendingSeeds.get(task.id);
+	// Deliberately NOT awaiting services.pendingSeeds here. Dependencies land
+	// under the agent while it works: seedNodeModules stages each tree outside
+	// the worktree and renames it in, so the worktree only ever shows an absent
+	// or a complete `node_modules`, never a half-copied one. That was the whole
+	// reason to block, and blocking cost ~25s of dead time before the terminal
+	// even appeared on a large monorepo. The card reports `preparing` while the
+	// copy is in flight, so the wait is visible instead of mysterious.
 
 	const terminalId = randomUUID();
 	// The conversation this tab holds. On a fresh launch we mint it — the

--- a/packages/server/test/client-api.test.ts
+++ b/packages/server/test/client-api.test.ts
@@ -14,7 +14,13 @@ import { streamClientTransport, streamServerTransport } from "../src/transport/s
 function makeEngine(db: AteamDb): Engine {
 	const ee = new EventEmitter();
 	return {
-		services: { db, pty: { has: () => false }, mergeQueue: {}, loopRunner: { describe: () => [] } },
+		services: {
+			db,
+			pty: { has: () => false },
+			mergeQueue: {},
+			loopRunner: { describe: () => [] },
+			pendingSeeds: new Map(),
+		},
 		on: (event: string, cb: (p: unknown) => void) => {
 			ee.on(event, cb);
 			return () => ee.off(event, cb);

--- a/packages/server/test/dispatcher.test.ts
+++ b/packages/server/test/dispatcher.test.ts
@@ -141,6 +141,42 @@ describe("createDispatcher", () => {
 		}
 	});
 
+	// The card must say "still preparing" while dependencies copy in, or the wait
+	// is invisible and the app looks like it ignored the click — which is exactly
+	// how this was reported. The flag is derived from the in-flight seed map and
+	// never stored, so a crash mid-seed cannot strand a task as preparing.
+	it("reports preparing while a seed is in flight, and not after", async () => {
+		const db = createTestDb();
+		const { engine } = makeEngine(db);
+		const d = createDispatcher(engine);
+		const project = repo.upsertProject(db, {
+			repoPath: "/r/p",
+			name: "P",
+			defaultBranch: "main",
+		});
+		const task = repo.createTask(db, {
+			projectId: project!.id,
+			name: "seeding now",
+			slug: "seeding-now",
+			branch: "seeding-now",
+			baseBranch: "main",
+			worktreePath: "/r/p/.ateam/worktrees/seeding-now",
+		});
+
+		const seeds = engine.services.pendingSeeds;
+		let release!: () => void;
+		seeds.set(task.id, new Promise<void>((r) => { release = r; }));
+
+		const during = (await d.handle(CH.tasksList, [project!.id])) as { preparing: boolean }[];
+		expect(during[0]?.preparing).toBe(true);
+
+		release();
+		seeds.delete(task.id);
+
+		const after = (await d.handle(CH.tasksList, [project!.id])) as { preparing: boolean }[];
+		expect(after[0]?.preparing).toBe(false);
+	});
+
 	// --- tabs a restart took away ---------------------------------------------
 
 	// The bug this exists for: a laptop restart kills the PTY daemon, and every

--- a/packages/server/test/rpc.test.ts
+++ b/packages/server/test/rpc.test.ts
@@ -38,6 +38,7 @@ function makeEngine(db: AteamDb): Engine {
 			pty: { has: () => false },
 			mergeQueue: {},
 			loopRunner: { describe: () => [] },
+			pendingSeeds: new Map(),
 		},
 		on: (event: string, cb: (p: unknown) => void) => {
 			ee.on(event, cb);

--- a/packages/server/test/socket.test.ts
+++ b/packages/server/test/socket.test.ts
@@ -21,7 +21,13 @@ afterEach(() => {
 function makeEngine(db: AteamDb): Engine {
 	const ee = new EventEmitter();
 	return {
-		services: { db, pty: { has: () => false }, mergeQueue: {}, loopRunner: { describe: () => [] } },
+		services: {
+			db,
+			pty: { has: () => false },
+			mergeQueue: {},
+			loopRunner: { describe: () => [] },
+			pendingSeeds: new Map(),
+		},
 		on: (event: string, cb: (p: unknown) => void) => {
 			ee.on(event, cb);
 			return () => ee.off(event, cb);

--- a/packages/server/test/stream.test.ts
+++ b/packages/server/test/stream.test.ts
@@ -14,7 +14,13 @@ import { streamClientTransport, streamServerTransport } from "../src/transport/s
 function makeEngine(db: AteamDb): Engine {
 	const ee = new EventEmitter();
 	return {
-		services: { db, pty: { has: () => false }, mergeQueue: {}, loopRunner: { describe: () => [] } },
+		services: {
+			db,
+			pty: { has: () => false },
+			mergeQueue: {},
+			loopRunner: { describe: () => [] },
+			pendingSeeds: new Map(),
+		},
 		on: (event: string, cb: (p: unknown) => void) => {
 			ee.on(event, cb);
 			return () => ee.off(event, cb);

--- a/packages/server/test/system.test.ts
+++ b/packages/server/test/system.test.ts
@@ -12,7 +12,13 @@ import { streamClientTransport, streamServerTransport } from "../src/transport/s
 function makeEngine(db: AteamDb): Engine {
 	const ee = new EventEmitter();
 	return {
-		services: { db, pty: { has: () => false }, mergeQueue: {}, loopRunner: { describe: () => [] } },
+		services: {
+			db,
+			pty: { has: () => false },
+			mergeQueue: {},
+			loopRunner: { describe: () => [] },
+			pendingSeeds: new Map(),
+		},
 		on: (event: string, cb: (p: unknown) => void) => {
 			ee.on(event, cb);
 			return () => ee.off(event, cb);

--- a/packages/server/test/ws.test.ts
+++ b/packages/server/test/ws.test.ts
@@ -22,7 +22,13 @@ import { wsServerTransport } from "../src/transport/ws";
 function makeEngine(db: AteamDb): Engine {
 	const ee = new EventEmitter();
 	return {
-		services: { db, pty: { has: () => false }, mergeQueue: {}, loopRunner: { describe: () => [] } },
+		services: {
+			db,
+			pty: { has: () => false },
+			mergeQueue: {},
+			loopRunner: { describe: () => [] },
+			pendingSeeds: new Map(),
+		},
 		on: (event: string, cb: (p: unknown) => void) => {
 			ee.on(event, cb);
 			return () => ee.off(event, cb);


### PR DESCRIPTION
## What

Two related fixes to how a new task's `node_modules` are seeded:

- **Atomic seeding** — `seedNodeModules` stages each dependency tree in a sibling `.seeding-*` directory, then `rename(2)`s it into the worktree. A worktree now only ever shows an absent or a complete `node_modules`, never a half-populated one (which resolves modules to nothing mid-build). The rename is same-filesystem metadata, measured at 0.1ms against the ~25s copy.
- **Launch no longer blocks** — `spawnAgentInTask` deliberately stops awaiting the pending seed. The agent launches immediately; the task card carries an ephemeral `preparing` flag (derived from the engine's in-flight seed map, never stored) so the wait is visible on the board instead of the terminal appearing ~25s late on a large monorepo.

## Tests

- `bun test packages/git-core packages/server` — 281 pass, 0 fail
- `scripts/typecheck.sh` — clean