### PR TITLE
Phone terminal: tap opens links, keyboard no longer toggles on tap

### DIFF
--- a/apps/mobile/modules/expo-swiftterm/ios/ExpoSwifttermModule.swift
+++ b/apps/mobile/modules/expo-swiftterm/ios/ExpoSwifttermModule.swift
@@ -5,7 +5,7 @@ public class ExpoSwifttermModule: Module {
     Name("ExpoSwiftterm")
 
     View(ExpoSwifttermView.self) {
-      Events("onInput", "onSizeChange")
+      Events("onInput", "onSizeChange", "onOpenLink")
 
       // Stream PTY bytes into the terminal. A view function (imperative) — not a
       // prop — so no chunk is ever dropped by RN prop-diffing.

--- a/apps/mobile/modules/expo-swiftterm/ios/ExpoSwifttermView.swift
+++ b/apps/mobile/modules/expo-swiftterm/ios/ExpoSwifttermView.swift
@@ -11,6 +11,16 @@ class ExpoSwifttermView: ExpoView {
   // Push events to JS.
   let onInput = EventDispatcher() // user keystrokes/selection → { data }
   let onSizeChange = EventDispatcher() // TUI needs cols/rows → { cols, rows }
+  let onOpenLink = EventDispatcher() // tapped a URL in the output → { url }
+
+  // Keyboard visibility is decoupled from first-responder status. The terminal
+  // stays first responder from mount (link taps, long-press selection and the
+  // Copy/Paste menu all need it, and none of them should drag the keyboard in or
+  // out); the keyboard itself is shown/hidden by swapping `inputView` — an empty
+  // view in place of the system keyboard. Without this, SwiftTerm's default
+  // (first responder == keyboard up) makes every tap a show/hide toggle.
+  private let noKeyboard = UIView(frame: .zero)
+  private(set) var keyboardShown = false
 
   required init(appContext: AppContext? = nil) {
     terminal = TerminalView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
@@ -24,6 +34,8 @@ class ExpoSwifttermView: ExpoView {
     // Drop SwiftTerm's built-in accessory bar (esc/tab/arrows) — we render our own
     // shortcut toolbar in RN, so this is just the plain iPhone keyboard.
     terminal.inputAccessoryView = nil
+    terminal.inputView = noKeyboard
+    terminal.tapRequestsKeyboard = { [weak self] in self?.focusKeyboard() }
 
     // Auto Layout (not a hand-set frame) so the terminal's own layoutSubviews fires
     // with real bounds → processSizeChange computes the grid + renders.
@@ -42,10 +54,26 @@ class ExpoSwifttermView: ExpoView {
     terminal.feed(text: text)
   }
 
-  // Keyboard control (SwiftTerm is a first responder; it has no keyboard-avoidance
-  // of its own, so the RN side resizes the view and toggles focus).
-  func blurKeyboard() { _ = terminal.resignFirstResponder() }
-  func focusKeyboard() { _ = terminal.becomeFirstResponder() }
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    if window != nil, !terminal.isFirstResponder { _ = terminal.becomeFirstResponder() }
+  }
+
+  // Keyboard control. SwiftTerm has no keyboard-avoidance of its own, so the RN
+  // side resizes the view; here we only swap the input view (see `noKeyboard`).
+  func blurKeyboard() {
+    guard keyboardShown else { return }
+    keyboardShown = false
+    terminal.inputView = noKeyboard
+    terminal.reloadInputViews()
+  }
+  func focusKeyboard() {
+    if !terminal.isFirstResponder { _ = terminal.becomeFirstResponder() }
+    guard !keyboardShown else { return }
+    keyboardShown = true
+    terminal.inputView = nil
+    terminal.reloadInputViews()
+  }
 
   var cols: Int { terminal.getTerminal().cols }
   var rows: Int { terminal.getTerminal().rows }
@@ -61,7 +89,10 @@ extension ExpoSwifttermView: TerminalViewDelegate {
   func setTerminalTitle(source: TerminalView, title: String) {}
   func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
   func scrolled(source: TerminalView, position: Double) {}
-  func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {}
+  func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {
+    // Tapped URL → JS decides how to open it (Linking / in-app browser / editor).
+    onOpenLink(["url": link])
+  }
   func bell(source: TerminalView) {}
   func clipboardCopy(source: TerminalView, content: Data) {
     // Native selection → Copy menu lands here; put it on the iOS clipboard.

--- a/apps/mobile/modules/expo-swiftterm/ios/vendor/SwiftTerm/iOS/iOSTerminalView.swift
+++ b/apps/mobile/modules/expo-swiftterm/ios/vendor/SwiftTerm/iOS/iOSTerminalView.swift
@@ -690,54 +690,77 @@ open class TerminalView: UIScrollView, UITextInputTraits, UIKeyInput, UIScrollVi
         contentOffset.y = max(0, CGFloat(lines) - bottomVisibleLine) * cellDimension.height
     }
     
+    // ATEAM PATCH (re-apply on SwiftTerm bump): touch-first single tap.
+    //
+    // Keyboard visibility is NOT tied to first-responder status. The host
+    // (ExpoSwifttermView) keeps this view first responder from mount and swaps
+    // `inputView` to show/hide the keyboard, so link taps, long-press selection and
+    // the Copy/Paste menu all work with the keyboard down. A tap therefore never
+    // toggles focus: it opens a link, else clears a selection, else asks the host
+    // for the keyboard when it lands near the CURSOR row — the universal "active
+    // input" location of any agent TUI (Claude/Codex/OpenCode keep their cursor in
+    // their input). Tapping the output/history does nothing to the keyboard.
+    public var tapRequestsKeyboard: (() -> Void)?
+
+    /// Link under a touch. Unlike `linkForClick`, this skips the hover-highlight
+    /// gate (`linkVisibleForClick`): touch has no hover, so on iOS that gate would
+    /// reject every implicit (plain-text) URL.
+    func linkForTouch(at position: Position) -> (link: String, params: [String:String])?
+    {
+        guard let match = terminal.linkMatch(at: .buffer(position), mode: .explicitAndImplicit) else {
+            return nil
+        }
+        if match.isExplicit,
+           let payload = payloadString(at: position),
+           let (url, params) = urlAndParamsFrom(payload: payload) {
+            return (url, params)
+        }
+        return (match.text, [:])
+    }
+
     @objc func singleTap (_ gestureRecognizer: UITapGestureRecognizer)
     {
         guard gestureRecognizer.view != nil, gestureRecognizer.state == .ended else { return }
 
-        // ATEAM PATCH (re-apply on SwiftTerm bump): the keyboard follows the tap
-        // relative to the CURSOR — the universal "active input" location for any agent
-        // (Claude/Codex/OpenCode all keep their cursor in their input). Tap near the
-        // cursor row → show the keyboard; tap the output/history → dismiss it. No
-        // hardcoded per-agent layout.
-        let tapRow = calculateTapHit(gesture: gestureRecognizer).grid.row
-        let cursorRow = terminal.displayBuffer.y + terminal.displayBuffer.yDisp
-        let nearInput = abs(tapRow - cursorRow) < 4
+        let tapHit = calculateTapHit(gesture: gestureRecognizer).grid
+        if let result = linkForTouch(at: tapHit) {
+            terminalDelegate?.requestOpenLink(source: self, link: result.link, params: result.params)
+            return
+        }
 
-        if isFirstResponder {
-            let tapHit = calculateTapHit(gesture: gestureRecognizer).grid
-            if let result = linkForClick(at: tapHit, hasCommandModifier: commandActive) {
-                terminalDelegate?.requestOpenLink(source: self, link: result.link, params: result.params)
-                return
+        let displayBuffer = terminal.displayBuffer
+        let cursorRow = displayBuffer.y + displayBuffer.yDisp
+        let nearInput = abs(tapHit.row - cursorRow) < 4
+
+        if allowMouseReporting && terminal.mouseMode.sendButtonPress() {
+            sharedMouseEvent(gestureRecognizer: gestureRecognizer, release: false)
+
+            if terminal.mouseMode.sendButtonRelease() {
+                sharedMouseEvent(gestureRecognizer: gestureRecognizer, release: true)
             }
-
-            if allowMouseReporting && terminal.mouseMode.sendButtonPress() {
-                sharedMouseEvent(gestureRecognizer: gestureRecognizer, release: false)
-
-                if terminal.mouseMode.sendButtonRelease() {
-                    sharedMouseEvent(gestureRecognizer: gestureRecognizer, release: true)
-                }
-            } else {
-                if selection.active {
-                    selection.selectNone()
-                    disableSelectionPanGesture()
-                }
-                if UIMenuController.shared.isMenuVisible {
-                    UIMenuController.shared.hideMenu()
-                } else {
-                    let location = gestureRecognizer.location(in: gestureRecognizer.view)
-                    let tapLoc = calculateTapHit(gesture: gestureRecognizer).grid
-                    let displayBuffer = terminal.displayBuffer
-                    if abs (tapLoc.col-displayBuffer.x) < 4 && abs (tapLoc.row - cursorRow) < 2 {
-                        showContextMenu (forRegion: makeContextMenuRegionForTap (point: location), pos: tapLoc)
-                    }
-                }
+        } else if selection.active {
+            selection.selectNone()
+            disableSelectionPanGesture()
+            if UIMenuController.shared.isMenuVisible {
+                UIMenuController.shared.hideMenu()
             }
             queuePendingDisplay()
-            // Tapped the output/history (not the input) → dismiss the keyboard.
-            if !nearInput { let _ = resignFirstResponder() }
-        } else if nearInput {
-            // Tapped in the input area while the keyboard is hidden → bring it up.
-            let _ = becomeFirstResponder ()
+            return
+        } else if UIMenuController.shared.isMenuVisible {
+            UIMenuController.shared.hideMenu()
+            return
+        } else if abs (tapHit.col-displayBuffer.x) < 4 && abs (tapHit.row - cursorRow) < 2 {
+            let location = gestureRecognizer.location(in: gestureRecognizer.view)
+            showContextMenu (forRegion: makeContextMenuRegionForTap (point: location), pos: tapHit)
+        }
+        queuePendingDisplay()
+
+        if nearInput {
+            if let request = tapRequestsKeyboard {
+                request()
+            } else {
+                let _ = becomeFirstResponder ()
+            }
         }
     }
     

--- a/apps/mobile/modules/expo-swiftterm/src/ExpoSwifttermView.tsx
+++ b/apps/mobile/modules/expo-swiftterm/src/ExpoSwifttermView.tsx
@@ -15,6 +15,7 @@ const NativeView: React.ComponentType<{
 	style?: StyleProp<ViewStyle>;
 	onInput?: (e: { nativeEvent: { data: string } }) => void;
 	onSizeChange?: (e: { nativeEvent: { cols: number; rows: number } }) => void;
+	onOpenLink?: (e: { nativeEvent: { url: string } }) => void;
 	ref?: React.Ref<NativeRef>;
 }> = requireNativeView("ExpoSwiftterm");
 
@@ -28,10 +29,11 @@ export interface SwiftTermViewProps {
 	style?: StyleProp<ViewStyle>;
 	onInput?: (data: string) => void;
 	onSizeChange?: (cols: number, rows: number) => void;
+	onOpenLink?: (url: string) => void;
 }
 
 export const SwiftTermView = React.forwardRef<SwiftTermHandle, SwiftTermViewProps>(
-	({ style, onInput, onSizeChange }, ref) => {
+	({ style, onInput, onSizeChange, onOpenLink }, ref) => {
 		const nativeRef = React.useRef<NativeRef>(null);
 		React.useImperativeHandle(ref, () => ({
 			feed: (text: string) => void nativeRef.current?.feed(text),
@@ -44,6 +46,7 @@ export const SwiftTermView = React.forwardRef<SwiftTermHandle, SwiftTermViewProp
 				style={style}
 				onInput={(e) => onInput?.(e.nativeEvent.data)}
 				onSizeChange={(e) => onSizeChange?.(e.nativeEvent.cols, e.nativeEvent.rows)}
+				onOpenLink={(e) => onOpenLink?.(e.nativeEvent.url)}
 			/>
 		);
 	},

--- a/apps/mobile/src/NativeTerminalScreen.tsx
+++ b/apps/mobile/src/NativeTerminalScreen.tsx
@@ -12,6 +12,7 @@ import {
 	ActivityIndicator,
 	Keyboard,
 	KeyboardAvoidingView,
+	Linking,
 	Platform,
 	Pressable,
 	ScrollView,
@@ -53,6 +54,13 @@ const KEYS: { label: string; bytes: string; scroll?: boolean }[] = [
 	{ label: "PgUp", bytes: "\x1b[5~", scroll: true },
 	{ label: "PgDn", bytes: "\x1b[6~", scroll: true },
 ];
+
+// A URL tapped in the terminal output. Only web links leave the app (a TUI can
+// print anything that looks like a link, including file: and custom schemes).
+function openTappedLink(url: string) {
+	if (!/^https?:\/\//i.test(url)) return;
+	void Linking.openURL(url);
+}
 
 // Backslash-escape shell-special chars so a typed path survives the shell — same
 // convention the desktop terminal uses for dropped/attached file paths.
@@ -189,20 +197,25 @@ export function NativeTerminalScreen({
 	// full-screen TUI (Claude agents) doesn't always repaint cleanly after the rapid
 	// resize animation, so once it settles, nudge a repaint: jiggle the size (rows-1
 	// → rows) to force a SIGWINCH-driven full redraw at the final dimensions.
+	// Listens to frame changes (not show/hide): the native view hides the keyboard
+	// by swapping in an empty input view, which iOS reports as a frame change.
 	useEffect(() => {
-		const settle = () =>
-			setTimeout(() => {
+		let timer: ReturnType<typeof setTimeout> | null = null;
+		const settle = () => {
+			if (timer) clearTimeout(timer);
+			timer = setTimeout(() => {
+				timer = null;
 				const id = terminalId;
 				const { cols, rows } = lastSize.current;
 				if (!id || !cols || !rows) return;
 				api.pty.resize(id, cols, Math.max(1, rows - 1));
 				setTimeout(() => api.pty.resize(id, cols, rows), 120);
 			}, 350);
-		const show = Keyboard.addListener("keyboardDidShow", settle);
-		const hide = Keyboard.addListener("keyboardDidHide", settle);
+		};
+		const sub = Keyboard.addListener("keyboardDidChangeFrame", settle);
 		return () => {
-			show.remove();
-			hide.remove();
+			sub.remove();
+			if (timer) clearTimeout(timer);
 		};
 	}, [api, terminalId]);
 
@@ -270,6 +283,7 @@ export function NativeTerminalScreen({
 						style={styles.term}
 						onInput={onInput}
 						onSizeChange={onSizeChange}
+						onOpenLink={openTappedLink}
 						ref={termRef}
 					/>
 					<ScrollView

--- a/apps/mobile/src/useKeyboardVisible.ts
+++ b/apps/mobile/src/useKeyboardVisible.ts
@@ -1,16 +1,24 @@
 import { useEffect, useState } from "react";
-import { Keyboard } from "react-native";
+import { Dimensions, Keyboard, type KeyboardEvent } from "react-native";
 
 // True while the soft keyboard is on screen. Used to drop the home-indicator
 // bottom padding when the keyboard is up (the keyboard already covers that area,
 // and KeyboardAvoidingView has lifted the content above it).
+//
+// Judged by the keyboard's end frame rather than show/hide events: the native
+// terminal hides its keyboard by swapping in an empty input view, which iOS
+// reports as a (zero-height) keyboard frame change, not as a hide.
 export function useKeyboardVisible(): boolean {
 	const [visible, setVisible] = useState(false);
 	useEffect(() => {
-		const show = Keyboard.addListener("keyboardWillShow", () => setVisible(true));
+		const onFrame = (e: KeyboardEvent) => {
+			const { height, screenY } = e.endCoordinates;
+			setVisible(height > 0 && screenY < Dimensions.get("screen").height);
+		};
+		const change = Keyboard.addListener("keyboardWillChangeFrame", onFrame);
 		const hide = Keyboard.addListener("keyboardWillHide", () => setVisible(false));
 		return () => {
-			show.remove();
+			change.remove();
 			hide.remove();
 		};
 	}, []);

--- a/docs/online-ateam.md
+++ b/docs/online-ateam.md
@@ -293,7 +293,10 @@ paste-a-URL door instead of the picker and skips the create-a-repo offer, becaus
 would accept the request and silently not do it.
 
 Its terminal is a real login shell on the box too, so re-logging into `claude` when a
-session expires and `gh auth refresh` also work from the app.
+session expires and `gh auth refresh` also work from the app. On the phone, tap the
+login URL the agent prints, even where it wraps across lines, and it opens in Safari;
+tapping the output never hides the keyboard (the **Hide** button does), and a long
+press selects text for Copy without bringing the keyboard up.
 
 ### Write a Tailscale ACL — this one isn't optional
 


### PR DESCRIPTION
## Summary
- SwiftTerm tied keyboard visibility to first-responder status, so on the phone every tap on the terminal output flipped the keyboard, link taps were gated behind a hover check touch can never satisfy, and the bridge's open-link callback was empty.
- The terminal now stays first responder and shows or hides the keyboard by swapping its input view. A tap opens a link, else clears a selection, else asks for the keyboard when near the cursor row. A tap never hides the keyboard; the Hide button does.
- Tapped http(s) URLs are forwarded to JS and opened with Linking. The keyboard-visible hook and the post-keyboard repaint nudge now key off keyboard frame changes, since an empty input view is reported as a frame change rather than a hide.

## Verification
- Built and run in the iPhone 15 Pro simulator against the Hetzner box over Tailscale.
- Tapping a row of the wrapped Claude Code `/login` URL opened Safari with the full URL and the login completed on the box.
- Keyboard stayed down through the flow; no show/hide ping-pong.
- Not yet exercised by touch: long-press selection + Copy with the keyboard down, and the Hide button round trip.