### PR TITLE
Resume the OpenCode conversation that belongs to the task's worktree

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -4,6 +4,7 @@ export type {
 	AvailableAgent,
 	BinaryPresence,
 	PromptTransport,
+	SessionScan,
 } from "./registry";
 export {
 	AGENTS,
@@ -11,6 +12,7 @@ export {
 	getAgent,
 	installAgentCli,
 	isAgentAvailable,
+	latestSessionInDir,
 	listAgents,
 	probeAgentBinary,
 } from "./registry";

--- a/packages/agents/src/registry.ts
+++ b/packages/agents/src/registry.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { resolve } from "node:path";
 import { promisify } from "node:util";
 
 const pexec = promisify(execFile);
@@ -42,6 +43,28 @@ export interface AgentDefinition {
 	 * it. Every harness can do this; only some let us choose the id up front.
 	 */
 	resumeIdCommand?: string;
+	/**
+	 * Args that print this CLI's conversations as JSON — each with the directory
+	 * it belongs to — so a resume can pick the id itself.
+	 *
+	 * Set ONLY for a CLI whose own "resume last" is scoped wider than the cwd.
+	 * `resumeCommand` is documented as "the most recent conversation in the cwd",
+	 * and for Claude that is true (its transcripts are filed by cwd). OpenCode
+	 * files them by PROJECT, and it counts every git worktree of a repo as one
+	 * project — so `opencode --continue` in one task's worktree happily reopens
+	 * the conversation another task was having in its own. See
+	 * `latestSessionInDir`.
+	 *
+	 * Not a bug waiting on an upstream fix: OpenCode scopes a session by its
+	 * path RELATIVE to the project, which is "" for every worktree root, so all
+	 * of them share one scope (their issue #41562). Four earlier reports of it
+	 * were closed not-planned (#25963, #26099, #18890, #28972) and the PR that
+	 * scoped `--continue` to the worktree (#33521) was closed unmerged. Treat
+	 * this as permanently ours. If a later release does scope it, resuming by id
+	 * stays strictly more precise — it pins THE conversation, not the newest one
+	 * — so this only ever becomes redundant, never wrong.
+	 */
+	sessionListArgs?: readonly string[];
 	/**
 	 * "Agent mode" command — the tool's autonomous multi-agent surface (e.g.
 	 * Claude Code's `claude agents` board), launched in the task's worktree.
@@ -148,6 +171,10 @@ export const AGENTS = [
 		// Same shape as Codex: `-s/--session <id>` continues a named session,
 		// but nothing pins the id of a new one.
 		resumeIdCommand: "opencode --session",
+		// So the id can be read back out instead. `session list` prints the root
+		// sessions of the whole PROJECT newest-first, each with its `directory`
+		// — which is also why `--continue` alone reaches the wrong worktree.
+		sessionListArgs: ["session", "list", "--format", "json"],
 		install: "curl -fsSL https://opencode.ai/install | bash",
 		loginCommand: "opencode auth login",
 		// `opencode run` takes the message as positional arguments.
@@ -252,6 +279,83 @@ export async function probeAgentBinary(
 		// ENOENT, neither of which knows anything about the binary.
 		return (err as { code?: unknown }).code === 1 ? "absent" : "unknown";
 	}
+}
+
+/**
+ * What a scan for "the newest conversation in this directory" learned. `ok`
+ * false is not "there is none": it is the CLI failing to answer, which the
+ * caller must not read as "start fresh" — that would silently drop a
+ * conversation the user asked to come back to.
+ */
+export interface SessionScan {
+	ok: boolean;
+	id: string | null;
+}
+
+/** A scan is one `<bin> session list`; measured at ~1s, so this is generous. */
+const SESSION_SCAN_TIMEOUT_MS = 15_000;
+
+/**
+ * The newest conversation this agent holds for `cwd`, by its own id.
+ *
+ * Only for agents that declare `sessionListArgs` — the ones whose "resume last"
+ * reaches beyond the working directory. Every task is a git worktree of a repo
+ * that has many, so "the newest conversation in the project" is very often
+ * ANOTHER task's, and resuming it drops the user into a transcript about a
+ * different branch, in a pane that is nonetheless cd'd into theirs.
+ *
+ * Run through the LOGIN shell for the same reason the binary probe is: this
+ * process's PATH is a boot-time snapshot that can be missing what `.zprofile`
+ * adds (login-env.ts).
+ *
+ * Deliberately the CLI and not the store behind it, even though session search
+ * already opens OpenCode's SQLite directly (session-search/sources/opencode.ts)
+ * and would answer this in a millisecond instead of the ~0.9s a process boot
+ * costs. The two want different things. Search reads message bodies for many
+ * cwds on a keystroke path and degrades to "no history", which is harmless; a
+ * resume needs ONE authoritative id, once, and its wrong answers are expensive.
+ * A schema or store that moved (OpenCode is mid-migration to a v2 store) makes
+ * a direct query return zero rows, which reads as "no conversation here" and
+ * silently starts a fresh one over the conversation the user asked to come back
+ * to. Asking the binary cannot answer about the wrong store, and if its output
+ * shape moves the parse fails LOUDLY into `ok: false`, which the caller
+ * degrades safely. Keep both readers; they are not required to agree.
+ */
+export async function latestSessionInDir(
+	agent: AgentDefinition,
+	cwd: string,
+	shell: string = defaultShell(),
+): Promise<SessionScan> {
+	if (!agent.sessionListArgs) return { ok: false, id: null };
+	let out: string;
+	try {
+		const cmd = `${agent.bin} ${agent.sessionListArgs.join(" ")}`;
+		({ stdout: out } = await pexec(shell, ["-lc", cmd], {
+			cwd,
+			timeout: SESSION_SCAN_TIMEOUT_MS,
+			maxBuffer: 8 * 1024 * 1024,
+		}));
+	} catch {
+		return { ok: false, id: null };
+	}
+	let rows: unknown;
+	try {
+		rows = JSON.parse(out);
+	} catch {
+		// An empty store prints nothing at all, which IS an answer: no session
+		// here. Anything else unparseable is the output shape having moved.
+		return out.trim() === "" ? { ok: true, id: null } : { ok: false, id: null };
+	}
+	if (!Array.isArray(rows)) return { ok: false, id: null };
+	const here = resolve(cwd);
+	let best: { id: string; updated: number } | null = null;
+	for (const row of rows as Array<Record<string, unknown>>) {
+		if (typeof row?.id !== "string" || typeof row.directory !== "string") continue;
+		if (resolve(row.directory) !== here) continue;
+		const updated = typeof row.updated === "number" ? row.updated : 0;
+		if (!best || updated > best.updated) best = { id: row.id, updated };
+	}
+	return { ok: true, id: best?.id ?? null };
 }
 
 /** Installers download a runtime; the slow ones are minutes, not seconds. */

--- a/packages/agents/test/latest-session.test.ts
+++ b/packages/agents/test/latest-session.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getAgent, latestSessionInDir } from "../src/registry";
+
+// OpenCode counts every git worktree of a repo as ONE project and lists their
+// conversations together, so `opencode --continue` in a task's worktree reaches
+// whichever task in the repo ran last. This scan is what picks the id that
+// actually belongs to the worktree in hand; these tests drive it with a stand-in
+// for the login shell, so nothing here depends on opencode being installed.
+const opencode = getAgent("opencode");
+const claude = getAgent("claude");
+if (!opencode || !claude) throw new Error("registry lost an agent");
+
+// A real directory: the scan runs the CLI IN the worktree it asks about.
+const HERE = mkdtempSync(join(tmpdir(), "ateam-worktree-"));
+const THERE = join(HERE, "..", "theirs");
+
+/** A `$SHELL -lc <cmd>` stand-in that prints `out` and exits with `code`. */
+function fakeShell(out: string, code = 0): string {
+	const dir = mkdtempSync(join(tmpdir(), "ateam-scan-"));
+	const path = join(dir, "shell");
+	writeFileSync(path, `#!/bin/sh\ncat <<'JSON'\n${out}\nJSON\nexit ${code}\n`);
+	chmodSync(path, 0o755);
+	return path;
+}
+
+const scan = (out: string, code = 0) => latestSessionInDir(opencode, HERE, fakeShell(out, code));
+
+describe("latestSessionInDir", () => {
+	it("takes the newest conversation in THIS directory, not the newest overall", async () => {
+		const rows = [
+			{ id: "ses_theirs", directory: THERE, updated: 300 },
+			{ id: "ses_mine_old", directory: HERE, updated: 100 },
+			{ id: "ses_mine", directory: HERE, updated: 200 },
+		];
+		expect(await scan(JSON.stringify(rows))).toEqual({ ok: true, id: "ses_mine" });
+	});
+
+	// "Asked, and this worktree has none" — the caller starts a fresh
+	// conversation on it, which is the honest answer for a worktree nothing has
+	// run in yet.
+	it("answers `none` when only other directories have conversations", async () => {
+		const rows = [{ id: "ses_theirs", directory: THERE, updated: 300 }];
+		expect(await scan(JSON.stringify(rows))).toEqual({ ok: true, id: null });
+	});
+
+	it("answers `none` for an empty store", async () => {
+		expect(await scan("")).toEqual({ ok: true, id: null });
+	});
+
+	// Not knowing must never read as "none": the caller falls back to the CLI's
+	// own resume rather than silently abandoning the conversation.
+	it("answers `unknown` when the CLI fails or its output moved", async () => {
+		expect(await scan("", 1)).toEqual({ ok: false, id: null });
+		expect(await scan("Session ID  Title  Updated")).toEqual({ ok: false, id: null });
+		expect(await scan('{"sessions":[]}')).toEqual({ ok: false, id: null });
+	});
+
+	it("declines to guess for an agent that lists nothing", async () => {
+		expect(await latestSessionInDir(claude, HERE, fakeShell("[]"))).toEqual({
+			ok: false,
+			id: null,
+		});
+	});
+});

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -1,4 +1,4 @@
-import type { BinaryPresence } from "@ateam/agents";
+import type { AgentDefinition, BinaryPresence, SessionScan } from "@ateam/agents";
 import type { AgentSession, AteamDb, Project, Task } from "@ateam/db";
 import type { ProjectDTO, SessionDTO, TaskDTO } from "@ateam/protocol";
 import type { FollowUps } from "./follow-ups";
@@ -33,6 +33,13 @@ export interface Services {
 	 * one runs an interactive login shell. Defaults to the real refresh.
 	 */
 	refreshPath?: (opts?: { force?: boolean }) => Promise<boolean>;
+	/**
+	 * The newest conversation an agent holds for a directory, asked before a
+	 * resume that would otherwise reach outside it (`latestSessionInDir`). A
+	 * seam for the same reason the two above are: the real one shells out to the
+	 * agent's CLI. Defaults to the real scan.
+	 */
+	latestSession?: (agent: AgentDefinition, cwd: string) => Promise<SessionScan>;
 	/**
 	 * In-flight `seedWorktree` calls by task id. A task's row is created (and its
 	 * card announced) as soon as the worktree exists, so its dependencies are

--- a/packages/server/src/session-search/sources/opencode.ts
+++ b/packages/server/src/session-search/sources/opencode.ts
@@ -5,6 +5,13 @@
 // Opened read-only, and every failure is swallowed into "no history": another
 // tool's database is not ours to repair, and a locked or moved store must not
 // take the search down for the other harnesses.
+//
+// This is not the only place that asks OpenCode which sessions belong to a
+// directory: a resume asks the same question through the CLI instead
+// (`latestSessionInDir`, agents/registry.ts), because there a store that moved
+// must fail loudly rather than answer "no sessions here". The two are meant to
+// differ — search wants bulk text fast and tolerates gaps, a resume wants one
+// id and tolerates a second of latency.
 
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";

--- a/packages/server/src/sessions.ts
+++ b/packages/server/src/sessions.ts
@@ -4,7 +4,13 @@
 // dispatcher's tasksCreate / ptySpawnAgent handlers.
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
-import { agentCommand, generateTaskTags, getAgent, probeAgentBinary } from "@ateam/agents";
+import {
+	agentCommand,
+	generateTaskTags,
+	getAgent,
+	latestSessionInDir,
+	probeAgentBinary,
+} from "@ateam/agents";
 import { repo, type Task } from "@ateam/db";
 import { createTask as gitCreateTask, seedWorktree } from "@ateam/git-core";
 import { buildAgentEnv, ensureClaudeHooks, ensureCodexHooks } from "./agent-setup";
@@ -148,6 +154,32 @@ export async function spawnAgentInTask(
 	// even appeared on a large monorepo. The card reports `preparing` while the
 	// copy is in flight, so the wait is visible instead of mysterious.
 
+	// "Resume the last conversation" is only ever aimed at THIS task, but not
+	// every CLI reads it that way. Claude files its transcripts by cwd, so
+	// `--continue` is already worktree-scoped; OpenCode files them by PROJECT
+	// and counts every git worktree of a repo as one project, so its
+	// `--continue` returns the newest conversation in ANY of them — reliably a
+	// sibling task's, since the newest one in this repo is whichever task ran
+	// last. That is a resume landing in the wrong branch's transcript, in a pane
+	// cd'd into the right one. So for those CLIs the id is picked here, from the
+	// conversations that actually belong to this worktree.
+	//
+	// A scan that could not run (`ok: false`) falls through to `--continue`: an
+	// imperfect resume beats silently starting a new conversation over one the
+	// user asked to come back to. A scan that ran and found nothing means this
+	// worktree has no conversation yet, so a fresh launch is the honest answer.
+	let resumeSessionId = input.resumeSessionId;
+	let resumeNewest = Boolean(input.resume);
+	if (resumeNewest && !resumeSessionId && agent.sessionListArgs) {
+		const scan = services.latestSession
+			? await services.latestSession(agent, task.worktreePath)
+			: await latestSessionInDir(agent, task.worktreePath, shell);
+		if (scan.ok) {
+			resumeSessionId = scan.id ?? undefined;
+			resumeNewest = false;
+		}
+	}
+
 	const terminalId = randomUUID();
 	// The conversation this tab holds. On a fresh launch we mint it — the
 	// terminal id doubles as the agent's session id, so the tab can be resumed
@@ -159,7 +191,7 @@ export async function spawnAgentInTask(
 	// or agent mode (a board, not a conversation). Recording the terminal id
 	// there would be a lie the restore then acts on.
 	const mintsId = Boolean(agent.sessionIdFlag) && !input.resume && !input.agentMode;
-	const agentSessionId = input.resumeSessionId ?? (mintsId ? terminalId : null);
+	const agentSessionId = resumeSessionId ?? (mintsId ? terminalId : null);
 	repo.createSession(services.db, {
 		taskId: task.id,
 		agentId: agent.id,
@@ -168,9 +200,9 @@ export async function spawnAgentInTask(
 		cwd: task.worktreePath,
 	});
 	// The tab this one is picking up is no longer waiting to be restored.
-	if (input.resumeSessionId) {
+	if (resumeSessionId) {
 		for (const prior of repo.listRestorableSessions(services.db, task.id)) {
-			if (prior.agentSessionId === input.resumeSessionId) {
+			if (prior.agentSessionId === resumeSessionId) {
 				repo.updateSession(services.db, prior.id, { exitReason: "restored" });
 			}
 		}
@@ -211,12 +243,12 @@ export async function spawnAgentInTask(
 	}
 	let agentCmd = agentCommand(agent, {
 		yolo: input.yolo,
-		resume: input.resume,
+		resume: resumeNewest,
 		agentMode: input.agentMode,
 		cwd: task.worktreePath,
 		prompt,
 		sessionId: agentSessionId ?? undefined,
-		resumeSessionId: input.resumeSessionId,
+		resumeSessionId,
 	});
 	if (agent.id === "codex") {
 		// Codex has no hooks, but `notify` invokes a program with a JSON

--- a/packages/server/test/spawn-resume.test.ts
+++ b/packages/server/test/spawn-resume.test.ts
@@ -26,14 +26,23 @@ function createTestDb(): AteamDb {
 let db: AteamDb;
 let services: Services;
 let taskId: string;
+let spawned: { command: string; cwd: string } | null;
 const T0 = 1_700_000_000_000;
 
 beforeEach(() => {
 	db = createTestDb();
+	spawned = null;
 	const scratch = mkdtempSync(join(tmpdir(), "ateam-spawn-"));
 	services = {
 		db,
-		pty: { spawn: () => "pty", has: () => false },
+		pty: {
+			// `args` is `["-l", "-c", "<agent cmd>; exec <shell> -l"]`.
+			spawn: (o: { args: string[]; cwd: string }) => {
+				spawned = { command: o.args[2] ?? "", cwd: o.cwd };
+				return "pty";
+			},
+			has: () => false,
+		},
 		hooksDir: scratch,
 		notifyScriptPath: join(scratch, "notify.sh"),
 		hookPort: 0,
@@ -44,6 +53,9 @@ beforeEach(() => {
 		// resume does to the card, not about what is installed on the machine.
 		probeAgent: async () => "present" as const,
 		refreshPath: async () => false,
+		// Overridden per-test. Defaults to "asked, nothing here", which is what an
+		// agent with no conversation in this worktree looks like.
+		latestSession: async () => ({ ok: true, id: null }),
 	} as unknown as Services;
 	const project = repo.upsertProject(db, {
 		repoPath: "/tmp/repo",
@@ -103,5 +115,47 @@ describe("spawnAgentInTask on resume", () => {
 		});
 		const task = repo.getTask(db, taskId);
 		expect(task).toMatchObject({ column: "running", agentStatus: "running", lastEventAt: T0 });
+	});
+});
+
+// OpenCode files its conversations by project, and every git worktree of a repo
+// is one project to it — so `opencode --continue` in this task's worktree
+// reopens whichever task in the repo ran last. A resume has to name the id.
+describe("resuming an agent whose --continue reaches beyond the worktree", () => {
+	it("resumes THIS worktree's newest conversation by id", async () => {
+		services.latestSession = async () => ({ ok: true, id: "ses_here" });
+		await spawnAgentInTask(services, () => {}, { taskId, agentId: "opencode", resume: true });
+		expect(spawned?.command).toStartWith("opencode --session 'ses_here'");
+		expect(spawned?.command).not.toInclude("--continue");
+	});
+
+	it("records the id, so the next restore skips the scan", async () => {
+		services.latestSession = async () => ({ ok: true, id: "ses_here" });
+		await spawnAgentInTask(services, () => {}, { taskId, agentId: "opencode", resume: true });
+		expect(repo.listSessionsByTask(db, taskId)[0]).toMatchObject({
+			agentSessionId: "ses_here",
+		});
+	});
+
+	it("starts fresh when this worktree has no conversation yet", async () => {
+		await spawnAgentInTask(services, () => {}, { taskId, agentId: "opencode", resume: true });
+		expect(spawned?.command).toStartWith("opencode;");
+	});
+
+	it("falls back to --continue when the scan itself failed", async () => {
+		services.latestSession = async () => ({ ok: false, id: null });
+		await spawnAgentInTask(services, () => {}, { taskId, agentId: "opencode", resume: true });
+		expect(spawned?.command).toStartWith("opencode --continue");
+	});
+
+	it("leaves an agent whose --continue is cwd-scoped alone", async () => {
+		let scanned = false;
+		services.latestSession = async () => {
+			scanned = true;
+			return { ok: true, id: "ses_here" };
+		};
+		await spawnAgentInTask(services, () => {}, { taskId, agentId: "claude", resume: true });
+		expect(scanned).toBe(false);
+		expect(spawned?.command).toStartWith("claude --continue");
 	});
 });


### PR DESCRIPTION
Selecting an old task and resuming it reopened whichever task in the repo ran last.

## Why

OpenCode scopes a session by its path **relative to the project**, and it counts every git worktree of a repo as one project. That path is `""` for every worktree root, so all of them share one continuation scope and `opencode --continue` returns the newest conversation in *any* of them. Worse than a confusing transcript: a resumed session adopts its own recorded directory, so the agent's tools were pointed at the other task's checkout.

Ateam never had an id to resume by. OpenCode mints its own, so `agent_sessions.agent_session_id` was null for every OpenCode tab and both resume paths (a restored tab, and "resume last conversation" for a task with nothing stranded) fell through to `--continue`.

Not waiting on upstream: OpenCode has closed four reports of this not-planned (#25963, #26099, #18890, #28972) and the PR that scoped `--continue` to the worktree was closed unmerged. The tracking issue (#41562) is still open.

## What changes

- `latestSessionInDir` asks `opencode session list --format json` (documented, unchanged since it landed) for the project's root sessions, each with the directory it belongs to, and takes the newest one for **this** worktree.
- `spawnAgentInTask` resolves the id on any resume that has none, spawns `opencode --session '<id>'`, and records it as the session's `agent_session_id` so later restores skip the scan.
- Driven by a new `sessionListArgs` field, set only for OpenCode. Claude is untouched: it files transcripts by cwd, so its `--continue` is already worktree-scoped.

Fallbacks are deliberate. A scan that cannot run keeps the old `--continue` behaviour, because an imperfect resume beats silently starting a new conversation over one the user asked to come back to. A scan that runs and finds nothing starts fresh, which is the honest answer for a worktree with no conversation yet.

Deliberately the CLI and not the SQLite store that session search already reads: a store that moved must fail loudly here rather than answer "no sessions", and OpenCode is mid-migration to a v2 store. Both readers now point at each other in comments.

## Verified

- The scan resolves this worktree's own conversation where `--continue` took the newest one from a sibling worktree, against the real CLI.
- In a real PTY, `opencode --session '<id>'` opens that exact conversation from any cwd.
- 0.90-0.93s per resolution, paid once per conversation (the id is then recorded).
- 13 new tests, 463 passing, typecheck and lint clean.