### PR TITLE
Sidebar rows show the state of the work, and every task's git facts stay fresh

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -8,6 +8,7 @@ import type {
 	SessionDTO,
 	SessionHitDTO,
 	TaskDTO,
+	TaskTriage,
 } from "@ateam/protocol";
 import { boxSupports, FEATURE_MIN_VERSION, PROTOCOL_VERSION } from "@ateam/protocol";
 import {
@@ -19,11 +20,13 @@ import {
 	ChevronDown,
 	ChevronRight,
 	ChevronUp,
+	CircleAlert,
 	Columns2,
 	ExternalLink,
 	FolderPlus,
 	GitCommitVertical,
 	GitMerge,
+	GitPullRequest,
 	Globe,
 	History,
 	LayoutGrid,
@@ -1448,6 +1451,49 @@ export function App() {
 	);
 }
 
+/**
+ * What the row's trailing slot says once no agent is attached.
+ *
+ * With a live agent the slot belongs to `agentStatus` (blue working, amber
+ * needs-you) — that is the most urgent thing a row can report. The rest of the
+ * time the useful question is the state of the WORK, which is exactly what
+ * `triage` answers, from the task row alone and with no git/gh calls. Before
+ * this, every such task wore the same green "idle" dot, so a task merged last
+ * week, one that never started, and one genuinely waiting on you were
+ * indistinguishable.
+ *
+ * `active` and `not_started` fall through to null deliberately: "recently
+ * touched" and "nothing here yet" are the row's resting state, and a glyph for
+ * them would be noise on every row.
+ */
+function TriageGlyph({ triage }: { triage: TaskTriage }) {
+	const props = { size: 12, strokeWidth: 2 } as const;
+	const glyph = (() => {
+		switch (triage.bucket) {
+			case "merged_done":
+				return { icon: <GitMerge {...props} />, tone: "done" };
+			case "merged_unfinished":
+				return { icon: <GitMerge {...props} />, tone: "attention" };
+			case "open_pr":
+				return { icon: <GitPullRequest {...props} />, tone: "open" };
+			case "unmerged_no_pr":
+				return { icon: <GitCommitVertical {...props} />, tone: "done" };
+			case "uncommitted":
+				return { icon: <GitCommitVertical {...props} />, tone: "attention" };
+			case "orphan":
+				return { icon: <CircleAlert {...props} />, tone: "alert" };
+			default:
+				return null;
+		}
+	})();
+	if (!glyph) return null;
+	return (
+		<span className={`tstate ${glyph.tone}`} title={triage.reason}>
+			{glyph.icon}
+		</span>
+	);
+}
+
 function TaskRow({
 	task: t,
 	selected,
@@ -1494,12 +1540,17 @@ function TaskRow({
 				    the one dot it gets — otherwise the trail is empty for the whole
 				    copy and the card looks idle while it is anything but. */}
 				{t.preparing ? (
+					<span className="tstatus preparing" title="Copying dependencies into the worktree…" />
+				) : t.agentStatus === "running" || t.agentStatus === "awaiting_input" ? (
+					// A live agent keeps this slot. `stalled` means it claims to be
+					// running but stopped advancing, so it wears the card's hollow
+					// treatment rather than the pulsing live one.
 					<span
-						className="tstatus preparing"
-						title="Copying dependencies into the worktree…"
+						className={`tstatus ${t.triage.bucket === "stalled" ? "stalled" : t.agentStatus}`}
+						title={t.triage.reason}
 					/>
 				) : (
-					t.agentStatus && <span className={`tstatus ${t.agentStatus}`} />
+					<TriageGlyph triage={t.triage} />
 				)}
 				<IconButton
 					icon={Trash2}

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -400,7 +400,9 @@ input {
 	pointer-events: auto;
 }
 .tasknode-row:hover .task-trail .tstatus,
-.task-trail:focus-within .tstatus {
+.tasknode-row:hover .task-trail .tstate,
+.task-trail:focus-within .tstatus,
+.task-trail:focus-within .tstate {
 	opacity: 0;
 }
 .tasknode {
@@ -408,7 +410,12 @@ input {
 	align-items: center;
 	gap: 7px;
 	width: 100%;
-	padding: 5px 14px 5px 22px;
+	/* The right padding reserves the trailing slot. `.task-trail` is absolutely
+	   positioned, so it takes no space in this flex row and the name would
+	   otherwise ellipsize straight under the state glyph. Reserved constantly,
+	   not only when a glyph is present, so a task changing state never reflows
+	   its own row. */
+	padding: 5px 28px 5px 22px;
 	cursor: pointer;
 	font-size: 13px;
 	text-align: left;
@@ -459,6 +466,37 @@ input {
 .tstatus.stopped {
 	background: var(--text-dim);
 }
+/* Claims to be running but stopped advancing — the sidebar's copy of
+   `.ring.stalled`: hollow, not pulsing, so it reads as "no longer live". */
+.tstatus.stalled {
+	background: transparent;
+	border: 1.5px solid var(--text-dim);
+}
+/* The work's state, shown in the same trailing slot once no agent is attached
+   (see TriageGlyph). A glyph rather than a dot: these say something structural
+   about the branch, not which of four agent states it is in, and the shapes are
+   the ones the toolbar already uses for the same concepts. Sized to sit on the
+   dot's optical centre so the slot never shifts as a task changes state. */
+.tstate {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 14px;
+	height: 14px;
+	margin-right: 4px;
+	color: var(--text-dim);
+}
+.tstate.open {
+	color: var(--green);
+}
+.tstate.attention {
+	color: var(--amber);
+}
+.tstate.alert {
+	color: var(--red);
+}
+/* `.done` keeps the inherited dim: a landed branch is the calmest thing on the
+   list and must not compete with live work for attention. */
 /* Dependencies still copying in. Dim rather than a status colour — nothing is
    wrong and nothing is running yet — with the same pulse the rail uses, so it
    reads as work in progress instead of a fifth agent state. */

--- a/packages/git-core/src/merge.ts
+++ b/packages/git-core/src/merge.ts
@@ -123,6 +123,17 @@ export interface DetectMergedResult {
 	merged: boolean;
 	prNumber: number | null;
 	prUrl: string | null;
+	/**
+	 * The PR's state as GitHub reports it (uppercase, like `PrStatus` below),
+	 * or null when there is no PR, gh is unavailable, or the answer came from
+	 * the merge-commit fallback rather than a PR.
+	 *
+	 * `merged` stays the authoritative "did this land" answer — it is also true
+	 * for the no-PR fallback, where `state` is null. This field is free: the
+	 * `gh pr view` that answers `merged` already returns it, and callers were
+	 * throwing it away and then reporting every un-merged PR as no PR at all.
+	 */
+	state: "OPEN" | "MERGED" | "CLOSED" | null;
 }
 
 /**
@@ -142,7 +153,7 @@ export async function detectMerged(input: {
 	try {
 		tip = (await git.raw(["rev-parse", input.branch])).trim();
 	} catch {
-		return { merged: false, prNumber: null, prUrl: null };
+		return { merged: false, prNumber: null, prUrl: null, state: null };
 	}
 
 	try {
@@ -166,14 +177,18 @@ export async function detectMerged(input: {
 					merged: true,
 					prNumber: p.number ?? null,
 					prUrl: p.url ?? null,
+					state: "MERGED",
 				};
 			}
-			// Stale PR — fall through to the local merge-commit check.
+			// Stale PR — fall through to the local merge-commit check. `state`
+			// stays null there: we just decided not to trust this PR, so it must
+			// not be persisted as this branch's state either.
 		} else if (p.state === "OPEN" || p.state === "CLOSED") {
 			return {
 				merged: false,
 				prNumber: p.number ?? null,
 				prUrl: p.url ?? null,
+				state: p.state,
 			};
 		}
 	} catch {
@@ -197,9 +212,9 @@ export async function detectMerged(input: {
 		const merged = mergeParents
 			.split("\n")
 			.some((line) => line.trim().split(/\s+/).slice(1).includes(tip));
-		return { merged, prNumber: null, prUrl: null };
+		return { merged, prNumber: null, prUrl: null, state: null };
 	} catch {
-		return { merged: false, prNumber: null, prUrl: null };
+		return { merged: false, prNumber: null, prUrl: null, state: null };
 	}
 }
 

--- a/packages/server/src/dispatcher.ts
+++ b/packages/server/src/dispatcher.ts
@@ -23,7 +23,6 @@ import {
 	commit,
 	createGithubRepo,
 	detectGithubRepo,
-	detectMerged,
 	diff,
 	errorMessage,
 	fileDiff,
@@ -34,7 +33,6 @@ import {
 	listRemoteRepos,
 	push,
 	registerProject,
-	trackingStatus,
 	updateFromBase,
 } from "@ateam/git-core";
 import {
@@ -43,7 +41,6 @@ import {
 	type CleanupCandidate,
 	type CreateLoopInput,
 	type DirEntryDTO,
-	type GitStatusSnapshot,
 	type KanbanColumn,
 	type MergeStrategy,
 	PROTOCOL_VERSION,
@@ -94,20 +91,6 @@ function requireProjectFor(services: Services, projectId: string) {
 	const project = repo.getProject(services.db, projectId);
 	if (!project) throw new Error(`Project not found: ${projectId}`);
 	return project;
-}
-
-async function computeGitStatus(
-	worktreePath: string,
-	baseBranch: string,
-): Promise<GitStatusSnapshot> {
-	const tracking = await trackingStatus(worktreePath);
-	const d = await diff({ worktreePath, baseBranch });
-	return {
-		ahead: tracking?.ahead ?? 0,
-		behind: tracking?.behind ?? 0,
-		dirty: d.files.length,
-		updatedAt: Date.now(),
-	};
 }
 
 /** Where install.sh is fetched from, matching the documented one-liner and the
@@ -186,39 +169,6 @@ export function createDispatcher(engine: Engine): Dispatcher {
 		}
 		return { removable, kept };
 	}
-
-	// Detect merges done OUTSIDE Ateam (the agent ran `gh pr merge` in its
-	// terminal, or the PR was merged on github.com) and move the task to Done.
-	// Throttled per task; fire-and-forget so status replies stay fast.
-	const mergeCheckedAt = new Map<string, number>();
-	const detectExternalMerge = async (taskId: string): Promise<void> => {
-		if (Date.now() - (mergeCheckedAt.get(taskId) ?? 0) < 60_000) return;
-		mergeCheckedAt.set(taskId, Date.now());
-		const task = repo.getTask(db, taskId);
-		if (!task || task.column === "merged") return;
-		// Done only when the conversation ended on a plain text reply: the agent
-		// fired Stop (idle/stopped) and is not waiting on a question/permission.
-		const finished =
-			task.agentStatus == null || task.agentStatus === "idle" || task.agentStatus === "stopped";
-		if (!finished || task.column === "needs_attention") return;
-		try {
-			const res = await detectMerged({
-				worktreePath: task.worktreePath,
-				branch: task.branch,
-				baseBranch: task.baseBranch,
-			});
-			if (!res.merged) return;
-			repo.updateTask(db, task.id, {
-				column: "merged",
-				prState: "merged",
-				prNumber: res.prNumber ?? task.prNumber ?? null,
-				prUrl: res.prUrl ?? task.prUrl ?? null,
-			});
-			engine.sendTaskUpdated(task.id);
-		} catch {
-			/* offline or gh unavailable — retried on a later refresh */
-		}
-	};
 
 	/** Open a login shell in a task's worktree and record the session. */
 	const spawnShellInTask = (task: { id: string; worktreePath: string }) => {
@@ -494,10 +444,10 @@ export function createDispatcher(engine: Engine): Dispatcher {
 		},
 		[CH.gitStatus]: async (taskId: string) => {
 			const task = requireTask(services, taskId);
-			const snapshot = await computeGitStatus(task.worktreePath, task.baseBranch);
-			repo.updateTask(db, task.id, { gitStatus: snapshot });
-			if (task.column !== "merged") void detectExternalMerge(task.id);
-			return snapshot;
+			// Same probe the background pass uses, sharing its throttle — so
+			// re-rendering an open panel can't shell out on every render, and the
+			// sweep can't double-probe a worktree the panel just refreshed.
+			return (await engine.worktreeSweep.refresh(task.id)) ?? task.gitStatus ?? null;
 		},
 
 		// ---- agents ----

--- a/packages/server/src/engine.ts
+++ b/packages/server/src/engine.ts
@@ -31,6 +31,7 @@ import { makeStrandReconciler } from "./pty/reconcile";
 import { liveAgentIds, type Services, toTaskDTO } from "./services";
 import { createTaskInProject, spawnAgentInTask } from "./sessions";
 import { readSettings } from "./settings-file";
+import { createWorktreeSweep, type WorktreeSweep } from "./worktree-sweep";
 
 export interface EngineOptions {
 	/** Where the SQLite db, hooks, and notify script live (app userData or ~/.ateam). */
@@ -67,6 +68,9 @@ export interface Engine {
 	sendTaskRemoved(taskId: string): void;
 	/** Emit the current loop list. */
 	sendLoopsUpdated(): void;
+	/** Keeps every task's git + PR facts fresh, not just the open one. The
+	 *  `CH.gitStatus` handler shares its throttle (see worktree-sweep.ts). */
+	readonly worktreeSweep: WorktreeSweep;
 	/** Connect to (or launch) the detached PTY daemon and learn live sessions. */
 	connectPty(): Promise<void>;
 	/** Start the user's scheduled loops (rebuilt from their persisted rows). */
@@ -382,6 +386,14 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 	// Stamp the ending BEFORE the kill, exactly as the close-tab handler does:
 	// the exit handler above reads it back, and `reaped` is what puts the tab on
 	// the restorable strip instead of retiring it to history.
+	// Refresh git + PR facts for tasks nobody is looking at, so a list row can
+	// say something true about a worktree whose panel was never opened.
+	const worktreeSweep = createWorktreeSweep({
+		db,
+		onTaskUpdated: (taskId) => sendTaskUpdated(taskId),
+		isLive: (taskId) => repo.listSessionsByTask(db, taskId).some((s) => pty.has(s.terminalId)),
+	});
+
 	let reapTimer: ReturnType<typeof setInterval> | null = null;
 	const reapIdleSessions = (): void => {
 		const due = reapableSessions(repo.listOpenSessions(db), Date.now(), REAP_IDLE_MS);
@@ -431,6 +443,7 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 			return () => emitter.off(event, listener as (...a: unknown[]) => void);
 		},
 		sendTaskUpdated,
+		worktreeSweep,
 		sendTaskRemoved(taskId: string) {
 			emitter.emit("taskRemoved", taskId);
 		},
@@ -443,11 +456,13 @@ export async function createEngine(opts: EngineOptions): Promise<Engine> {
 		startLoops() {
 			loopRunner.start();
 			reapTimer ??= setInterval(reapIdleSessions, REAP_SWEEP_MS);
+			worktreeSweep.start();
 		},
 		stop() {
 			pty.disconnect();
 			hooks.stop();
 			loopRunner.stop();
+			worktreeSweep.stop();
 			if (reapTimer) {
 				clearInterval(reapTimer);
 				reapTimer = null;

--- a/packages/server/src/worktree-sweep.ts
+++ b/packages/server/src/worktree-sweep.ts
@@ -1,0 +1,201 @@
+/**
+ * Keep every task's git + PR facts fresh, not just the one you're looking at.
+ *
+ * Until this existed, `gitStatus` and external-merge detection both hung off a
+ * single RPC (`CH.gitStatus`), which the renderer fires from exactly one place:
+ * the open task's panel. Every other row on the board and in the sidebar was
+ * therefore showing a snapshot from whenever you last opened it — or nothing at
+ * all, for a task you never opened in this install. That is fine for a diff
+ * view (you're looking at it) and useless for a list (you're not).
+ *
+ * Two triggers, ONE path. `refresh()` is what the RPC calls and what the timer
+ * calls, so they share the per-task throttle below and can never double-probe
+ * the same worktree. Everything is best-effort: a failed probe leaves the last
+ * known values in place and is retried on the next pass.
+ */
+
+import { type AteamDb, repo, type Task } from "@ateam/db";
+import { detectMerged, diff, trackingStatus } from "@ateam/git-core";
+import type { GitStatusSnapshot, PrState } from "@ateam/protocol";
+
+/** How often the background pass runs. */
+export const SWEEP_MS = 90_000;
+/**
+ * Floor between two probes of the SAME task, whichever trigger asks. Opening a
+ * task panel re-renders often; without this, every render would shell out.
+ */
+export const PROBE_THROTTLE_MS = 60_000;
+/** Worktrees probed per pass. Each costs git calls plus at most one `gh`. */
+export const SWEEP_BATCH = 12;
+
+export async function computeGitStatus(
+	worktreePath: string,
+	baseBranch: string,
+): Promise<GitStatusSnapshot> {
+	const tracking = await trackingStatus(worktreePath);
+	const d = await diff({ worktreePath, baseBranch });
+	return {
+		ahead: tracking?.ahead ?? 0,
+		behind: tracking?.behind ?? 0,
+		dirty: d.files.length,
+		updatedAt: Date.now(),
+	};
+}
+
+/** git-core speaks GitHub's uppercase; the DB column is lowercase. */
+function toPrState(s: "OPEN" | "MERGED" | "CLOSED" | null): PrState | null {
+	if (s === "OPEN") return "open";
+	if (s === "MERGED") return "merged";
+	if (s === "CLOSED") return "closed";
+	return null;
+}
+
+export interface WorktreeSweep {
+	/**
+	 * Probe one task now and persist what changed. Returns the fresh git
+	 * snapshot, or the stored one when the throttle skipped the probe (so the
+	 * RPC always has something to answer with).
+	 */
+	refresh(taskId: string): Promise<GitStatusSnapshot | null>;
+	start(): void;
+	stop(): void;
+}
+
+export interface SweepDeps {
+	db: AteamDb;
+	onTaskUpdated: (taskId: string) => void;
+	/** True while a PTY is live for this task. Live tasks are refreshed by
+	 *  their own events, so the background pass skips them. */
+	isLive: (taskId: string) => boolean;
+	sweepMs?: number;
+}
+
+export function createWorktreeSweep(deps: SweepDeps): WorktreeSweep {
+	const { db, onTaskUpdated, isLive } = deps;
+	const probedAt = new Map<string, number>();
+	let timer: ReturnType<typeof setInterval> | null = null;
+	/** Round-robin cursor, so a project with more tasks than SWEEP_BATCH still
+	 *  gets every one of them refreshed, just over several passes. */
+	let cursor = 0;
+
+	/**
+	 * Persist the PR facts we just learned. Deliberately split from the column
+	 * move below: recording that a PR is open costs nothing and is always safe,
+	 * whereas moving a task to Done is consequential and keeps its old guards.
+	 */
+	function applyPrFacts(task: Task, res: Awaited<ReturnType<typeof detectMerged>>): boolean {
+		const state = toPrState(res.state);
+		const patch: Parameters<typeof repo.updateTask>[2] = {};
+		let changed = false;
+		if (state !== null && state !== task.prState) {
+			patch.prState = state;
+			changed = true;
+		}
+		// Never clear a known PR: `gh` being unavailable must not look like the
+		// PR was withdrawn.
+		if (res.prNumber != null && res.prNumber !== task.prNumber) {
+			patch.prNumber = res.prNumber;
+			changed = true;
+		}
+		if (res.prUrl != null && res.prUrl !== task.prUrl) {
+			patch.prUrl = res.prUrl;
+			changed = true;
+		}
+		// A merge found outside Ateam moves the card to Done — but only under the
+		// same conditions the old inline check used: the conversation wrapped up
+		// (agent idle/stopped, not parked on a question) and nothing is flagged
+		// for the user. Otherwise the task keeps its column and just wears the
+		// merged PR state.
+		const finished =
+			task.agentStatus == null || task.agentStatus === "idle" || task.agentStatus === "stopped";
+		if (res.merged && finished && task.column !== "merged" && task.column !== "needs_attention") {
+			patch.column = "merged";
+			patch.prState = "merged";
+			changed = true;
+		}
+		if (!changed) return false;
+		repo.updateTask(db, task.id, patch);
+		return true;
+	}
+
+	async function probe(task: Task): Promise<GitStatusSnapshot | null> {
+		let changed = false;
+		let snapshot: GitStatusSnapshot | null = null;
+		try {
+			snapshot = await computeGitStatus(task.worktreePath, task.baseBranch);
+			repo.updateTask(db, task.id, { gitStatus: snapshot });
+			changed = true;
+		} catch {
+			/* worktree gone or git unavailable — keep the last known snapshot */
+		}
+		// A merged task is terminal: no PR fact can change what it says.
+		if (task.column !== "merged") {
+			try {
+				const res = await detectMerged({
+					worktreePath: task.worktreePath,
+					branch: task.branch,
+					baseBranch: task.baseBranch,
+				});
+				// Re-read: computeGitStatus above already wrote, and the merge probe
+				// is slow enough that the row may have moved under us.
+				const fresh = repo.getTask(db, task.id);
+				if (fresh && applyPrFacts(fresh, res)) changed = true;
+			} catch {
+				/* offline or gh unavailable — retried on a later pass */
+			}
+		}
+		if (changed) onTaskUpdated(task.id);
+		return snapshot;
+	}
+
+	async function refresh(taskId: string): Promise<GitStatusSnapshot | null> {
+		const task = repo.getTask(db, taskId);
+		if (!task) return null;
+		if (Date.now() - (probedAt.get(taskId) ?? 0) < PROBE_THROTTLE_MS) {
+			return task.gitStatus ?? null;
+		}
+		probedAt.set(taskId, Date.now());
+		return probe(task);
+	}
+
+	/** One pass: the next few stale, not-live tasks across every project. */
+	async function sweep(): Promise<void> {
+		const all: Task[] = [];
+		for (const project of repo.listProjects(db)) all.push(...repo.listTasks(db, project.id));
+		if (all.length === 0) return;
+		const now = Date.now();
+		const due = all.filter(
+			(t) => !isLive(t.id) && now - (probedAt.get(t.id) ?? 0) >= PROBE_THROTTLE_MS,
+		);
+		if (due.length === 0) return;
+		if (cursor >= due.length) cursor = 0;
+		const batch = due.slice(cursor, cursor + SWEEP_BATCH);
+		cursor += batch.length;
+		for (const task of batch) {
+			probedAt.set(task.id, Date.now());
+			await probe(task);
+		}
+	}
+
+	let running = false;
+	return {
+		refresh,
+		start() {
+			timer ??= setInterval(() => {
+				// Overlap guard: a slow pass (many worktrees, a hung `gh`) must not
+				// stack passes on top of each other.
+				if (running) return;
+				running = true;
+				void sweep().finally(() => {
+					running = false;
+				});
+			}, deps.sweepMs ?? SWEEP_MS);
+		},
+		stop() {
+			if (timer) {
+				clearInterval(timer);
+				timer = null;
+			}
+		},
+	};
+}


### PR DESCRIPTION
A sidebar row could only say whether an agent was attached. A task merged last week, one that never started, and one genuinely waiting on you all wore the same green "idle" dot (`.tstatus.idle`).

The row's trailing slot now answers the question that remains once no agent is attached: **what state is the work in.** It renders `triage.bucket` with `triage.reason` as the tooltip.

| bucket | glyph | colour |
|---|---|---|
| `merged_done` | `GitMerge` | dim |
| `merged_unfinished` | `GitMerge` | amber |
| `open_pr` | `GitPullRequest` | green |
| `unmerged_no_pr` | `GitCommitVertical` | dim |
| `uncommitted` | `GitCommitVertical` | amber |
| `orphan` | `CircleAlert` | red |
| `active` / `not_started` | nothing | |

A live agent keeps the slot (blue running, amber needs-you, hollow when triage says stalled, mirroring the card's `.ring.stalled`). The leading agent glyphs are unchanged.

## Two things had to be true first

**`prState` was a write-only-`"merged"` field.** Its only two writers both wrote the literal `"merged"`, so `open` and `closed` were unreachable despite being in the type — `.pr.open` in the CSS had never once rendered. `detectMerged` already parsed the state from the `gh pr view` it was paying for, then the caller returned early on `!merged` and threw it away. It now returns that state, at **no new I/O**.

**Git and PR facts only refreshed for the open task.** `CH.gitStatus` is fired from the task panel alone, so every other row showed a snapshot from whenever it was last opened, or nothing at all. `worktree-sweep.ts` makes that one refresh path with two triggers (the RPC, plus a 90s background pass started beside the reap timer), sharing a 60s per-task throttle so they cannot double-probe. Each pass takes 12 worktrees round-robin, skipping live tasks (their events already cover them) and terminal `merged` ones. Recording PR facts is split from moving a card to Done: noting an open PR is always safe, while the column move keeps its old guards.

Also fixes a collision the glyph exposed: `.task-trail` is absolutely positioned, so names ellipsized *underneath* it. The row now reserves that space constantly, so changing state never reflows it.

## Verification

- 474 tests pass, full workspace typecheck clean, zero new lint diagnostics.
- Ran the real app against an **isolated scratch data dir** seeded with one task per bucket; confirmed the real database was untouched. Hover swap verified with dispatched mouse events (glyph out, trash in and clickable, glyph returns).
- `detectMerged` run against **live GitHub**: `add-search-bar-for-tasks-at` → `{merged:true, prNumber:61, state:"MERGED"}`; `show-sidebar-scrollbar-opacity-only-on` → `{merged:false, prNumber:114, state:"OPEN"}`. That second case is precisely what the old code discarded.

**Known gap:** `worktree-sweep.ts` has no unit test. The throttle, the batch cursor, and the record-PR-state-without-moving-the-column split are the logic worth pinning down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)