### PR TITLE
Prefer Codex automatic approval review in Auto mode

### DIFF
--- a/packages/agents/src/registry.ts
+++ b/packages/agents/src/registry.ts
@@ -18,7 +18,9 @@ export interface AgentDefinition {
 	 */
 	command: string;
 	/**
-	 * Extra flag(s) appended for "YOLO" mode (bypass permissions/approvals).
+	 * Extra flag(s) appended for Auto mode. Prefer the CLI's native automatic
+	 * approval mode over bypassing permissions and sandboxing when available.
+	 * The legacy `yoloFlag` name does not imply that safeguards are disabled.
 	 * Omitted for an agent that has no such flag — Auto mode then does nothing
 	 * for it, which is why an omission must be deliberate and verified against
 	 * the CLI's own --help.
@@ -102,7 +104,7 @@ export interface HeadlessInvocation {
 	lastMessageFlag?: string;
 }
 
-// Registry of the supported agent CLIs. Command lines and the YOLO bypass
+// Registry of the supported agent CLIs. Command lines and the Auto mode
 // flags come from each tool's own documented CLI surface. `command` is the
 // SAFE default; `yoloFlag` is what makes it autonomous.
 export const AGENTS = [
@@ -139,7 +141,9 @@ export const AGENTS = [
 		description: "OpenAI's coding agent for reading, modifying, and running code across tasks.",
 		bin: "codex",
 		command: "codex",
-		yoloFlag: "--dangerously-bypass-approvals-and-sandbox",
+		// Verified with `codex --help` and `codex resume --help` (0.154.0):
+		// automatic approval review with the workspace-write sandbox retained.
+		yoloFlag: "--approve-for-me",
 		resumeCommand: "codex resume --last",
 		// `codex resume [SESSION_ID]` takes a UUID, but Codex mints it itself —
 		// there is no flag to hand it one, so its tabs stay unrestorable until
@@ -182,7 +186,7 @@ export const AGENTS = [
 	},
 ] as const satisfies readonly AgentDefinition[];
 
-/** Build the launch command line for an agent (YOLO, resume, or agent-mode variants). */
+/** Build the launch command line for an agent (Auto, resume, or agent-mode variants). */
 export function agentCommand(
 	agent: AgentDefinition,
 	opts: {

--- a/packages/agents/test/commands.test.ts
+++ b/packages/agents/test/commands.test.ts
@@ -14,7 +14,7 @@ describe("agentCommand", () => {
 		expect(agentCommand(claude, { sessionId: "abc-123" })).toBe("claude --session-id 'abc-123'");
 	});
 
-	it("keeps the id alongside YOLO and the prompt", () => {
+	it("keeps the id alongside Auto mode and the prompt", () => {
 		expect(agentCommand(claude, { sessionId: "abc-123", yolo: true, prompt: "go" })).toBe(
 			"claude --permission-mode auto --session-id 'abc-123' 'go'",
 		);
@@ -44,12 +44,26 @@ describe("agentCommand", () => {
 		expect(agentCommand(opencode, { sessionId: "abc-123" })).toBe("opencode");
 	});
 
-	// Every registered agent must actually have a bypass flag: the Auto toggle
+	// Every registered agent must actually have an Auto flag: the Auto toggle
 	// renders for all of them, and an omission here turns it into a silent
 	// no-op — the launch is safe, the toggle was a lie.
 	it("makes Auto mode real for every agent, opencode included", () => {
 		expect(agentCommand(opencode, { yolo: true, prompt: "go" })).toBe(
 			"opencode --auto --prompt 'go'",
+		);
+	});
+
+	it("uses Codex automatic approval review for a fresh Auto launch", () => {
+		expect(agentCommand(codex, { yolo: true, prompt: "go" })).toBe("codex --approve-for-me 'go'");
+		expect(agentCommand(codex, { yolo: false, prompt: "go" })).toBe("codex 'go'");
+	});
+
+	it("keeps Codex automatic approval review when resuming", () => {
+		expect(agentCommand(codex, { yolo: true, resume: true })).toBe(
+			"codex resume --last --approve-for-me",
+		);
+		expect(agentCommand(codex, { yolo: true, resume: true, resumeSessionId: "old-1" })).toBe(
+			"codex resume 'old-1' --approve-for-me",
 		);
 	});
 


### PR DESCRIPTION
Auto mode previously launched Codex with approvals and sandboxing disabled. Use `--approve-for-me` so Codex reviews approval requests automatically while retaining its workspace-write sandbox, for both fresh and resumed sessions. Claude and OpenCode already use their native Auto flags.

Validated with all 476 tests passing, full workspace typecheck, and lint for the changed files. Codex 0.154.0 accepts the generated fresh, resume-last, and resume-by-ID commands. Regression tests cover Auto on/off and both resume paths.
