### PR TITLE
chore: release 0.1.56

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ateam/desktop",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "private": true,
   "main": "./out/main/bootstrap.js",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/desktop": {
       "name": "@ateam/desktop",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "dependencies": {
         "better-sqlite3": "^11.8.1",
         "electron-updater": "^6.8.3",


### PR DESCRIPTION
Ships since 0.1.55:

- **#215** — Task dependencies seed atomically (staged + renamed in, never a half-copied `node_modules`), and the card shows a `preparing` flag instead of blocking the agent launch ~25s
- **#214** — Editor: a new task no longer inherits the previous task's VS Code, and the cached URL can no longer go stale
- **#212** — Record the chosen agent at task creation, so a new card never shows a guessed icon
- **#211** — Terminal sidebar: keep the agent in view beside the editor, and stop Copilot Chat popping open
- **#213** — README: combined desktop board + iOS hero image