### PR TITLE
Task tabs read like editor tabs, and a task shows every live session

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -53,7 +53,7 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { AgentIcon } from "./components/AgentIcon";
+import { SessionGlyphs, SessionIcon } from "./components/AgentIcon";
 import { CleanupDialog } from "./components/CleanupDialog";
 import { FileDiffView } from "./components/FileDiffView";
 import { IconButton } from "./components/IconButton";
@@ -65,7 +65,7 @@ import { TerminalView } from "./components/Terminal";
 import { usePrompt } from "./components/usePrompt";
 import { PanelRightFilled } from "./components/PanelRightFilled";
 import { VscodeLogo } from "./components/VscodeLogo";
-import { activeTerminal, sessionTabs } from "./session-tabs";
+import { activeTerminal, sessionTabs, taskGlyphs } from "./session-tabs";
 import { matchesTagQuery, tagsFor, taskIcon } from "./task-tags";
 import { byWhatsNext, relativeAge } from "./triage-order";
 import { type Alias, aliasLabel, type UnifiedProject, unifyProjects } from "./unify";
@@ -912,6 +912,9 @@ export function App() {
 						</button>
 						{visibleSidebarTasks.map((t) => {
 							const Icon = taskIcon(t.name);
+							// One tile, one glyph: the first live session, and a count when
+							// there are more — the row and the card have room to show them all.
+							const [glyph, ...rest] = taskGlyphs(t);
 							return (
 								<button
 									type="button"
@@ -920,11 +923,12 @@ export function App() {
 									title={t.name}
 									onClick={() => toggleTask(t)}
 								>
-									{t.agentId ? (
-										<AgentIcon agentId={t.agentId} size={16} />
+									{glyph ? (
+										<SessionIcon agentId={glyph} size={16} />
 									) : (
 										<Icon size={16} strokeWidth={1.75} />
 									)}
+									{rest.length > 0 && <span className="rail-count">{rest.length + 1}</span>}
 									{t.preparing ? (
 										<span className="corner preparing" />
 									) : (
@@ -1437,15 +1441,16 @@ function TaskRow({
 }) {
 	const Icon = taskIcon(t.name);
 	const tags = tagsFor(t);
+	const glyphs = taskGlyphs(t);
 	// Row and trailing slot are siblings so the trash click can't nest inside the
 	// row button (same pattern as proj-row / proj-open above). The status dot and
 	// delete button share the trailing slot and swap in place on hover.
 	return (
 		<div className="tasknode-row">
 			<button type="button" className={`tasknode ${selected ? "selected" : ""}`} onClick={onClick}>
-				{t.agentId ? (
-					<span className="ticon">
-						<AgentIcon agentId={t.agentId} size={14} />
+				{glyphs.length > 0 ? (
+					<span className="ticon glyphs">
+						<SessionGlyphs ids={glyphs} size={14} />
 					</span>
 				) : (
 					<Icon className="ticon" size={14} strokeWidth={1.75} />
@@ -1569,6 +1574,7 @@ function Board({
 						</h3>
 						{items.map((t) => {
 							const tags = tagsFor(t);
+							const glyphs = taskGlyphs(t);
 							const isSelected = t.id === selectedId;
 							return (
 								<motion.div
@@ -1636,7 +1642,11 @@ function Board({
 											{relativeAge(t.lastEventAt, Date.now()) && (
 												<span className="age">{relativeAge(t.lastEventAt, Date.now())}</span>
 											)}
-											{t.agentId && <AgentIcon agentId={t.agentId} size={15} />}
+											{glyphs.length > 0 && (
+												<span className="glyphs">
+													<SessionGlyphs ids={glyphs} size={15} />
+												</span>
+											)}
 										</span>
 									</div>
 								</motion.div>
@@ -2031,7 +2041,10 @@ function TaskPanel({
 									void restoreTab(session);
 								}}
 							>
-								{label}
+								<span className="sess-tab-icon">
+									<SessionIcon agentId={session.agentId} size={14} />
+								</span>
+								<span>{label}</span>
 							</button>
 							{/* A stranded tab has no process to kill, and it retires itself
 							    after one run of the app — so it carries no close button. */}
@@ -2043,7 +2056,7 @@ function TaskPanel({
 									title={`Close ${label}`}
 									onClick={() => closeSession(session, label)}
 								>
-									<X size={11} />
+									<X size={14} />
 								</button>
 							)}
 						</div>

--- a/apps/desktop/src/renderer/src/components/AgentIcon.tsx
+++ b/apps/desktop/src/renderer/src/components/AgentIcon.tsx
@@ -1,3 +1,5 @@
+import { SquareTerminal } from "lucide-react";
+
 // Brand glyphs for the agent that a task is using. Shown on task cards and in
 // the Tasks sidebar in place of the inferred task icon.
 export function AgentIcon({
@@ -46,4 +48,23 @@ export function AgentIcon({
 		default:
 			return null;
 	}
+}
+
+/** The glyph for one session: the agent's brand mark, or the terminal icon for a shell. */
+export function SessionIcon({ agentId, size = 14 }: { agentId: string; size?: number }) {
+	if (agentId === "shell") return <SquareTerminal size={size} strokeWidth={1.75} />;
+	return <AgentIcon agentId={agentId} size={size} />;
+}
+
+/**
+ * One glyph per session, in order. Keys number repeats of a kind ("claude-1",
+ * "claude-2") the way the panel's tabs do, so two Claudes are two glyphs.
+ */
+export function SessionGlyphs({ ids, size = 14 }: { ids: string[]; size?: number }) {
+	const seen = new Map<string, number>();
+	return ids.map((id) => {
+		const n = (seen.get(id) ?? 0) + 1;
+		seen.set(id, n);
+		return <SessionIcon key={`${id}-${n}`} agentId={id} size={size} />;
+	});
 }

--- a/apps/desktop/src/renderer/src/components/Menu.tsx
+++ b/apps/desktop/src/renderer/src/components/Menu.tsx
@@ -71,6 +71,8 @@ export function Menu({
 				ref={btnRef}
 				className="iconbtn"
 				aria-label={label}
+				aria-haspopup="menu"
+				aria-expanded={pos !== null}
 				title={label}
 				onClick={toggle}
 			>

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -204,6 +204,20 @@ input {
 	background: var(--bg-elev-2);
 	color: var(--text);
 }
+/* How many sessions the tile stands for, when more than one: the tile has
+   room for one glyph, so the rest are a number. Opposite corner to the status
+   dot. */
+.rail-tile .rail-count {
+	position: absolute;
+	right: 3px;
+	bottom: 2px;
+	padding: 1px 3px;
+	border-radius: 4px;
+	background: var(--bg-elev);
+	font-size: 9px;
+	line-height: 1;
+	color: var(--text);
+}
 .rail-tile .corner {
 	position: absolute;
 	top: 3px;
@@ -414,6 +428,12 @@ input {
 .tasknode .ticon {
 	color: var(--text-dim);
 	flex: none;
+}
+/* One glyph per live session, on the sidebar row and the board card. */
+.glyphs {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
 }
 .tasknode .tname {
 	flex: 1;
@@ -975,7 +995,11 @@ input {
 .sess-tabs {
 	display: flex;
 	align-items: center;
-	gap: 2px;
+	align-self: stretch;
+	/* Tabs sit flush, VS Code style: the strip bleeds through the row's padding
+	   so a tab touches the row's top, bottom and left edges. */
+	gap: 0;
+	margin: -6px 0 -6px -10px;
 	min-width: 0;
 	overflow-x: auto;
 	/* A horizontal scrollbar must not shove the row taller than the icons. */
@@ -984,67 +1008,114 @@ input {
 .sess-tabs::-webkit-scrollbar {
 	display: none;
 }
-/* The `+` never scrolls away with the tabs — it's how you make the next one. */
+/* The `+` never scrolls away with the tabs — it's how you make the next one.
+   It shows only while the pointer is over the toolbar row (or it has keyboard
+   focus, or its menu is open): a control you reach for, not a permanent tab. */
 .sess-tabs > :last-child {
 	position: sticky;
 	right: 0;
 	flex: none;
+	margin-left: 4px;
 	background: var(--bg);
+	opacity: 0;
+	transition: opacity 0.1s;
 }
+.actions:hover .sess-tabs > :last-child,
+.sess-tabs > :last-child:focus-visible,
+.sess-tabs > [aria-expanded="true"] {
+	opacity: 1;
+}
+/* An editor tab: square, icon + name + close. Only the active one is a surface;
+   the rest sit on the row's own background, and it carries a white line along
+   its top — the VS Code accent line, in this chrome's only selection colour
+   (see the sidebar rows and the selected card). The line is a border on every
+   tab, transparent until lit, so lighting it never moves text. */
 .sess-tab {
 	display: flex;
 	align-items: center;
 	flex: none;
-	border-radius: 6px;
+	align-self: stretch;
+	padding: 0 6px 0 14px;
+	border-top: 1px solid transparent;
+	background: transparent;
 	color: var(--text-dim);
 }
 .sess-tab:hover {
-	background: var(--bg-elev);
+	color: var(--text);
 }
 .sess-tab.active {
 	background: var(--bg-elev-2);
 	color: var(--text);
+	border-top-color: var(--text);
 }
 /* A tab a restart took away: it holds no terminal until you click it, so it
    reads as an outline rather than a surface. Dashed, not merely faded — faded
    alone would say "disabled", and this one is the clickable kind. */
 .sess-tab.restorable {
 	border: 1px dashed var(--border);
+	padding-right: 10px;
 	opacity: 0.6;
 }
 .sess-tab.restorable:hover {
 	opacity: 1;
 }
-.sess-tab.restorable .sess-tab-name {
-	padding-right: 8px;
-}
 .sess-tab-name {
-	max-width: 140px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	padding: 3px 2px 3px 8px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+	max-width: 160px;
+	height: 100%;
+	padding: 0;
 	border: none;
+	border-radius: 0;
 	background: transparent;
 	color: inherit;
 	font-size: 12px;
 	cursor: pointer;
 }
+/* The tab is the surface, not its name: the generic button hover must not
+   paint a second, rounded one inside it. */
+.sess-tab-name:hover {
+	background: transparent;
+}
+.sess-tab-name > span {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+/* The glyph: a brand mark for an agent, the terminal icon for a shell. A brand
+   mark keeps its colour, so it dims at rest like the VS Code logo in the
+   toolbar does, rather than outshining the tab it sits in. */
+.sess-tab-icon {
+	display: flex;
+	flex: none;
+}
+.sess-tab:not(.active) .sess-tab-icon {
+	opacity: 0.7;
+}
+/* The × shows on the active tab and on the one under the pointer (or focus);
+   the others keep its space so nothing shifts as you sweep across the strip. */
 .sess-tab-close {
 	display: grid;
 	place-items: center;
 	padding: 2px;
-	margin-right: 4px;
+	margin-left: 4px;
 	border: none;
 	background: transparent;
 	border-radius: 4px;
 	color: inherit;
-	opacity: 0.5;
+	opacity: 0;
 	cursor: pointer;
 }
-.sess-tab-close:hover {
+.sess-tab.active .sess-tab-close,
+.sess-tab:hover .sess-tab-close,
+.sess-tab:focus-within .sess-tab-close {
+	opacity: 0.6;
+}
+.sess-tab .sess-tab-close:hover {
 	opacity: 1;
-	background: var(--bg-elev-2);
+	background: rgba(255, 255, 255, 0.12);
 }
 
 /* panel body: terminal, or the changes view (files left · diff right) */

--- a/apps/desktop/src/renderer/src/session-tabs.test.ts
+++ b/apps/desktop/src/renderer/src/session-tabs.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import type { AgentDTO, SessionDTO } from "@ateam/protocol";
-import { activeTerminal, sessionTabs } from "./session-tabs";
+import { activeTerminal, sessionTabs, taskGlyphs } from "./session-tabs";
 
 const AGENTS: AgentDTO[] = [
 	{ id: "claude", label: "Claude Code", description: "", available: true },
@@ -125,4 +125,17 @@ test("several stranded sessions each get their own numbered tab", () => {
 // A stranded tab holds no terminal, so it must never be what the panel shows.
 test("a stranded session is not something the view can land on", () => {
 	expect(activeTerminal([], null)).toBeNull();
+});
+
+test("a task's glyphs are its live sessions, falling back to the last agent launched", () => {
+	expect(taskGlyphs({ agentId: "claude", agentIds: ["claude", "shell", "claude"] })).toEqual([
+		"claude",
+		"shell",
+		"claude",
+	]);
+	// Nothing live: the task still reads as the agent that last ran here.
+	expect(taskGlyphs({ agentId: "claude", agentIds: [] })).toEqual(["claude"]);
+	// An engine too old to send the field reads the same as nothing live.
+	expect(taskGlyphs({ agentId: "codex" })).toEqual(["codex"]);
+	expect(taskGlyphs({ agentId: null })).toEqual([]);
 });

--- a/apps/desktop/src/renderer/src/session-tabs.ts
+++ b/apps/desktop/src/renderer/src/session-tabs.ts
@@ -9,7 +9,7 @@
 // reconcile and come back here as RESTORABLE tabs: they hold no process, they
 // sit at the end of the strip, and clicking one spawns a terminal that resumes
 // the same conversation. Everything else about a tab is unchanged.
-import type { AgentDTO, SessionDTO } from "@ateam/protocol";
+import type { AgentDTO, SessionDTO, TaskDTO } from "@ateam/protocol";
 
 export interface SessionTab {
 	session: SessionDTO;
@@ -72,4 +72,17 @@ export function activeTerminal(sessions: SessionDTO[], current: string | null): 
 	let best: SessionDTO | null = null;
 	for (const s of pool) if (!best || (s.lastEventAt ?? 0) >= (best.lastEventAt ?? 0)) best = s;
 	return best?.terminalId ?? null;
+}
+
+/**
+ * What a task shows for what runs in it — the sidebar row, the rail tile and
+ * the board card all draw from this. One glyph per live session, oldest first
+ * (TaskDTO.agentIds), so two agents and a shell read as three glyphs, not as
+ * whichever agent launched last. When nothing is live, the last agent launched
+ * here: an idle Claude task still reads as a Claude task. Empty for a task no
+ * agent has touched, which falls back to the icon inferred from its name.
+ */
+export function taskGlyphs(task: Pick<TaskDTO, "agentId" | "agentIds">): string[] {
+	if (task.agentIds?.length) return task.agentIds;
+	return task.agentId ? [task.agentId] : [];
 }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -200,6 +200,15 @@ export interface TaskDTO {
 	column: KanbanColumn;
 	agentStatus: AgentStatus | null;
 	agentId: string | null;
+	/**
+	 * The agent behind each session that is live in this task right now, oldest
+	 * first — "shell" for a plain terminal. `agentId` above is the last agent
+	 * launched here and outlives its session; this is what is actually running,
+	 * so a task holding two agents and a shell shows all three. Empty when
+	 * nothing runs. Absent from an engine older than this field, which reads
+	 * the same as empty — a read-only addition, so no protocol bump.
+	 */
+	agentIds?: string[];
 	/** Merge-queue position; null when the task is not queued to merge. */
 	mergeStatus: MergeStatus | null;
 	prNumber: number | null;

--- a/packages/server/src/dispatcher.ts
+++ b/packages/server/src/dispatcher.ts
@@ -55,7 +55,7 @@ import { refreshLoginPath } from "./login-env";
 import type { Engine } from "./engine";
 import { LOOP_TEMPLATES } from "./loops/templates";
 import { createSizeArbiter } from "./pty/size-arbiter";
-import { type Services, toProjectDTO, toSessionDTO, toTaskDTO } from "./services";
+import { liveAgentIds, type Services, toProjectDTO, toSessionDTO, toTaskDTO } from "./services";
 import { searchSessions } from "./session-search";
 import { createTaskInProject, type SpawnAgentInput, shell, spawnAgentInTask } from "./sessions";
 
@@ -334,7 +334,11 @@ export function createDispatcher(engine: Engine): Dispatcher {
 
 		// ---- tasks ----
 		[CH.tasksList]: async (projectId: string) =>
-			repo.listTasks(db, projectId).map((t) => toTaskDTO(t, services.pendingSeeds.has(t.id))),
+			repo
+				.listTasks(db, projectId)
+				.map((t) =>
+					toTaskDTO(t, services.pendingSeeds.has(t.id), liveAgentIds(db, services.pty, t.id)),
+				),
 		[CH.tasksCreate]: async (input: {
 			projectId: string;
 			name: string;
@@ -368,14 +372,14 @@ export function createDispatcher(engine: Engine): Dispatcher {
 		[CH.tasksMarkRead]: async (id: string) => {
 			const row = repo.updateTask(db, id, { isUnread: false });
 			engine.sendTaskUpdated(id);
-			return toTaskDTO(row!);
+			return toTaskDTO(row!, false, liveAgentIds(db, services.pty, id));
 		},
 		[CH.tasksSetColumn]: async (id: string, column: KanbanColumn) => {
 			const row = repo.updateTask(db, id, { column });
 			// Broadcast so every view (board, sidebar) reflects the move — e.g. the
 			// "Done" button under the terminal that sends a review task to merged.
 			engine.sendTaskUpdated(id);
-			return toTaskDTO(row!);
+			return toTaskDTO(row!, false, liveAgentIds(db, services.pty, id));
 		},
 
 		// Candidates for the interactive cleanup dialog: EVERY task in the project,

--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -28,7 +28,7 @@ import { MergeQueue } from "./merge-queue";
 import { PtyClient } from "./pty/pty-client";
 import { reapableSessions } from "./pty/reap";
 import { makeStrandReconciler } from "./pty/reconcile";
-import { type Services, toTaskDTO } from "./services";
+import { liveAgentIds, type Services, toTaskDTO } from "./services";
 import { createTaskInProject, spawnAgentInTask } from "./sessions";
 
 export interface EngineOptions {
@@ -159,7 +159,12 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 
 	const sendTaskUpdated = (taskId: string): void => {
 		const task = repo.getTask(db, taskId);
-		if (task) emitter.emit("taskUpdated", toTaskDTO(task, pendingSeeds.has(taskId)));
+		if (task) {
+			emitter.emit(
+				"taskUpdated",
+				toTaskDTO(task, pendingSeeds.has(taskId), liveAgentIds(db, pty, taskId)),
+			);
+		}
 	};
 
 	// The detached PTY daemon survives restarts; daemonPath is run via execPath as
@@ -248,15 +253,19 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 	): void => {
 		repo.updateSession(db, sessionId, { status: "stopped", exitedAt, exitReason });
 		const task = repo.getTask(db, taskId);
-		if (task && task.column === "running") {
+		if (!task) return;
+		if (task.column === "running") {
 			repo.updateTask(db, task.id, {
 				agentStatus: "stopped",
 				column:
 					task.prNumber != null || (task.gitStatus?.ahead ?? 0) > 0 ? "review" : "needs_attention",
 				...(markUnread ? { isUnread: true } : {}),
 			});
-			sendTaskUpdated(task.id);
 		}
+		// Announced whether or not the column moved: a session ending changes
+		// what the task is running (TaskDTO.agentIds), and a shell closing on a
+		// reviewed task would otherwise keep its glyph on the card for good.
+		sendTaskUpdated(task.id);
 	};
 
 	// PTY output/exit → emitted for the transport to forward.

--- a/packages/server/src/services.ts
+++ b/packages/server/src/services.ts
@@ -1,5 +1,5 @@
 import type { AgentDefinition, BinaryPresence, SessionScan } from "@ateam/agents";
-import type { AgentSession, AteamDb, Project, Task } from "@ateam/db";
+import { type AgentSession, type AteamDb, type Project, repo, type Task } from "@ateam/db";
 import type { ProjectDTO, SessionDTO, TaskDTO } from "@ateam/protocol";
 import type { FollowUps } from "./follow-ups";
 import type { HookServer } from "./hooks/hook-server";
@@ -62,7 +62,25 @@ export function toProjectDTO(p: Project): ProjectDTO {
 	};
 }
 
-export function toTaskDTO(t: Task, preparing = false): TaskDTO {
+/**
+ * The agent behind each of a task's live sessions, oldest first: TaskDTO.agentIds.
+ * Liveness is the daemon's word (`pty.has`), never the session row's status —
+ * the same rule pty:listForTask follows, so the glyphs a card shows are exactly
+ * the tabs its panel would open.
+ */
+export function liveAgentIds(
+	db: AteamDb,
+	pty: { has(terminalId: string): boolean },
+	taskId: string,
+): string[] {
+	return repo
+		.listSessionsByTask(db, taskId)
+		.filter((s) => pty.has(s.terminalId))
+		.map((s) => s.agentId)
+		.reverse();
+}
+
+export function toTaskDTO(t: Task, preparing = false, agentIds: string[] = []): TaskDTO {
 	return {
 		id: t.id,
 		projectId: t.projectId,
@@ -75,6 +93,7 @@ export function toTaskDTO(t: Task, preparing = false): TaskDTO {
 		column: t.column,
 		agentStatus: t.agentStatus ?? null,
 		agentId: t.agentId ?? null,
+		agentIds,
 		mergeStatus: t.mergeStatus ?? null,
 		prNumber: t.prNumber ?? null,
 		prUrl: t.prUrl ?? null,

--- a/packages/server/test/live-agent-ids.test.ts
+++ b/packages/server/test/live-agent-ids.test.ts
@@ -1,0 +1,47 @@
+import { Database } from "bun:sqlite";
+import { expect, test } from "bun:test";
+import type { AteamDb } from "@ateam/db";
+import { bootstrap, repo } from "@ateam/db";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import * as schema from "../../db/src/schema";
+import { liveAgentIds } from "../src/services";
+
+// The glyphs a card shows for what runs in a task (TaskDTO.agentIds) come from
+// this: live sessions only, in the order they were opened.
+
+function createTestDb(): AteamDb {
+	const sqlite = new Database(":memory:");
+	sqlite.exec("PRAGMA foreign_keys = ON;");
+	bootstrap(sqlite);
+	return drizzle(sqlite, { schema }) as unknown as AteamDb;
+}
+
+test("lists the agent of every live session, oldest first, and skips dead ones", () => {
+	const db = createTestDb();
+	const project = repo.upsertProject(db, { repoPath: "/tmp/repo", name: "Repo" });
+	if (!project) throw new Error("failed to seed project");
+	const task = repo.createTask(db, {
+		projectId: project.id,
+		name: "t",
+		slug: "t",
+		branch: "feat/t",
+		baseBranch: "main",
+		worktreePath: "/tmp/w",
+	});
+	const T0 = 1_700_000_000_000;
+	for (const [i, [agentId, terminalId]] of [
+		["claude", "a"],
+		["shell", "b"],
+		["claude", "c"],
+		["codex", "dead"],
+	].entries()) {
+		repo.createSession(db, { taskId: task.id, agentId, terminalId, cwd: "/tmp/w" });
+		// Spread the start times so "oldest first" is a real ordering to test.
+		repo.updateSession(db, repo.getSessionByTerminal(db, terminalId)!.id, {
+			startedAt: T0 + i * 1000,
+		});
+	}
+	const pty = { has: (id: string) => id !== "dead" };
+	expect(liveAgentIds(db, pty, task.id)).toEqual(["claude", "shell", "claude"]);
+	expect(liveAgentIds(db, { has: () => false }, task.id)).toEqual([]);
+});


### PR DESCRIPTION
## What

**Session tabs** in the task panel now follow VS Code's editor tabs: square, flush to the toolbar row's edges, an icon per tab (agent brand glyph, terminal glyph for a shell), a 1px white line along the active tab's top (white, not VS Code's blue, matching the chrome's selection colour), the close cross only on the active or hovered tab, and the `+` only while the row is hovered (or focused, or its menu is open).

**Every live session on the task**: the sidebar row, the collapsed rail tile and the board card drew one glyph from the last agent launched, so a task holding two agents and a shell looked like a single agent. `TaskDTO` gains `agentIds`, the agent behind every live session, oldest first, using the same PTY liveness check the panel's tabs use. The row and card draw one glyph per session; the rail tile shows the first plus a count.

## Engine

- `liveAgentIds` in services.ts feeds the task list and every task-updated push.
- A session exit now announces the task even when its column does not move, so a shell closing on a reviewed task drops its glyph instead of keeping it for good.
- The field is optional and read-only: an engine that omits it reads as "nothing live", so no protocol bump.

## Verified

Driven in the dev app: opened a shell beside a Claude session, saw both glyphs on the row, card and rail badge, closed the shell, saw them drop back to one. Full suite passes (466 tests, two new). All four typechecks clean.