### PR TITLE
Move private docs out of the wiki submodule into clawnify/wiki

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "wiki"]
-	path = wiki
-	url = https://github.com/clawnify/ateam-wiki.git


### PR DESCRIPTION
Worktrees never populated the submodule (Ateam stops at repo boundaries when
seeding one, and git worktree add does not init submodules), so agents could
only read the docs from the main checkout. The docs now live under ateam/ in
the private clawnify/wiki repo, cloned to ~/wiki on every machine.
