### PR TITLE
Keep the mouse working in OpenCode panes after reattach, and let Option-drag select text

### DIFF
--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -57,6 +57,18 @@ export function TerminalView({
 			cursorBlink: true,
 			theme: { background: "#000000", foreground: "#e6e6ea" },
 			scrollback: 5000,
+			// A TUI that captures the mouse (OpenCode turns on modes 1000-1006 at
+			// startup; Claude Code never does) gets every drag as mouse reports, so
+			// xterm's own text selection is off. On macOS xterm offers no way around
+			// that unless this flag is set: Option+drag then selects text while the
+			// app keeps the mouse otherwise. Same convention as VS Code and iTerm2.
+			macOptionClickForcesSelection: true,
+			// Forcing selection also arms xterm's Option+click "move the cursor here"
+			// (its default), which types a path of arrow keys towards the click.
+			// Reproduced here: one Option+click on OpenCode's alt screen sent the
+			// renderer into an unbounded loop in that path computation and killed
+			// the window (out of memory). No agent wants those arrows anyway.
+			altClickMovesCursor: false,
 		});
 		const fit = new FitAddon();
 		term.loadAddon(fit);

--- a/packages/server/src/pty/daemon.ts
+++ b/packages/server/src/pty/daemon.ts
@@ -26,6 +26,7 @@ import { dirname, join } from "node:path";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Terminal } from "@xterm/headless";
 import * as pty from "node-pty";
+import { trackMouseEncoding } from "./snapshot-modes";
 
 const SOCK = process.env.ATEAM_PTY_SOCK || join(homedir(), ".ateam", "pty-daemon.sock");
 const SCROLLBACK = 5000; // lines of scrollback the emulator (and snapshot) keeps
@@ -37,6 +38,9 @@ interface Session {
 	// Headless emulator mirroring the PTY: source of truth for snapshot state.
 	term: Terminal;
 	serialize: SerializeAddon;
+	// The mouse encoding the app asked for, which serialize() cannot replay
+	// (see snapshot-modes.ts). Appended to every snapshot.
+	mouseEncoding: () => string;
 	exited: boolean;
 	cwd: string;
 	agentId: string;
@@ -98,6 +102,7 @@ function spawnSession(m: {
 		proc,
 		term,
 		serialize,
+		mouseEncoding: trackMouseEncoding(term),
 		exited: false,
 		cwd: m.cwd,
 		agentId: m.agentId ?? "shell",
@@ -179,7 +184,7 @@ function handleMessage(sock: net.Socket, m: Record<string, unknown>): void {
 			// xterm parses writes asynchronously; drain the queue with an empty
 			// write so the serialized snapshot reflects the very latest bytes
 			// (modes included) rather than a state a few frames stale.
-			s.term.write("", () => reply(s.serialize.serialize(), cutSeq));
+			s.term.write("", () => reply(s.serialize.serialize() + s.mouseEncoding(), cutSeq));
 			break;
 		}
 		case "list":

--- a/packages/server/src/pty/snapshot-modes.ts
+++ b/packages/server/src/pty/snapshot-modes.ts
@@ -1,0 +1,49 @@
+// Snapshot state the serialize addon does not carry.
+//
+// The daemon's snapshot is `SerializeAddon.serialize()`, which replays every
+// DEC mode xterm exposes through `terminal.modes` — alt screen, bracketed
+// paste, focus reporting, mouse TRACKING (?1000/?1002/?1003). It has no way to
+// replay the mouse ENCODING (?1006 SGR, ?1016 SGR-pixels): `modes` does not
+// expose it, so `serialize()` never writes it.
+//
+// That gap breaks the mouse on reattach for any TUI that owns it (OpenCode
+// enables ?1003 + ?1006 at startup). The fresh renderer replays ?1003h without
+// ?1006h, so its xterm falls back to the legacy X10 encoding — which xterm
+// emits on `onBinary`, not `onData`, and the views only forward `onData`.
+// Every wheel, click and drag is silently dropped until the app restarts.
+//
+// Fix: watch the encoding requests as they stream through the emulator's own
+// parser (so split chunks are handled for us) and append the active one to the
+// snapshot. Handlers return false so xterm's built-in handling still runs.
+import type { Terminal } from "@xterm/headless";
+
+const SGR = "\x1b[?1006h";
+const SGR_PIXELS = "\x1b[?1016h";
+
+/**
+ * Track the mouse encoding an app has requested on `term`. Returns a getter
+ * for the sequence to append to a snapshot: the active encoding's set-mode
+ * sequence, or "" when the app is on the default (or reset) encoding.
+ */
+export function trackMouseEncoding(term: Terminal): () => string {
+	let active = "";
+	const flat = (params: (number | number[])[]) => params.flat();
+	term.parser.registerCsiHandler({ prefix: "?", final: "h" }, (params) => {
+		for (const p of flat(params)) {
+			if (p === 1006) active = SGR;
+			else if (p === 1016) active = SGR_PIXELS;
+		}
+		return false;
+	});
+	// Resetting either encoding puts xterm back on the default one.
+	term.parser.registerCsiHandler({ prefix: "?", final: "l" }, (params) => {
+		for (const p of flat(params)) if (p === 1006 || p === 1016) active = "";
+		return false;
+	});
+	// RIS (full reset) drops every mode, encoding included.
+	term.parser.registerEscHandler({ final: "c" }, () => {
+		active = "";
+		return false;
+	});
+	return () => active;
+}

--- a/packages/server/test/snapshot-modes.test.ts
+++ b/packages/server/test/snapshot-modes.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { SerializeAddon } from "@xterm/addon-serialize";
+import { Terminal } from "@xterm/headless";
+import { trackMouseEncoding } from "../src/pty/snapshot-modes";
+
+// What OpenCode 1.18 sends at startup (captured from a real PTY): alt screen,
+// bracketed paste, every mouse tracking mode, then SGR encoding.
+const OPENCODE_STARTUP = "\x1b[?1049h\x1b[?2004h\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h";
+
+function setup() {
+	const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true });
+	const serialize = new SerializeAddon();
+	term.loadAddon(serialize);
+	const encoding = trackMouseEncoding(term);
+	const write = (s: string) => new Promise<void>((r) => term.write(s, r));
+	const snapshot = () => serialize.serialize() + encoding();
+	return { term, write, snapshot, serialize, encoding };
+}
+
+describe("snapshot mouse encoding", () => {
+	test("serialize alone replays tracking but not the SGR encoding (the gap)", async () => {
+		const { write, serialize } = setup();
+		await write(OPENCODE_STARTUP);
+		const s = serialize.serialize();
+		expect(s).toContain("\x1b[?1003h");
+		expect(s).not.toContain("\x1b[?1006h");
+	});
+
+	test("snapshot carries ?1006h once an app enabled SGR", async () => {
+		const { write, snapshot } = setup();
+		await write(OPENCODE_STARTUP);
+		const s = snapshot();
+		expect(s).toContain("\x1b[?1003h");
+		expect(s).toContain("\x1b[?1006h");
+	});
+
+	test("a request split across PTY chunks is still seen", async () => {
+		const { write, encoding } = setup();
+		await write("\x1b[?1000h\x1b[?10");
+		expect(encoding()).toBe("");
+		await write("06h");
+		expect(encoding()).toBe("\x1b[?1006h");
+	});
+
+	test("combined params and the pixel variant", async () => {
+		const { write, encoding } = setup();
+		await write("\x1b[?1000;1006h");
+		expect(encoding()).toBe("\x1b[?1006h");
+		await write("\x1b[?1016h");
+		expect(encoding()).toBe("\x1b[?1016h");
+	});
+
+	test("resetting the encoding, or a full reset, drops it", async () => {
+		const { write, encoding } = setup();
+		await write(OPENCODE_STARTUP);
+		await write("\x1b[?1006l");
+		expect(encoding()).toBe("");
+		await write("\x1b[?1006h");
+		await write("\x1bc");
+		expect(encoding()).toBe("");
+	});
+
+	test("xterm's own handling still runs (handlers fall through)", async () => {
+		const { term, write } = setup();
+		await write("\x1b[?1003h\x1b[?1006h");
+		expect(term.modes.mouseTrackingMode).toBe("any");
+		await write("\x1b[?1003l");
+		expect(term.modes.mouseTrackingMode).toBe("none");
+	});
+});


### PR DESCRIPTION
## Why

OpenCode takes over the mouse at startup (DEC modes 1000-1006). Two things broke in Ateam's terminal because of that.

**Scrolling stopped after any reattach.** Reopening the task panel, a second window, or an app restart rebuilds the pane from the PTY daemon's serialized snapshot. `@xterm/addon-serialize` replays mouse tracking (`?1003h`) but has no way to replay the mouse encoding (`?1006h`, not in `terminal.modes`). The fresh xterm fell back to the legacy X10 encoding, which xterm emits on `onBinary`; the views only forward `onData`, so every wheel, click and drag was dropped until the app restarted.

**Text selection never worked** while an app owned the mouse: on macOS xterm offers no bypass unless `macOptionClickForcesSelection` is set.

## What

- `packages/server/src/pty/snapshot-modes.ts`: track `?1006`/`?1016` requests through the headless terminal's own parser (split chunks handled for free, RIS resets it) and append the active encoding to every snapshot. Wired in `daemon.ts`. Covers desktop, box and mobile panes since they all replay the same snapshot.
- `Terminal.tsx`: `macOptionClickForcesSelection: true`. Option+drag selects, plain drag still goes to the app (VS Code / iTerm2 convention).
- `altClickMovesCursor: false`. With forced selection on, xterm's default Option+click "move cursor here" runs, and on OpenCode's alt screen its `moveToCellSequence` loop diverged and grew a string until the renderer died out of memory (reproduced at ~20 GB). Disabled; no agent wants those arrow keys anyway.

## Verified

- Live in the dev app with OpenCode 1.18.29: wheel (mouse and trackpad deltas) scrolls; Option+drag selects; plain drag does not; Option+click stays harmless with memory flat.
- Scratch daemon built from this branch: OpenCode's snapshot now replays both `?1003h` and `?1006h`.
- `bun test` (server): 260 pass. Typecheck and biome clean.

## Left for later (parked in the repo sidenotes)

- `onBinary` still unforwarded for apps that enable tracking without SGR (none today).
- iOS: touch gestures never become mouse reports for a mouse-owning TUI.
- Upstream xterm.js bug report for the `moveToCellSequence` loop.
