### PR TITLE
A terminal's size follows the viewer in use, not whoever fitted last

### DIFF
--- a/apps/desktop/src/main/aggregate.ts
+++ b/apps/desktop/src/main/aggregate.ts
@@ -15,6 +15,7 @@
 // single-active path until this is proven and flag-gated in. It is the load-bearing
 // slice: hold N backends, route every call correctly, merge the board.
 import { CH } from "@ateam/protocol";
+import type { CallContext } from "@ateam/server";
 import type { Backend } from "./backend";
 import { withTimeout } from "./timeout";
 
@@ -124,7 +125,7 @@ function merge(results: unknown[]): unknown[] {
 
 export interface Aggregate {
 	/** Route/merge one request across the held backends (drop-in for Router.handle). */
-	handle(method: string, args: unknown[]): Promise<unknown>;
+	handle(method: string, args: unknown[], ctx?: CallContext): Promise<unknown>;
 	/** Invoke a method ON the engine that owns `ownerId` (fallback when unknown) —
 	 *  for calls whose own args carry no routable id (e.g. util:writeImageBytes
 	 *  must land on the engine whose agent will read the file). */
@@ -148,7 +149,7 @@ export function createAggregate(
 	const reg = new Map<string, Backend>();
 	const mergeTimeoutMs = opts.mergeTimeoutMs ?? MERGE_TIMEOUT_MS;
 
-	async function handle(method: string, args: unknown[]): Promise<unknown> {
+	async function handle(method: string, args: unknown[], ctx?: CallContext): Promise<unknown> {
 		if (MERGE.has(method)) {
 			const results = await Promise.all(
 				backends.map(async (b) => {
@@ -178,7 +179,7 @@ export function createAggregate(
 			const id = candidateId(args);
 			backend = (id && reg.get(id)) || fallback;
 		}
-		const result = await backend.handle(method, args);
+		const result = await backend.handle(method, args, ctx);
 		learn(reg, backend, result);
 		return result;
 	}

--- a/apps/desktop/src/main/backend.ts
+++ b/apps/desktop/src/main/backend.ts
@@ -4,7 +4,7 @@
 // Both satisfy one shape, so the IPC bridge (ipc.ts) and event forwarding (host.ts)
 // don't care which is active — they route to whatever Backend is current.
 import type { RpcClient } from "@ateam/protocol";
-import { createDispatcher, type Engine } from "@ateam/server";
+import { type CallContext, createDispatcher, type Engine } from "@ateam/server";
 
 /** The engine push-events forwarded to the renderer. */
 export type BackendEvent = "taskUpdated" | "taskRemoved" | "loopsUpdated" | "ptyData" | "ptyExit";
@@ -13,10 +13,14 @@ export interface Backend {
 	readonly kind: "local" | "remote";
 	/** The RPC method channels this backend serves (same set for local + remote). */
 	readonly methods: readonly string[];
-	/** Route one request; the IPC bridge awaits (or ignores, for send channels) this. */
-	handle(method: string, args: unknown[]): unknown | Promise<unknown>;
+	/** Route one request; the IPC bridge awaits (or ignores, for send channels) this.
+	 *  `ctx` names the calling window; only the local engine can use it (a box sees
+	 *  this whole desktop as one client, its own connection). */
+	handle(method: string, args: unknown[], ctx?: CallContext): unknown | Promise<unknown>;
 	/** Subscribe to a push-event; returns an unsubscribe. */
 	on(event: BackendEvent, cb: (payload: unknown) => void): () => void;
+	/** A calling window closed: release what the engine held for it. Local only. */
+	release?(client: string): void;
 	/** Release transport resources. No-op for local (the engine outlives swaps). */
 	dispose(): void;
 }
@@ -28,7 +32,9 @@ export interface Backend {
  */
 export interface Router {
 	readonly methods: readonly string[];
-	handle(method: string, args: unknown[]): unknown | Promise<unknown>;
+	handle(method: string, args: unknown[], ctx?: CallContext): unknown | Promise<unknown>;
+	/** A calling window closed (see Backend.release). */
+	release(client: string): void;
 	/** Invoke a method ON the engine that owns `ownerId` (local when unknown) — for
 	 *  calls whose own args carry no routable id, like staging an attachment on the
 	 *  machine whose agent will read it. */
@@ -43,9 +49,10 @@ export function localBackend(engine: Engine): Backend {
 	return {
 		kind: "local",
 		methods: dispatcher.methods,
-		handle: (method, args) => dispatcher.handle(method, args),
+		handle: (method, args, ctx) => dispatcher.handle(method, args, ctx),
 		// engine.on is typed per-event; the Backend surface is event-agnostic.
 		on: (event, cb) => engine.on(event, cb as never),
+		release: (client) => dispatcher.release(client),
 		dispose: () => {},
 	};
 }

--- a/apps/desktop/src/main/host.ts
+++ b/apps/desktop/src/main/host.ts
@@ -646,7 +646,8 @@ export function createHost({ localEngine, broadcast }: HostDeps): Host {
 
 	const router: Router = {
 		methods: local.methods,
-		handle: (method, args) => agg.handle(method, args),
+		handle: (method, args, ctx) => agg.handle(method, args, ctx),
+		release: (client) => local.release?.(client),
 		handleFor: (ownerId, method, args) => agg.handleFor(ownerId, method, args),
 		ownerKind: (ownerId) => agg.ownerKindOf(ownerId),
 	};

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -77,9 +77,28 @@ export interface NativeHandlers {
  * the desktop OS itself (native dialog/clipboard, window management) live here.
  */
 export function registerIpc(router: Router, native: NativeHandlers): void {
+	// The send channels are the terminal's input + size, and the engine needs to
+	// know WHICH window they come from: a terminal open in two windows must not
+	// have each window's size clobber the other's (see the server's size-arbiter).
+	// Name the window by its webContents and release it when the window goes.
+	const seen = new Set<number>();
+	const clientOf = (wc: Electron.WebContents): string => {
+		const client = `window:${wc.id}`;
+		if (!seen.has(wc.id)) {
+			seen.add(wc.id);
+			wc.once("destroyed", () => {
+				seen.delete(wc.id);
+				router.release(client);
+			});
+		}
+		return client;
+	};
 	for (const method of router.methods) {
 		if (SEND_CHANNELS.has(method)) {
-			ipcMain.on(method, (_e, ...args: unknown[]) => void router.handle(method, args));
+			ipcMain.on(
+				method,
+				(e, ...args: unknown[]) => void router.handle(method, args, { client: clientOf(e.sender) }),
+			);
 		} else {
 			ipcMain.handle(method, (_e, ...args: unknown[]) => router.handle(method, args));
 		}

--- a/packages/server/src/dispatcher.ts
+++ b/packages/server/src/dispatcher.ts
@@ -54,6 +54,7 @@ import { createEditorHost, installCodeServer } from "./editor";
 import { refreshLoginPath } from "./login-env";
 import type { Engine } from "./engine";
 import { LOOP_TEMPLATES } from "./loops/templates";
+import { createSizeArbiter } from "./pty/size-arbiter";
 import { type Services, toProjectDTO, toSessionDTO, toTaskDTO } from "./services";
 import { searchSessions } from "./session-search";
 import { createTaskInProject, type SpawnAgentInput, shell, spawnAgentInTask } from "./sessions";
@@ -115,11 +116,18 @@ const INSTALL_URL =
 /** An update is in flight in THIS process (see CH.systemUpdate). */
 let updating = false;
 
+/** Who is calling: one id per client connection (a desktop window, the phone). */
+export interface CallContext {
+	client: string;
+}
+
 export interface Dispatcher {
 	/** Method names this dispatcher handles (the non-native CH.* channels). */
 	readonly methods: string[];
 	/** Invoke a method with its positional args; throws on unknown method. */
-	handle(method: string, args: unknown[]): Promise<unknown>;
+	handle(method: string, args: unknown[], ctx?: CallContext): Promise<unknown>;
+	/** A client connection went away: release anything it held (its PTY sizing). */
+	release(client: string): void;
 }
 
 export function createDispatcher(engine: Engine): Dispatcher {
@@ -702,12 +710,6 @@ export function createDispatcher(engine: Engine): Dispatcher {
 			spawnAgentInTask(services, engine.sendTaskUpdated, input),
 		[CH.ptySpawnShell]: async (input: { taskId: string }) =>
 			spawnShellInTask(requireTask(services, input.taskId)),
-		[CH.ptyWrite]: (terminalId: string, data: string) => {
-			services.pty.write(terminalId, data);
-		},
-		[CH.ptyResize]: (terminalId: string, cols: number, rows: number) => {
-			services.pty.resize(terminalId, cols, rows);
-		},
 		[CH.ptyKill]: async (terminalId: string) => {
 			// Stamp WHY before the exit lands: closing a tab is the one ending that
 			// means "I am done with this", so it must not come back as a restorable
@@ -780,12 +782,39 @@ export function createDispatcher(engine: Engine): Dispatcher {
 		},
 	} satisfies Record<string, (...args: never[]) => unknown>;
 
+	// ---- pty input/size: the only handlers that need to know WHO is calling ----
+	// One terminal, many viewers (desktop + phone on a box, two windows): the PTY's
+	// size follows the viewer the user is using, not whoever reported last. The
+	// arbiter (size-arbiter.ts) decides; the transport supplies the client id.
+	// A call with no context (an older desktop main, a test) counts as one
+	// anonymous viewer, which is exactly the old last-writer-wins behaviour.
+	const sizes = createSizeArbiter();
+	engine.on("ptyExit", (e) => sizes.forget(e.terminalId));
+	const contextual = {
+		[CH.ptyWrite]: (ctx: CallContext, terminalId: string, data: string) => {
+			const size = sizes.activity(terminalId, ctx.client);
+			if (size) services.pty.resize(terminalId, size.cols, size.rows);
+			services.pty.write(terminalId, data);
+		},
+		[CH.ptyResize]: (ctx: CallContext, terminalId: string, cols: number, rows: number) => {
+			const size = sizes.resize(terminalId, ctx.client, { cols, rows });
+			if (size) services.pty.resize(terminalId, size.cols, size.rows);
+		},
+	} satisfies Record<string, (ctx: CallContext, ...args: never[]) => unknown>;
+
 	return {
-		methods: Object.keys(handlers),
-		async handle(method: string, args: unknown[]): Promise<unknown> {
+		methods: [...Object.keys(handlers), ...Object.keys(contextual)],
+		async handle(method: string, args: unknown[], ctx?: CallContext): Promise<unknown> {
+			const c = (contextual as Record<string, (ctx: CallContext, ...a: unknown[]) => unknown>)[
+				method
+			];
+			if (c) return await c(ctx ?? ANONYMOUS, ...args);
 			const h = (handlers as Record<string, (...a: unknown[]) => unknown>)[method];
 			if (!h) throw new Error(`Unknown method: ${method}`);
 			return await h(...args);
 		},
+		release: (client) => sizes.dropClient(client),
 	};
 }
+
+const ANONYMOUS: CallContext = { client: "anonymous" };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -15,7 +15,7 @@ export {
 	recordConnection,
 	resolveTransport,
 } from "./connections";
-export type { Dispatcher } from "./dispatcher";
+export type { CallContext, Dispatcher } from "./dispatcher";
 export { createDispatcher } from "./dispatcher";
 export type { Engine, EngineOptions } from "./engine";
 export { createEngine } from "./engine";

--- a/packages/server/src/pty/size-arbiter.ts
+++ b/packages/server/src/pty/size-arbiter.ts
@@ -1,0 +1,97 @@
+// Who gets to size a PTY when several viewers show the same terminal.
+//
+// A PTY has exactly one size, but one task is routinely open in more than one
+// place at once: the desktop and the phone on a box, two desktop windows, an
+// `ateam attach` shell. Every viewer fits its xterm to its own viewport and
+// reports that size, and until now each report was applied verbatim — last
+// writer wins. A phone that merely OPENS the task (or shows its keyboard) then
+// shrinks the desktop's terminal to phone dimensions, and the desktop never
+// recovers because it only re-reports when its own grid changes.
+//
+// This is tmux's problem, and tmux's answer (`window-size latest`) is the one
+// used here: the PTY follows the viewer the user is actually USING. A viewer
+// owns the size from the moment it claims it — by being the first to report a
+// size, or by sending input — and keeps it until another viewer sends input or
+// the owner goes away. Everyone else's size reports are remembered, not applied,
+// so that when a viewer takes over by typing its last-known size is applied at
+// once, even though it has nothing new to report.
+//
+// Pure policy, no I/O: the dispatcher asks it what to apply and calls the PTY.
+
+export interface TermSize {
+	cols: number;
+	rows: number;
+}
+
+interface TerminalSizing {
+	/** The viewer whose size the PTY follows; null until anyone reports one. */
+	owner: string | null;
+	/** Each viewer's last reported size, applied or not. */
+	sizes: Map<string, TermSize>;
+	/** What the PTY was last told, so a takeover with the same size is a no-op. */
+	applied: TermSize | null;
+}
+
+export interface SizeArbiter {
+	/**
+	 * A viewer reported its size. Returns the size to apply to the PTY, or null
+	 * when this viewer is not the owner (the report is remembered for later).
+	 */
+	resize(terminalId: string, client: string, size: TermSize): TermSize | null;
+	/**
+	 * A viewer sent input: it becomes the owner. Returns its remembered size if
+	 * the PTY is not already at it, else null.
+	 */
+	activity(terminalId: string, client: string): TermSize | null;
+	/** A viewer disconnected: forget its sizes and release any terminal it owned. */
+	dropClient(client: string): void;
+	/** A terminal is gone: forget everything about it. */
+	forget(terminalId: string): void;
+}
+
+const same = (a: TermSize | null, b: TermSize): boolean =>
+	a !== null && a.cols === b.cols && a.rows === b.rows;
+
+export function createSizeArbiter(): SizeArbiter {
+	const terminals = new Map<string, TerminalSizing>();
+	const get = (terminalId: string): TerminalSizing => {
+		let t = terminals.get(terminalId);
+		if (!t) {
+			t = { owner: null, sizes: new Map(), applied: null };
+			terminals.set(terminalId, t);
+		}
+		return t;
+	};
+
+	return {
+		resize(terminalId, client, size) {
+			const t = get(terminalId);
+			t.sizes.set(client, size);
+			// The first viewer to report holds the size until someone else acts:
+			// a second viewer that just opens the terminal must not resize it.
+			if (t.owner === null) t.owner = client;
+			if (t.owner !== client || same(t.applied, size)) return null;
+			t.applied = size;
+			return size;
+		},
+		activity(terminalId, client) {
+			const t = get(terminalId);
+			t.owner = client;
+			const size = t.sizes.get(client);
+			if (!size || same(t.applied, size)) return null;
+			t.applied = size;
+			return size;
+		},
+		dropClient(client) {
+			for (const t of terminals.values()) {
+				t.sizes.delete(client);
+				// Nobody inherits: the PTY keeps its size until the next viewer acts,
+				// and that viewer's first report (or keystroke) takes it over.
+				if (t.owner === client) t.owner = null;
+			}
+		},
+		forget(terminalId) {
+			terminals.delete(terminalId);
+		},
+	};
+}

--- a/packages/server/src/rpc.ts
+++ b/packages/server/src/rpc.ts
@@ -2,6 +2,7 @@
 // answer its requests through the dispatcher. Transport-agnostic — the desktop
 // hands it an Electron-IPC connection, the SSH server an stdio one — so every
 // client drives the identical engine + dispatcher.
+import { randomUUID } from "node:crypto";
 import { errorMessage } from "@ateam/git-core";
 import type { ClientFrame, ServerFrame } from "@ateam/protocol";
 import type { Dispatcher } from "./dispatcher";
@@ -34,14 +35,18 @@ export function serveRpc(
 		engine.on("ptyData", forward("ptyData")),
 		engine.on("ptyExit", forward("ptyExit")),
 	];
+	// One id per connection: the dispatcher tells viewers of the same terminal
+	// apart by it (whose size the PTY follows), and forgets them when they go.
+	const client = randomUUID();
 	const dispose = () => {
 		for (const u of unsubscribe) u();
+		dispatcher.release(client);
 	};
 
 	transport.onFrame(async (frame) => {
 		if (frame.t !== "req") return;
 		try {
-			const result = await dispatcher.handle(frame.method, frame.args);
+			const result = await dispatcher.handle(frame.method, frame.args, { client });
 			transport.send({ t: "res", id: frame.id, ok: true, result });
 		} catch (err) {
 			transport.send({ t: "res", id: frame.id, ok: false, error: errorMessage(err) });

--- a/packages/server/test/dispatcher.test.ts
+++ b/packages/server/test/dispatcher.test.ts
@@ -52,6 +52,7 @@ function makeEngine(db: AteamDb, agentPresence: BinaryPresence = "present") {
 			// would leak out of this test into every one that shells out after it.
 			refreshPath: async () => false,
 		},
+		on: () => () => {},
 		sendTaskUpdated: (id: string) => taskUpdated.push(id),
 		sendLoopsUpdated: () => {},
 	} as unknown as Engine;
@@ -576,5 +577,68 @@ describe("createDispatcher", () => {
 		} finally {
 			await rm(base, { recursive: true, force: true });
 		}
+	});
+});
+
+// One terminal, two clients (the desktop and the phone on a box). Each serveRpc
+// connection passes its own client id; the dispatcher must let the PTY follow
+// the client in use rather than whichever reported its size last.
+describe("pty sizing across clients", () => {
+	function makeSpyEngine() {
+		const calls: string[] = [];
+		const engine = {
+			services: {
+				db: createTestDb(),
+				pty: {
+					has: () => true,
+					write: (id: string, data: string) => calls.push(`write ${id} ${data}`),
+					resize: (id: string, c: number, r: number) => calls.push(`resize ${id} ${c}x${r}`),
+				},
+				followUps: { arm() {}, discard() {} },
+				pendingSeeds: new Map(),
+				hooks: {},
+				mergeQueue: {},
+				loopRunner: { describe: () => [] },
+				probeAgent: async () => "present",
+				refreshPath: async () => false,
+			},
+			on: () => () => {},
+			sendTaskUpdated: () => {},
+			sendLoopsUpdated: () => {},
+		} as unknown as Engine;
+		return { engine, calls };
+	}
+
+	it("a second viewer's size is held back until it types, then restored on return", async () => {
+		const { engine, calls } = makeSpyEngine();
+		const d = createDispatcher(engine);
+		const desk = { client: "desk" };
+		const phone = { client: "phone" };
+		await d.handle(CH.ptyResize, ["t", 200, 50], desk);
+		await d.handle(CH.ptyResize, ["t", 40, 20], phone);
+		expect(calls).toEqual(["resize t 200x50"]);
+		// Typing on the phone applies its size before the keystroke lands.
+		await d.handle(CH.ptyWrite, ["t", "y"], phone);
+		expect(calls.slice(1)).toEqual(["resize t 40x20", "write t y"]);
+		// Typing on the desktop takes it back, no window resize needed.
+		await d.handle(CH.ptyWrite, ["t", "z"], desk);
+		expect(calls.slice(3)).toEqual(["resize t 200x50", "write t z"]);
+	});
+
+	it("a disconnected owner releases the size; a call with no context still works", async () => {
+		const { engine, calls } = makeSpyEngine();
+		const d = createDispatcher(engine);
+		await d.handle(CH.ptyResize, ["t", 200, 50], { client: "desk" });
+		await d.handle(CH.ptyResize, ["t", 40, 20], { client: "phone" });
+		d.release("desk");
+		await d.handle(CH.ptyResize, ["t", 40, 21], { client: "phone" });
+		expect(calls).toEqual(["resize t 200x50", "resize t 40x21"]);
+		// No context (an older caller): one anonymous viewer, last writer wins.
+		const e = makeSpyEngine();
+		const d2 = createDispatcher(e.engine);
+		await d2.handle(CH.ptyResize, ["t", 10, 10]);
+		await d2.handle(CH.ptyResize, ["t", 11, 11]);
+		await d2.handle(CH.ptyWrite, ["t", "k"]);
+		expect(e.calls).toEqual(["resize t 10x10", "resize t 11x11", "write t k"]);
 	});
 });

--- a/packages/server/test/fs-util.test.ts
+++ b/packages/server/test/fs-util.test.ts
@@ -17,6 +17,7 @@ function makeEngine(userDataDir: string): Engine {
 			loopRunner: { describe: () => [] },
 			userDataDir,
 		},
+		on: () => () => {},
 		sendTaskUpdated: () => {},
 		sendLoopsUpdated: () => {},
 	} as unknown as Engine;

--- a/packages/server/test/size-arbiter.test.ts
+++ b/packages/server/test/size-arbiter.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import { createSizeArbiter } from "../src/pty/size-arbiter";
+
+// The user's actual complaint: a task open on the desktop AND on the phone, both
+// against one box. The phone's terminal reported its size and the desktop's
+// terminal shrank to phone dimensions — and stayed there, because the desktop
+// only re-reports its size when its own grid changes.
+const desktop = { cols: 200, rows: 50 };
+const phone = { cols: 40, rows: 20 };
+
+describe("size arbiter", () => {
+	it("applies the first viewer's size and ignores a second viewer that just opens", () => {
+		const a = createSizeArbiter();
+		expect(a.resize("t", "desktop", desktop)).toEqual(desktop);
+		// The phone opens the task: its fit is remembered, not applied.
+		expect(a.resize("t", "phone", phone)).toBeNull();
+		// The phone's keyboard shows and hides: still nothing reaches the PTY.
+		expect(a.resize("t", "phone", { cols: 40, rows: 12 })).toBeNull();
+		expect(a.resize("t", "phone", phone)).toBeNull();
+	});
+
+	it("hands the size to whoever types, and back again", () => {
+		const a = createSizeArbiter();
+		a.resize("t", "desktop", desktop);
+		a.resize("t", "phone", phone);
+		// Typing on the phone: it takes over, and its remembered size is applied
+		// at once even though it has nothing new to report.
+		expect(a.activity("t", "phone")).toEqual(phone);
+		// Now the phone's own re-fits apply, the desktop's don't.
+		expect(a.resize("t", "phone", { cols: 40, rows: 12 })).toEqual({ cols: 40, rows: 12 });
+		expect(a.resize("t", "desktop", { cols: 210, rows: 50 })).toBeNull();
+		// Back at the desk, the first keystroke restores the desktop's latest size.
+		expect(a.activity("t", "desktop")).toEqual({ cols: 210, rows: 50 });
+	});
+
+	it("does not resize for a takeover when the PTY is already at that size", () => {
+		const a = createSizeArbiter();
+		a.resize("t", "desktop", desktop);
+		// The owner typing again is not a resize.
+		expect(a.activity("t", "desktop")).toBeNull();
+		// Nor is a viewer reporting the size the PTY already has.
+		expect(a.resize("t", "desktop", { ...desktop })).toBeNull();
+	});
+
+	it("a viewer that never reported a size takes over without resizing", () => {
+		const a = createSizeArbiter();
+		a.resize("t", "phone", phone);
+		expect(a.activity("t", "cli")).toBeNull();
+		// It now owns the size: the phone can no longer resize under it…
+		expect(a.resize("t", "phone", { cols: 40, rows: 12 })).toBeNull();
+		// …and its own first report applies.
+		expect(a.resize("t", "cli", desktop)).toEqual(desktop);
+	});
+
+	it("releases a terminal when its owner disconnects, and forgets that viewer's sizes", () => {
+		const a = createSizeArbiter();
+		a.resize("t", "desktop", desktop);
+		a.resize("t", "phone", phone);
+		a.dropClient("desktop");
+		// Nobody inherits automatically: the PTY keeps its size…
+		// …until the next report claims it — the phone's keyboard re-fit here.
+		expect(a.resize("t", "phone", phone)).toEqual(phone);
+		// A reconnected desktop is a new client and can't be the old owner.
+		expect(a.resize("t", "desktop-2", desktop)).toBeNull();
+		expect(a.activity("t", "desktop-2")).toEqual(desktop);
+	});
+
+	it("keeps terminals independent", () => {
+		const a = createSizeArbiter();
+		a.resize("t1", "desktop", desktop);
+		expect(a.resize("t2", "phone", phone)).toEqual(phone);
+		expect(a.resize("t1", "phone", phone)).toBeNull();
+	});
+
+	it("forgets an exited terminal so a reused id starts clean", () => {
+		const a = createSizeArbiter();
+		a.resize("t", "desktop", desktop);
+		a.forget("t");
+		expect(a.resize("t", "phone", phone)).toEqual(phone);
+	});
+});

--- a/packages/server/test/ws.test.ts
+++ b/packages/server/test/ws.test.ts
@@ -130,3 +130,56 @@ describe("a half-open WebSocket", () => {
 		wss.close();
 	});
 });
+
+// The user's setup: one task open on the desktop AND on the phone, each its own
+// WebSocket to the box. The PTY has one size; it must follow the viewer in use,
+// not whichever xterm fitted itself last (which left the desktop rendered at
+// phone dimensions). serveRpc names each connection, so the dispatcher can tell
+// them apart — and releases the name when the connection closes.
+describe("two viewers of one terminal over ws", () => {
+	it("holds a second viewer's size back until it types, and releases on close", async () => {
+		const db = createTestDb();
+		const engine = makeEngine(db);
+		const calls: string[] = [];
+		(engine.services as unknown as { pty: unknown }).pty = {
+			has: () => true,
+			write: (id: string, data: string) => calls.push(`write ${id} ${data}`),
+			resize: (id: string, c: number, r: number) => calls.push(`resize ${id} ${c}x${r}`),
+		};
+		const dispatcher = createDispatcher(engine);
+		const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+		wss.on("connection", (sock) => serveRpc(engine, dispatcher, wsServerTransport(sock)));
+		await new Promise<void>((resolve) => wss.once("listening", resolve));
+		const { port } = wss.address() as AddressInfo;
+		const desk = wsClientTransport(`ws://127.0.0.1:${port}`);
+		const phone = wsClientTransport(`ws://127.0.0.1:${port}`);
+		const deskApi = buildAteamApi(createRpcClient(desk.transport), native);
+		const phoneApi = buildAteamApi(createRpcClient(phone.transport), native);
+		// pty.write/resize are fire-and-forget; a round-trip call fences them.
+		const settle = async () => {
+			await deskApi.tasks.list("none");
+			await phoneApi.tasks.list("none");
+		};
+
+		deskApi.pty.resize("t", 200, 50);
+		await settle();
+		phoneApi.pty.resize("t", 40, 20);
+		await settle();
+		expect(calls).toEqual(["resize t 200x50"]);
+
+		phoneApi.pty.write("t", "y");
+		await settle();
+		expect(calls.slice(1)).toEqual(["resize t 40x20", "write t y"]);
+
+		// The phone (now the owner) goes away: its hold is released, so the
+		// desktop's next report applies without it having to type first.
+		phone.close();
+		await new Promise((r) => setTimeout(r, 50));
+		deskApi.pty.resize("t", 201, 50);
+		await deskApi.tasks.list("none");
+		expect(calls.slice(3)).toEqual(["resize t 201x50"]);
+
+		desk.close();
+		wss.close();
+	});
+});


### PR DESCRIPTION
One task open on the desktop and the phone (or in two desktop windows) shares one PTY, and every viewer pushed its own xterm fit straight to it. Last writer won: the phone merely opening the task (or showing its keyboard) shrank the desktop's terminal to phone width, and the desktop never recovered because it only re-reports when its own grid changes.

Now the PTY follows the viewer in use, tmux's `window-size latest` rule:

- The first viewer to report a size holds it; a second viewer that just opens the terminal has its size remembered, not applied.
- Typing on a viewer hands the size over and applies that viewer's remembered size at once, so coming back to the desk and typing restores the desktop size with no window resize.
- A closed connection releases its hold; the next report claims it.

Each `serveRpc` connection gets an id (desktop and phone are distinct viewers on a box), and the desktop IPC bridge names each window by its webContents so two local windows are distinct too. The policy is one pure module (`size-arbiter.ts`); the dispatcher routes only `pty:write` and `pty:resize` through it. The PTY daemon is untouched.

Known trade-off: a non-owner viewer still fits its xterm to its own screen, so the phone shows desktop-width output wrapped until you type on it. Follow-up: broadcast the PTY size so non-owner viewers render the PTY grid.

Tests: arbiter policy, dispatcher with two clients, and a two-WebSocket end-to-end run including release on close.