### PR TITLE
Diff view shows the content of files an agent created but never staged

### DIFF
--- a/apps/desktop/src/renderer/src/components/FileDiffView.tsx
+++ b/apps/desktop/src/renderer/src/components/FileDiffView.tsx
@@ -51,7 +51,7 @@ export function FileDiffView({
 					</div>
 				) : files.length === 0 ? (
 					<div className="muted" style={{ padding: 12 }}>
-						No textual diff (binary or untracked file)
+						No textual diff (binary file)
 					</div>
 				) : (
 					files.map((f) => (
@@ -61,9 +61,7 @@ export function FileDiffView({
 							diffType={f.type}
 							hunks={f.hunks}
 						>
-							{(hunks) =>
-								hunks.map((h) => <Hunk key={h.content} hunk={h} />)
-							}
+							{(hunks) => hunks.map((h) => <Hunk key={h.content} hunk={h} />)}
 						</Diff>
 					))
 				)}

--- a/packages/git-core/src/diff.ts
+++ b/packages/git-core/src/diff.ts
@@ -1,3 +1,5 @@
+import { open } from "node:fs/promises";
+import { join } from "node:path";
 import { gitFor, safeRaw } from "./git-client";
 
 export interface DiffFile {
@@ -40,6 +42,37 @@ function parseNumstatInto(raw: string, into: Map<string, DiffFile>): void {
 	}
 }
 
+/**
+ * Line count + binary-ness of a file on disk, the way `git diff --numstat`
+ * would report it once added: a trailing partial line counts, and a NUL byte
+ * in the first 8000 bytes means binary (git's own heuristic). Streamed, so a
+ * stray large untracked file costs I/O, not memory.
+ */
+async function countNewFile(absPath: string): Promise<{ additions: number; binary: boolean }> {
+	const fh = await open(absPath, "r");
+	try {
+		const buf = Buffer.alloc(64 * 1024);
+		let lines = 0;
+		let first = true;
+		let lastByte = -1;
+		for (;;) {
+			const { bytesRead } = await fh.read(buf, 0, buf.length, null);
+			if (bytesRead === 0) break;
+			const chunk = buf.subarray(0, bytesRead);
+			if (first) {
+				first = false;
+				if (chunk.subarray(0, 8000).includes(0)) return { additions: 0, binary: true };
+			}
+			for (let i = chunk.indexOf(10); i !== -1; i = chunk.indexOf(10, i + 1)) lines++;
+			lastByte = chunk[bytesRead - 1] ?? lastByte;
+		}
+		if (lastByte !== -1 && lastByte !== 10) lines++;
+		return { additions: lines, binary: false };
+	} finally {
+		await fh.close();
+	}
+}
+
 export interface DiffInput {
 	worktreePath: string;
 	/** When provided, includes committed changes vs `origin/<base>` merge-base. */
@@ -58,32 +91,27 @@ export async function diff(input: DiffInput): Promise<DiffResult> {
 
 	if (input.baseBranch) {
 		parseNumstatInto(
-			await safeRaw(git, [
-				"diff",
-				"--numstat",
-				"--merge-base",
-				`origin/${input.baseBranch}`,
-			]),
+			await safeRaw(git, ["diff", "--numstat", "--merge-base", `origin/${input.baseBranch}`]),
 			files,
 		);
 	}
 	parseNumstatInto(await safeRaw(git, ["diff", "--numstat", "--staged"]), files);
 	parseNumstatInto(await safeRaw(git, ["diff", "--numstat"]), files);
 
-	// Untracked files never appear in `git diff`; list them explicitly.
-	const untracked = await safeRaw(git, [
-		"ls-files",
-		"--others",
-		"--exclude-standard",
-	]);
+	// Untracked files never appear in `git diff`; list them explicitly, with
+	// every line counted as an addition (what staging them would report).
+	const untracked = await safeRaw(git, ["ls-files", "--others", "--exclude-standard"]);
 	for (const line of untracked.split("\n")) {
 		const path = line.trim();
 		if (!path || files.has(path)) continue;
+		const counted = await countNewFile(join(input.worktreePath, path)).catch(() => ({
+			additions: 0,
+			binary: false,
+		}));
 		files.set(path, {
 			path,
-			additions: 0,
+			...counted,
 			deletions: 0,
-			binary: false,
 			untracked: true,
 		});
 	}
@@ -103,14 +131,18 @@ export interface FileDiffInput {
 /** The unified patch for a single file (lazily fetched by the viewer). */
 export async function fileDiff(input: FileDiffInput): Promise<string> {
 	const git = gitFor(input.worktreePath);
-	if (input.baseBranch) {
-		return safeRaw(git, [
-			"diff",
-			"--merge-base",
-			`origin/${input.baseBranch}`,
-			"--",
-			input.file,
-		]);
-	}
-	return safeRaw(git, ["diff", "--", input.file]);
+	const patch = input.baseBranch
+		? await safeRaw(git, ["diff", "--merge-base", `origin/${input.baseBranch}`, "--", input.file])
+		: await safeRaw(git, ["diff", "--", input.file]);
+	if (patch) return patch;
+
+	// `git diff` is silent on an untracked file (an agent's freshly created
+	// file that nothing staged yet). Diff it against nothing instead, which
+	// yields a regular "new file" patch. `--no-index` exits 1 on any difference
+	// with nothing on stderr, which simple-git reports as success.
+	const isUntracked = (
+		await safeRaw(git, ["ls-files", "--others", "--exclude-standard", "--", input.file])
+	).trim();
+	if (!isUntracked) return patch;
+	return safeRaw(git, ["diff", "--no-index", "--", "/dev/null", input.file]);
 }

--- a/packages/git-core/test/git-core.test.ts
+++ b/packages/git-core/test/git-core.test.ts
@@ -11,6 +11,7 @@ import {
 	detectDefaultBranch,
 	detectMerged,
 	diff,
+	fileDiff,
 	initRepository,
 	parseGithubRepo,
 	parseWorktreeList,
@@ -583,6 +584,39 @@ describe("commit & diff", () => {
 		});
 		const x = after.files.find((f) => f.path === "x.txt");
 		expect(x?.additions).toBe(2);
+	});
+
+	// An agent's freshly created file is untracked: `git diff` is silent on it,
+	// so the viewer used to show "+0 -0" and an empty patch for real content.
+	it("reports an untracked file's lines and a new-file patch", async () => {
+		const task = await createTask({ repoPath: repo.work, name: "new file" });
+		await Bun.write(join(task.worktreePath, "notes.md"), "# notes\n\nfirst\nlast without newline");
+		await Bun.write(join(task.worktreePath, "blob.bin"), new Uint8Array([0, 1, 2, 3]));
+
+		const d = await diff({ worktreePath: task.worktreePath, baseBranch: "main" });
+		const notes = d.files.find((f) => f.path === "notes.md");
+		expect(notes).toMatchObject({ untracked: true, additions: 4, deletions: 0, binary: false });
+		const blob = d.files.find((f) => f.path === "blob.bin");
+		expect(blob).toMatchObject({ untracked: true, additions: 0, binary: true });
+
+		const patch = await fileDiff({
+			worktreePath: task.worktreePath,
+			file: "notes.md",
+			baseBranch: "main",
+		});
+		expect(patch).toContain("new file mode");
+		expect(patch).toContain("+++ b/notes.md");
+		expect(patch).toContain("+last without newline");
+
+		// A file git already knows about keeps the ordinary path.
+		await Bun.write(join(task.worktreePath, "README.md"), "# temp repo\nmore\n");
+		const tracked = await fileDiff({
+			worktreePath: task.worktreePath,
+			file: "README.md",
+			baseBranch: "main",
+		});
+		expect(tracked).toContain("+more");
+		expect(tracked).not.toContain("new file mode");
 	});
 });
 


### PR DESCRIPTION
An untracked file never appears in `git diff`, so the changes list showed it as +0 -0 and the patch pane said there was no textual diff, even though the file had real content (VS Code shows the same file as all-added). Any agent that creates a file without staging it hit this; it surfaced first with OpenCode.

- `diff()` counts the lines of each untracked file (streamed, git's binary heuristic)
- `fileDiff()` falls back to `git diff --no-index /dev/null <file>` when the ordinary diff is empty and the file is untracked, yielding a normal new-file patch
- Empty-state copy in the file pane now says binary file only
- Test covers untracked text, no trailing newline, binary, and the tracked path

Verified against the real worktree from the report: 80 additions and a proper new-file patch.