### PR TITLE
Task lists open on last updated first

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -215,7 +215,9 @@ export function App() {
 		document.body.style.userSelect = "none";
 	};
 	const [taskSort, setTaskSortState] = useState<TaskSortMode>(
-		() => (localStorage.getItem("ateam.taskSort") as TaskSortMode) || "next",
+		// Default: last updated first. The list you scan is the list you just
+		// touched, so the freshest work sits at the top without a menu trip.
+		() => (localStorage.getItem("ateam.taskSort") as TaskSortMode) || "updated",
 	);
 	const [customOrder, setCustomOrder] = useState<string[]>([]);
 	const [cleanupOpen, setCleanupOpen] = useState(false);

--- a/apps/mobile/src/HomeScreen.tsx
+++ b/apps/mobile/src/HomeScreen.tsx
@@ -1,5 +1,6 @@
-// Home: the desktop sidebar as a phone list. A Tasks section in status order
-// (Review, Needs You, In Progress, Backlog) and a Loops section below, each row
+// Home: the desktop sidebar as a phone list. A Tasks section, last updated
+// first (tap the header to switch to status order: Review, Needs You, In
+// Progress, Backlog), and a Loops section below, each row
 // an icon, a name and a status dot. Tap a task for its terminal; tap a loop for
 // its task's terminal, or the Loops tab if it has never run.
 import type { LoopDTO, ProjectDTO, TaskDTO } from "@ateam/protocol";
@@ -116,7 +117,7 @@ export function HomeScreen({
 	onOpenLoops: () => void;
 	onNewLoop: () => void;
 }) {
-	const [sort, setSort] = useState<TaskSort>("status");
+	const [sort, setSort] = useState<TaskSort>("updated");
 	const [projectsOpen, setProjectsOpen] = useState(true);
 	const [tasksOpen, setTasksOpen] = useState(true);
 	const [loopsOpen, setLoopsOpen] = useState(true);


### PR DESCRIPTION
The sidebar defaulted to **What's next** and the phone list to **status order**. Both now open on **last updated first**: the list you scan is the list you just touched, so the freshest work sits at the top without a menu trip.

Every other mode stays exactly where it was, one menu away.

- `apps/desktop/src/renderer/src/App.tsx` — the fallback when `ateam.taskSort` is unset is now `"updated"`.
- `apps/mobile/src/HomeScreen.tsx` — the Home list starts on `"updated"`; header comment updated to match.

This only changes the default for a profile that has never picked a sort. Anyone who has already used the menu has `ateam.taskSort` in localStorage and keeps their choice — no migration here.

## Verification

Launched the dev app with CDP, confirmed `ateam.taskSort` was unset in that profile, and read the **Order tasks** menu back from the DOM:

```
[ ] What's next
[ ] By status
[x] Last updated first
[ ] Custom (drag to reorder)
```

Desktop renderer tests: 62 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)