### PR TITLE
Loops form matches the composer, and a loop takes an explicit name

### DIFF
--- a/apps/desktop/src/renderer/src/components/LoopsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/LoopsPanel.tsx
@@ -15,6 +15,7 @@ import {
 	Zap,
 } from "lucide-react";
 import { useEffect, useState } from "react";
+import { titleFromPrompt } from "../titleFromPrompt";
 import { type Alias, aliasLabel, type EngineMember } from "../unify";
 import { AgentPicker } from "./AgentPicker";
 import { EnvironmentPicker, type EnvOption } from "./EnvironmentPicker";
@@ -165,7 +166,7 @@ function LoopForm({
 			if (editing) {
 				await window.ateam.loops.update({
 					id: editing.id,
-					name: name.trim() || "Loop",
+					name: name.trim() || titleFromPrompt(prompt) || "Loop",
 					intervalMs: Number(everyMin) * 60_000,
 					config: {
 						prompt: prompt.trim(),
@@ -179,7 +180,7 @@ function LoopForm({
 				// engine owns the loop and runs every session there.
 				await window.ateam.loops.create({
 					templateId: "agent-session",
-					name: name.trim() || "Loop",
+					name: name.trim() || titleFromPrompt(prompt) || "Loop",
 					projectId,
 					intervalMs: Number(everyMin) * 60_000,
 					config: {
@@ -214,6 +215,9 @@ function LoopForm({
 		alias: m.alias,
 		label: aliasLabel(m.alias),
 		disabled: false,
+		// Surface a skewed box on the pill itself, like the composer does — the
+		// feature gates below read off the same engine.
+		skew: m.alias && envProtocol[m.alias] !== undefined ? envProtocol[m.alias] : undefined,
 	}));
 	const pickEnv = (alias: string | null) => {
 		const member = members.find((m) => m.alias === alias);
@@ -231,24 +235,27 @@ function LoopForm({
 						onChange={(e) => setName(e.target.value)}
 					/>
 				</div>
+				{/* biome-ignore lint/a11y/noAutofocus: the loop form should focus its prompt, like the composer */}
 				<textarea
+					autoFocus
 					className="comp-prompt"
 					placeholder="What should each run do?"
 					value={prompt}
 					onChange={(e) => setPrompt(e.target.value)}
 				/>
-				<div className="loop-form-row">
-					<label>
+				<div className="loop-followup">
+					<span>
 						{followUpBlockedBy === null
 							? "Follow-up (optional) — sent once, after the agent's first reply"
 							: `Follow-up — needs Ateam v${FEATURE_MIN_VERSION.followUps} on this box (it runs v${followUpBlockedBy})`}
-						<textarea
-							value={followUp}
-							disabled={followUpBlockedBy !== null}
-							placeholder="/check"
-							onChange={(e) => setFollowUp(e.target.value)}
-						/>
-					</label>
+					</span>
+					<textarea
+						className="comp-prompt"
+						value={followUp}
+						disabled={followUpBlockedBy !== null}
+						placeholder="/check"
+						onChange={(e) => setFollowUp(e.target.value)}
+					/>
 				</div>
 				<div className="comp-foot">
 					<AgentPicker
@@ -299,6 +306,9 @@ function LoopForm({
 						<Zap size={16} strokeWidth={1.75} />
 					</button>
 					<span className="spacer" />
+					<button type="button" className="navbtn" onClick={() => close(onCancel)}>
+						<X size={14} /> Cancel
+					</button>
 					<span className="muted" style={{ fontSize: 11 }}>
 						⌘⏎
 					</span>
@@ -321,11 +331,6 @@ function LoopForm({
 						<AlertTriangle size={13} /> {error}
 					</div>
 				)}
-			</div>
-			<div className="loop-actions">
-				<button type="button" className="navbtn" onClick={() => close(onCancel)}>
-					<X size={14} /> Cancel
-				</button>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/src/components/LoopsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/LoopsPanel.tsx
@@ -15,7 +15,6 @@ import {
 	Zap,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { titleFromPrompt } from "../titleFromPrompt";
 import { type Alias, aliasLabel, type EngineMember } from "../unify";
 import { AgentPicker } from "./AgentPicker";
 import { EnvironmentPicker, type EnvOption } from "./EnvironmentPicker";
@@ -156,7 +155,7 @@ function LoopForm({
 	// permission-prompted, which wedges an unattended loop on its first ask.
 	const autoBlockedBy = gatedBy("loopAutoMode");
 
-	const ready = prompt.trim() && projectId && Number(everyMin) >= 1;
+	const ready = name.trim() && prompt.trim() && projectId && Number(everyMin) >= 1;
 
 	const submit = async () => {
 		if (!ready) return;
@@ -166,7 +165,7 @@ function LoopForm({
 			if (editing) {
 				await window.ateam.loops.update({
 					id: editing.id,
-					name: name.trim() || titleFromPrompt(prompt) || "Loop",
+					name: name.trim(),
 					intervalMs: Number(everyMin) * 60_000,
 					config: {
 						prompt: prompt.trim(),
@@ -180,7 +179,7 @@ function LoopForm({
 				// engine owns the loop and runs every session there.
 				await window.ateam.loops.create({
 					templateId: "agent-session",
-					name: name.trim() || titleFromPrompt(prompt) || "Loop",
+					name: name.trim(),
 					projectId,
 					intervalMs: Number(everyMin) * 60_000,
 					config: {
@@ -230,7 +229,7 @@ function LoopForm({
 				<div className="comp-head">
 					<input
 						className="comp-name"
-						placeholder="Loop name (optional)"
+						placeholder="Loop name"
 						value={name}
 						onChange={(e) => setName(e.target.value)}
 					/>

--- a/apps/desktop/src/renderer/src/components/PromptComposer.tsx
+++ b/apps/desktop/src/renderer/src/components/PromptComposer.tsx
@@ -2,8 +2,9 @@ import type { AgentDTO } from "@ateam/protocol";
 import { ArrowUp, Paperclip, X, Zap } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { HostStatus } from "../../../shared/host";
+import { titleFromPrompt } from "../titleFromPrompt";
 import { AgentPicker } from "./AgentPicker";
-import { type EnvOption, EnvironmentPicker } from "./EnvironmentPicker";
+import { EnvironmentPicker, type EnvOption } from "./EnvironmentPicker";
 
 /** Last path segment, for a compact chip label. */
 function baseName(p: string): string {
@@ -17,11 +18,6 @@ function slugify(s: string): string {
 		.replace(/[^a-z0-9]+/g, "-")
 		.replace(/^-+|-+$/g, "")
 		.slice(0, 48);
-}
-
-/** Readable task name derived from the prompt's first words. */
-function titleFromPrompt(p: string): string {
-	return p.trim().split(/\s+/).slice(0, 6).join(" ").slice(0, 60);
 }
 
 /**

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -2303,39 +2303,28 @@ input {
 .loop-form {
 	flex-direction: column;
 	align-items: stretch;
-	gap: 10px;
+	padding: 18px 20px;
 }
-.loop-form .loop-actions {
-	justify-content: flex-end;
-}
-.loop-form-row {
-	display: flex;
-	gap: 12px;
-	flex-wrap: wrap;
-}
-.loop-form-row label {
+/* The form's sections live in .loop-main (a single child of .loop-card), so the
+   section spacing is this div's gap, not the card's. */
+.loop-form .loop-main {
 	display: flex;
 	flex-direction: column;
-	gap: 4px;
+	gap: 14px;
+}
+.loop-followup {
+	display: flex;
+	flex-direction: column;
+	gap: 7px;
 	font-size: 11px;
 	color: var(--text-dim);
-	flex: 1;
-	min-width: 160px;
 }
-.loop-form-row select,
-.loop-form-row input,
-.loop-form-row textarea {
-	background: var(--bg-elev-2);
-	border: 1px solid var(--border);
-	border-radius: 7px;
-	color: var(--text);
-	padding: 6px 8px;
-	font-size: 13px;
-}
-.loop-form-row textarea {
-	resize: vertical;
+.loop-followup .comp-prompt {
 	min-height: 56px;
-	font-family: inherit;
+}
+.loop-followup .comp-prompt:disabled,
+.loop-followup .comp-prompt:disabled::placeholder {
+	opacity: 0.5;
 }
 /* The loop form borrows the composer's foot pills (agent, environment, Auto);
    the interval and a fixed-at-creation environment are the loop-specific two. */
@@ -2343,24 +2332,24 @@ input {
 	display: inline-flex;
 	align-items: center;
 	gap: 5px;
-	font-size: 11.5px;
+	font-size: 13px;
 	color: var(--text-dim);
-	border: 1px solid var(--border);
-	border-radius: 7px;
-	padding: 5px 9px;
-	background: var(--bg-elev-2);
+	padding: 4px 6px;
 	user-select: none;
 }
 .comp-every input {
-	width: 44px;
+	width: 56px;
 	border: none;
 	background: transparent;
 	color: var(--text);
-	font-size: 12.5px;
+	font-size: 13px;
 	text-align: right;
-	outline: none;
+	padding: 0;
 	appearance: textfield;
 	-moz-appearance: textfield;
+}
+.comp-every:focus-within {
+	color: var(--text);
 }
 .comp-every input::-webkit-outer-spin-button,
 .comp-every input::-webkit-inner-spin-button {
@@ -2371,18 +2360,15 @@ input {
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
-	font-size: 12px;
+	font-size: 13px;
 	color: var(--text-dim);
-	border: 1px dashed var(--border);
-	border-radius: 7px;
-	padding: 5px 9px;
-}
-.comp-yolo:disabled {
-	opacity: 0.35;
-	cursor: default;
+	padding: 4px 6px;
+	/* Locked, not disabled: the house idiom for "fixed at creation" is a dimmed
+	   pill (dashed means clickable-but-not-real, see .sess-tab.restorable). */
+	opacity: 0.65;
 }
 .loop-form .comp-prompt {
-	min-height: 72px;
+	width: 100%;
 }
 .loop-auto {
 	display: inline-flex;

--- a/apps/desktop/src/renderer/src/titleFromPrompt.ts
+++ b/apps/desktop/src/renderer/src/titleFromPrompt.ts
@@ -1,0 +1,4 @@
+/** Readable name derived from a prompt's first words (shared by the task composer and loop forms). */
+export function titleFromPrompt(p: string): string {
+	return p.trim().split(/\s+/).slice(0, 6).join(" ").slice(0, 60);
+}


### PR DESCRIPTION
The Loops form and the task composer are the same gesture (prompt, agent, environment, go), so they should look and behave the same. They did not.

## Changes

- **The form matches the composer**: full-width prompt, foot pills aligned with it, and live keyboard behaviour (Esc closes, Cmd+Enter submits) instead of a form you could only leave with the mouse.
- **`titleFromPrompt` is shared** rather than reimplemented, so anything that names itself from a prompt does it identically.
- **A loop takes an explicit name.** The placeholder drops "(optional)", Create/Save stays disabled until the name is filled, and both create and update send it through as typed. A loop is a standing job you return to, so the list should read as a set of names, not truncated prompts. The prompt-derived fallback stays on tasks, which are named once and then forgotten.

Touches `LoopsPanel.tsx`, `PromptComposer.tsx`, `index.css` and `titleFromPrompt.ts` in the desktop renderer.